### PR TITLE
fix(bgm): persist library lyrics/tags, surface non-MP3 downloads, unify dialog toolbar color

### DIFF
--- a/app/src/main/java/com/webtoapp/core/bgm/OnlineMusicDownloader.kt
+++ b/app/src/main/java/com/webtoapp/core/bgm/OnlineMusicDownloader.kt
@@ -174,7 +174,9 @@ object OnlineMusicDownloader {
         }
     }
 
-    private val MUSIC_EXTENSIONS = listOf("mp3", "m4a", "aac", "ogg", "flac", "wav")
+    // Shared with the library scanner so a downloaded track is always visible in the
+    // selector, whatever extension detectExtension picked for it.
+    private val MUSIC_EXTENSIONS = BgmStorage.MUSIC_EXTENSIONS
 
     fun isMusicDownloaded(context: Context, track: OnlineMusicTrack): Boolean {
         val bgmDir = BgmStorage.getBgmDir(context)

--- a/app/src/main/java/com/webtoapp/ui/components/BgmCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/BgmCard.kt
@@ -51,7 +51,10 @@ fun BgmCard(
                 exit = CardCollapseTransition
             ) {
               Column(
-                  modifier = Modifier.padding(horizontal = WtaSpacing.RowHorizontal),
+                  modifier = Modifier.padding(
+                      horizontal = WtaSpacing.RowHorizontal,
+                      vertical = WtaSpacing.ContentGap
+                  ),
                   verticalArrangement = Arrangement.spacedBy(12.dp)
               ) {
                 if (config.playlist.isNotEmpty()) {

--- a/app/src/main/java/com/webtoapp/ui/components/BgmSelector.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/BgmSelector.kt
@@ -91,19 +91,24 @@ fun BgmSelectorDialog(
     var showLrcEditorDialog by remember { mutableStateOf(false) }
     var lrcEditorBgm by remember { mutableStateOf<BgmItem?>(null) }
 
-    var draggedItemIndex by remember { mutableIntStateOf(-1) }
-    var draggedOverItemIndex by remember { mutableIntStateOf(-1) }
-
     val snackbarHostState = remember { SnackbarHostState() }
 
-    val refreshBgmList: () -> Unit = {
+    // Rescan the library after uploads/downloads and reconcile the selected playlist.
+    // Config-only fields (lyrics/tags saved before a sidecar existed) win over the fresh
+    // scan, so a refresh can never wipe data the library file does not carry yet.
+    val refreshLibrary: () -> Unit = {
         scope.launch {
-            withContext(Dispatchers.IO) {
-                availableBgm = BgmStorage.scanAllBgm(context)
+            val scanned = withContext(Dispatchers.IO) {
+                BgmStorage.scanAllBgm(context)
             }
-
+            availableBgm = scanned
             selectedPlaylist = selectedPlaylist.map { selected ->
-                availableBgm.find { it.path == selected.path } ?: selected
+                scanned.find { it.path == selected.path }?.let { fresh ->
+                    selected.copy(
+                        tags = fresh.tags.ifEmpty { selected.tags },
+                        lrcData = fresh.lrcData ?: selected.lrcData
+                    )
+                } ?: selected
             }
         }
     }
@@ -138,6 +143,7 @@ fun BgmSelectorDialog(
                     } else {
                         setDataSource(bgm.path)
                     }
+                    setVolume(volume, volume)
                     setOnCompletionListener {
                         previewingBgm = null
                     }
@@ -168,12 +174,18 @@ fun BgmSelectorDialog(
                 Column(modifier = Modifier.fillMaxSize().systemBarsPadding()) {
 
                     TopAppBar(
-                    title = { Text(Strings.selectBgm) },
-                    navigationIcon = {
-                        IconButton(onClick = onDismiss) {
-                            Icon(Icons.Default.Close, Strings.close)
-                        }
-                    },
+                        title = { Text(Strings.selectBgm) },
+                        colors = TopAppBarDefaults.topAppBarColors(
+                            containerColor = Color.Transparent,
+                            navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+                            titleContentColor = MaterialTheme.colorScheme.onSurface,
+                            actionIconContentColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        navigationIcon = {
+                            IconButton(onClick = onDismiss) {
+                                Icon(Icons.Default.Close, Strings.close)
+                            }
+                        },
                     actions = {
                         TextButton(
                             onClick = {
@@ -541,12 +553,8 @@ fun BgmSelectorDialog(
     if (showUploadDialog) {
         UploadBgmDialog(
             onDismiss = { showUploadDialog = false },
-            onUploaded = { newBgm ->
-                scope.launch {
-                    withContext(Dispatchers.IO) {
-                        availableBgm = BgmStorage.scanAllBgm(context)
-                    }
-                }
+            onUploaded = { _ ->
+                refreshLibrary()
                 showUploadDialog = false
             }
         )
@@ -555,12 +563,8 @@ fun BgmSelectorDialog(
     if (showOnlineMusicDialog) {
         OnlineMusicSearchDialog(
             onDismiss = { showOnlineMusicDialog = false },
-            onMusicDownloaded = { bgmItem ->
-                scope.launch {
-                    withContext(Dispatchers.IO) {
-                        availableBgm = BgmStorage.scanAllBgm(context)
-                    }
-                }
+            onMusicDownloaded = { _ ->
+                refreshLibrary()
             }
         )
     }
@@ -570,6 +574,11 @@ fun BgmSelectorDialog(
             bgm = bgm,
             onDismiss = { editingTagsBgm = null },
             onConfirm = { updatedBgm ->
+                scope.launch {
+                    withContext(Dispatchers.IO) {
+                        BgmStorage.saveTagsForBgm(context, updatedBgm, updatedBgm.tags)
+                    }
+                }
                 availableBgm = availableBgm.map {
                     if (it.path == updatedBgm.path) updatedBgm else it
                 }
@@ -618,8 +627,12 @@ fun BgmSelectorDialog(
                 manualAlignerBgm = null
             },
             onSave = { newLrcData ->
-
                 val updatedBgm = manualAlignerBgm!!.copy(lrcData = newLrcData)
+                scope.launch {
+                    withContext(Dispatchers.IO) {
+                        BgmStorage.saveLrc(context, updatedBgm.path, newLrcData)
+                    }
+                }
                 availableBgm = availableBgm.map {
                     if (it.path == updatedBgm.path) updatedBgm else it
                 }
@@ -648,8 +661,12 @@ fun BgmSelectorDialog(
                 lrcEditorBgm = null
             },
             onSave = { newLrcData ->
-
                 val updatedBgm = lrcEditorBgm!!.copy(lrcData = newLrcData)
+                scope.launch {
+                    withContext(Dispatchers.IO) {
+                        BgmStorage.saveLrc(context, updatedBgm.path, newLrcData)
+                    }
+                }
                 availableBgm = availableBgm.map {
                     if (it.path == updatedBgm.path) updatedBgm else it
                 }

--- a/app/src/main/java/com/webtoapp/ui/components/LrcEditorDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/LrcEditorDialog.kt
@@ -154,6 +154,12 @@ fun LrcEditorDialog(
 
                 TopAppBar(
                     title = { Text(Strings.editLrc) },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Color.Transparent,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                        actionIconContentColor = MaterialTheme.colorScheme.onSurface
+                    ),
                     navigationIcon = {
                         IconButton(onClick = {
                             mediaPlayer?.release()

--- a/app/src/main/java/com/webtoapp/ui/components/ManualLrcAligner.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ManualLrcAligner.kt
@@ -224,6 +224,12 @@ fun ManualLrcAlignerDialog(
                             else -> com.webtoapp.core.i18n.Strings.previewConfirm
                         })
                     },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Color.Transparent,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                        actionIconContentColor = MaterialTheme.colorScheme.onSurface
+                    ),
                     navigationIcon = {
                         if (currentStep == 1) {
 

--- a/app/src/main/java/com/webtoapp/ui/components/OnlineMusicSearchDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/OnlineMusicSearchDialog.kt
@@ -389,6 +389,12 @@ fun OnlineMusicSearchDialog(
                 topBar = {
                     TopAppBar(
                         title = { Text(Strings.onlineMusic) },
+                        colors = TopAppBarDefaults.topAppBarColors(
+                            containerColor = Color.Transparent,
+                            navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+                            titleContentColor = MaterialTheme.colorScheme.onSurface,
+                            actionIconContentColor = MaterialTheme.colorScheme.onSurface
+                        ),
                         navigationIcon = {
                             IconButton(onClick = {
                                 mediaPlayer?.release()

--- a/app/src/main/java/com/webtoapp/util/BgmStorage.kt
+++ b/app/src/main/java/com/webtoapp/util/BgmStorage.kt
@@ -2,7 +2,10 @@ package com.webtoapp.util
 
 import android.content.Context
 import android.net.Uri
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.webtoapp.data.model.BgmItem
+import com.webtoapp.data.model.BgmTag
 import com.webtoapp.data.model.LrcData
 import com.webtoapp.data.model.LrcLine
 import com.webtoapp.core.logging.AppLogger
@@ -24,6 +27,15 @@ object BgmStorage {
     private val SAFE_NAME_REGEX = Regex("[^a-zA-Z0-9\u4e00-\u9fa5_-]")
 
     private val IMAGE_COVER_EXTENSIONS = setOf("png", "jpg", "jpeg", "jpe", "jfif", "webp", "bmp", "gif", "heic", "heif")
+
+    /** Audio extensions every writer (upload, online download) and the library scanner agree on. */
+    val MUSIC_EXTENSIONS = listOf("mp3", "m4a", "aac", "ogg", "flac", "wav")
+
+    private val MUSIC_EXTENSION_SET = MUSIC_EXTENSIONS.toSet()
+
+    private const val LIBRARY_TAGS_FILE = "library_tags.json"
+
+    private val tagGson = Gson()
 
     fun getBgmDir(context: Context): File {
         val dir = File(context.filesDir, BGM_DIR)
@@ -50,10 +62,13 @@ object BgmStorage {
             val assetManager = context.assets
             val files = assetManager.list(ASSETS_BGM_DIR) ?: return emptyList()
 
-            val mp3Files = files.filter { it.lowercase().endsWith(".mp3") }
+            val tagOverrides = loadTagOverrides(context)
+            val audioFiles = files.filter {
+                it.substringAfterLast('.', missingDelimiterValue = "").lowercase() in MUSIC_EXTENSION_SET
+            }
 
-            for (mp3File in mp3Files) {
-                val nameWithoutExt = mp3File.substringBeforeLast(".")
+            for (audioFile in audioFiles) {
+                val nameWithoutExt = audioFile.substringBeforeLast(".")
 
                 val coverFile = files.find { file ->
                     val fileNameWithoutExt = file.substringBeforeLast(".")
@@ -62,7 +77,7 @@ object BgmStorage {
                         ext in IMAGE_COVER_EXTENSIONS
                 }
 
-                val bgmPath = "asset:///$ASSETS_BGM_DIR/$mp3File"
+                val bgmPath = "asset:///$ASSETS_BGM_DIR/$audioFile"
                 val userLrcFile = File(getBgmDir(context), "$nameWithoutExt.lrc")
                 val lrcData = if (userLrcFile.exists()) {
 
@@ -82,6 +97,9 @@ object BgmStorage {
                     path = bgmPath,
                     coverPath = coverFile?.let { "asset:///$ASSETS_BGM_DIR/$it" },
                     isAsset = true,
+                    tags = tagOverrides[trackKey(isAsset = true, basename = nameWithoutExt)]
+                        ?.mapNotNull { runCatching { BgmTag.valueOf(it) }.getOrNull() }
+                        ?: emptyList(),
                     lrcData = lrcData
                 ))
             }
@@ -100,7 +118,8 @@ object BgmStorage {
 
         val files = bgmDir.listFiles() ?: return emptyList()
 
-        val mp3Files = files.filter { it.extension.lowercase() == "mp3" }
+        val tagOverrides = loadTagOverrides(context)
+        val mp3Files = files.filter { it.extension.lowercase() in MUSIC_EXTENSION_SET }
 
         for (mp3File in mp3Files) {
             val nameWithoutExt = mp3File.nameWithoutExtension
@@ -122,6 +141,9 @@ object BgmStorage {
                 path = mp3File.absolutePath,
                 coverPath = coverFile?.absolutePath,
                 isAsset = false,
+                tags = tagOverrides[trackKey(isAsset = false, basename = nameWithoutExt)]
+                    ?.mapNotNull { runCatching { BgmTag.valueOf(it) }.getOrNull() }
+                    ?: emptyList(),
                 lrcData = lrcData
             ))
         }
@@ -296,11 +318,52 @@ object BgmStorage {
 
             bgmItem.coverPath?.let { File(it).delete() }
 
+            runCatching { File(getLrcPathForBgm(context, bgmItem.path)).delete() }
+                .onFailure { AppLogger.w(TAG, "删除歌词文件失败", it) }
+
+            saveTagsForBgm(context, bgmItem, emptyList())
+
             true
         } catch (e: Exception) {
             AppLogger.e(TAG, "Operation failed", e)
             false
         }
+    }
+
+    /**
+     * Library-level tag overrides, keyed by origin + file basename so they survive
+     * rescans. Without this, tags edited in the selector lived only inside the app
+     * configs that happened to include the track.
+     */
+    fun saveTagsForBgm(context: Context, bgm: BgmItem, tags: List<BgmTag>) {
+        try {
+            val overrides = loadTagOverrides(context)
+            val key = trackKey(bgm.isAsset, File(bgm.path).nameWithoutExtension)
+            if (tags.isEmpty()) {
+                overrides.remove(key)
+            } else {
+                overrides[key] = tags.map { it.name }
+            }
+            File(getBgmDir(context), LIBRARY_TAGS_FILE).writeText(tagGson.toJson(overrides))
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "保存标签元数据失败", e)
+        }
+    }
+
+    private fun loadTagOverrides(context: Context): MutableMap<String, List<String>> {
+        return try {
+            val file = File(getBgmDir(context), LIBRARY_TAGS_FILE)
+            if (!file.exists()) return mutableMapOf()
+            val type = object : TypeToken<MutableMap<String, List<String>>>() {}.type
+            tagGson.fromJson(file.readText(), type) ?: mutableMapOf()
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "读取标签元数据失败", e)
+            mutableMapOf()
+        }
+    }
+
+    private fun trackKey(isAsset: Boolean, basename: String): String {
+        return "${if (isAsset) "asset" else "user"}/$basename"
     }
 
     fun getBgmInputStream(context: Context, path: String): java.io.InputStream? {
@@ -353,6 +416,11 @@ object BgmStorage {
                     val seconds = ((line.startTime % 60000) / 1000).toInt()
                     val millis = ((line.startTime % 1000) / 10).toInt()
                     appendLine("[%02d:%02d.%02d]%s".format(minutes, seconds, millis, line.text))
+                    // Match the export wire format (ApkBuilder.convertLrcDataToLrcString) so
+                    // translated lyrics survive the sidecar round-trip.
+                    line.translation?.let { translation ->
+                        appendLine("[%02d:%02d.%02d]%s".format(minutes, seconds, millis, translation))
+                    }
                 }
             }
 

--- a/app/src/test/java/com/webtoapp/util/BgmStorageLibraryTest.kt
+++ b/app/src/test/java/com/webtoapp/util/BgmStorageLibraryTest.kt
@@ -1,0 +1,115 @@
+package com.webtoapp.util
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.BgmItem
+import com.webtoapp.data.model.BgmTag
+import com.webtoapp.data.model.LrcData
+import com.webtoapp.data.model.LrcLine
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Regression coverage for the BGM library: the scanner used to list .mp3 files only,
+ * so online-downloaded .m4a/.flac/... tracks were saved but never shown in the
+ * selector, and lyrics/tag edits lived only in memory (or inside a single app's
+ * config) because nothing persisted them to disk.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class BgmStorageLibraryTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        BgmStorage.getBgmDir(context).deleteRecursively()
+    }
+
+    private fun writeAudio(fileName: String): File {
+        return File(BgmStorage.getBgmDir(context), fileName)
+            .apply { writeBytes(ByteArray(16) { it.toByte() }) }
+    }
+
+    @Test
+    fun `scanUserBgm lists every supported audio extension`() {
+        writeAudio("song.mp3")
+        writeAudio("song.m4a")
+        writeAudio("track.flac")
+        writeAudio("voice.ogg")
+
+        val scanned = BgmStorage.scanUserBgm(context)
+
+        assertThat(scanned.map { File(it.path).name }.toSet())
+            .containsExactly("song.mp3", "song.m4a", "track.flac", "voice.ogg")
+    }
+
+    @Test
+    fun `saved lyrics sidecar round-trips through the scan`() {
+        val audio = writeAudio("with_lrc.mp3")
+        val lrc = LrcData(
+            title = "Title",
+            artist = "Artist",
+            lines = listOf(LrcLine(startTime = 61230L, endTime = 70000L, text = "hello"))
+        )
+
+        assertThat(BgmStorage.saveLrc(context, audio.absolutePath, lrc)).isTrue()
+
+        val scanned = BgmStorage.scanUserBgm(context).single()
+        assertThat(scanned.lrcData?.title).isEqualTo("Title")
+        assertThat(scanned.lrcData?.artist).isEqualTo("Artist")
+        assertThat(scanned.lrcData?.lines?.single()?.text).isEqualTo("hello")
+        assertThat(scanned.lrcData?.lines?.single()?.startTime).isEqualTo(61230L)
+    }
+
+    @Test
+    fun `tag overrides persist across scans`() {
+        val audio = writeAudio("tagged.m4a")
+        val item = BgmItem(name = "tagged", path = audio.absolutePath, isAsset = false)
+
+        BgmStorage.saveTagsForBgm(context, item, listOf(BgmTag.POP, BgmTag.ROCK))
+
+        val scanned = BgmStorage.scanUserBgm(context).single()
+        assertThat(scanned.tags).containsExactly(BgmTag.POP, BgmTag.ROCK).inOrder()
+    }
+
+    @Test
+    fun `clearing tags persists the removal`() {
+        val audio = writeAudio("untagged.mp3")
+        val item = BgmItem(name = "untagged", path = audio.absolutePath, isAsset = false)
+        BgmStorage.saveTagsForBgm(context, item, listOf(BgmTag.POP))
+
+        BgmStorage.saveTagsForBgm(context, item, emptyList())
+
+        assertThat(BgmStorage.scanUserBgm(context).single().tags).isEmpty()
+    }
+
+    @Test
+    fun `deleteBgm removes audio cover and lyrics sidecar`() {
+        val audio = writeAudio("gone.mp3")
+        val cover = File(BgmStorage.getBgmDir(context), "gone.jpg").apply { writeBytes(ByteArray(4)) }
+        val item = BgmItem(
+            name = "gone",
+            path = audio.absolutePath,
+            coverPath = cover.absolutePath,
+            isAsset = false
+        )
+        BgmStorage.saveLrc(
+            context,
+            audio.absolutePath,
+            LrcData(lines = listOf(LrcLine(startTime = 0L, endTime = 1L, text = "x")))
+        )
+
+        assertThat(BgmStorage.deleteBgm(context, item)).isTrue()
+
+        assertThat(audio.exists()).isFalse()
+        assertThat(cover.exists()).isFalse()
+        assertThat(BgmStorage.hasLrc(context, audio.absolutePath)).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #655. The background-music library workflow had three functional defects and one shared visual defect:

1. **Non-MP3 downloads invisible.** `OnlineMusicDownloader` saves files with their real extension (m4a/aac/ogg/flac/wav) and its own `isMusicDownloaded` check accepts all six — but `BgmStorage.scanUserBgm` filtered `mp3` only, so a downloaded track passed the download check yet never appeared in the library. Both sides now share one `BgmStorage.MUSIC_EXTENSIONS` list.

2. **Lyrics/tags never persisted.** The lyric aligner, LRC editor, and tag editor only mutated in-memory state. Lyric saves now write the sidecar `.lrc` through the existing `BgmStorage.saveLrc` (its serializer now also emits translation lines, matching `ApkBuilder.convertLrcDataToLrcString`), and tags persist to `library_tags.json` keyed by origin + basename; both scanners merge the overrides. `deleteBgm` cleans up the sidecar and the tag entry.

3. **Dead refresh that would be harmful.** The unused `refreshBgmList` replaced playlist entries wholesale — wiring it later would have wiped config-only lyrics/tags. Replaced with a `refreshLibrary` merge (fresh scan wins on file-backed fields, config-only data preserved) and wired it to the upload/download callbacks.

4. **Dialog toolbar color mismatch.** The four full-screen dialogs (BGM selector, LRC editor, online music search, manual lyric aligner) rendered a default `TopAppBar` over a `colorScheme.surface` root — a detached lighter band at the top in light theme. The bars are now transparent with explicit `onSurface` content colors, inheriting the dialog body color in both themes.

Also: removed unused drag-state declarations, applied the configured volume to the selector preview player, and added the standard vertical zone padding inside the `BgmCard` expanded section.

## Test plan

- [x] New `BgmStorageLibraryTest` (Robolectric, SDK 28): multi-extension scanning (`song.mp3`/`song.m4a`/`track.flac`/`voice.ogg` all listed), lyrics sidecar round-trip incl. title/artist/timestamp, tag persistence across scans, tag clearing, and delete removing audio + cover + sidecar
- [x] `:shell:assembleRelease` green (`BgmStorage` is shell-synced; scanner changes compile in the shell dependency set)
- [x] `checkConfigFieldDrift` OK
- [x] Emulator (API 29) verification: BGM selector toolbar now shares the dialog body color (screenshot verified against the previous detached white band), `BgmCard` expanded zone padding aligns with neighbouring cards' content columns, toggle/expand animation intact
- [ ] CI green on this PR

Fixes #655