### PR TITLE
fix(gecko): materialize picked content:// files before FilePrompt.confirm

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/GeckoUploadMaterializer.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoUploadMaterializer.kt
@@ -1,0 +1,133 @@
+package com.webtoapp.core.engine
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.net.Uri
+import android.provider.OpenableColumns
+import com.webtoapp.core.logging.AppLogger
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+
+/**
+ * Turns file-picker results into something GeckoView's FilePrompt.confirm() can hand to the
+ * page (#638). confirm() never reads streams — it resolves each Uri to a local path string via
+ * the `_data` column / externalstorage document ids, and silently feeds null paths into the
+ * upload when a provider refuses (galleries, cloud, most vendor pickers). Firefox avoids this
+ * by copying every content:// through ContentResolver into a cache-backed file first
+ * (android-components toFileUri); this mirrors that for the shell bridge.
+ *
+ * Copy failures fall back to the original Uri so one unreadable item cannot sink the whole
+ * selection — upstream resolution may still succeed where the copy could not.
+ *
+ * Copies must outlive the pick dialog (pages upload asynchronously) but cannot be kept forever:
+ * stale files are purged on the next prompt and everything is wiped when the engine is
+ * destroyed. The caller runs I/O off the UI thread; FilePrompt.confirm() is @UiThread.
+ */
+internal object GeckoUploadMaterializer {
+
+    private const val TAG = "GeckoUploadMaterializer"
+
+    const val UPLOAD_TTL_MS: Long = 60L * 60L * 1000L
+
+    private const val MAX_FILE_NAME_LENGTH = 100
+
+    /**
+     * Returns Uris safe to pass to FilePrompt.confirm(): content:// entries are copied into
+     * [uploadsDir] and replaced by file:// Uris pointing at the copies, other schemes pass
+     * through unchanged. Never throws.
+     */
+    fun prepare(
+        uris: Array<Uri>,
+        uploadsDir: File,
+        resolver: ContentResolver?,
+        nowMs: Long = System.currentTimeMillis()
+    ): Array<Uri> {
+        runCatching { purgeStale(uploadsDir, nowMs) }
+            .onFailure { AppLogger.w(TAG, "Upload cache purge failed: ${it.message}") }
+        return Array(uris.size) { i -> materialize(uris[i], uploadsDir, resolver) }
+    }
+
+    /** Deletes every cached upload (engine teardown: all sessions are gone by then). */
+    fun purgeAll(uploadsDir: File) {
+        val files = uploadsDir.listFiles() ?: return
+        for (file in files) {
+            runCatching { file.delete() }
+        }
+    }
+
+    internal fun materialize(uri: Uri, uploadsDir: File, resolver: ContentResolver?): Uri {
+        return when (uri.scheme) {
+            "content" -> runCatching { copyToCache(uri, uploadsDir, resolver) }
+                .onFailure { failure ->
+                    AppLogger.w(TAG, "Content URI not materialized, using as-is (${failure.javaClass.simpleName}): $uri")
+                }
+                .getOrNull()?.let { Uri.fromFile(it) } ?: uri
+            else -> uri
+        }
+    }
+
+    internal fun purgeStale(uploadsDir: File, nowMs: Long) {
+        val files = uploadsDir.listFiles() ?: return
+        for (file in files) {
+            if (!file.isFile) continue
+            // A future lastModified (clock skew) yields a negative age and is kept.
+            if (nowMs - file.lastModified() > UPLOAD_TTL_MS) {
+                runCatching { file.delete() }
+            }
+        }
+    }
+
+    private fun copyToCache(uri: Uri, uploadsDir: File, resolver: ContentResolver?): File {
+        if (!uploadsDir.exists()) uploadsDir.mkdirs()
+        if (resolver == null) throw IllegalStateException("No ContentResolver to read $uri")
+
+        val target = uniqueTarget(uploadsDir, sanitizeUploadFileName(displayName(resolver, uri)))
+        resolver.openInputStream(uri)?.use { input ->
+            FileOutputStream(target).use { output -> input.copyTo(output) }
+        } ?: throw IllegalStateException("Provider returned no stream for $uri")
+        return target
+    }
+
+    private fun displayName(resolver: ContentResolver, uri: Uri): String? {
+        return try {
+            resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { cursor -> displayNameFrom(cursor) }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun displayNameFrom(cursor: Cursor): String? {
+        val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        if (index < 0 || !cursor.moveToFirst()) return null
+        return try { cursor.getString(index) } catch (e: Exception) { null }
+    }
+
+    internal fun sanitizeUploadFileName(raw: String?): String {
+        var name = raw?.map { ch ->
+            if (ch.isLetterOrDigit()) ch else if (ch == '.' || ch == '-' || ch == '_' || ch == ' ') ch else '_'
+        }?.joinToString("")?.trim().orEmpty()
+
+        // Trim from the front so an over-long name keeps its extension (the part that matters).
+        if (name.length > MAX_FILE_NAME_LENGTH) {
+            name = "..." + name.takeLast(MAX_FILE_NAME_LENGTH - 3)
+        }
+        if (name.isEmpty() || name.all { it == '.' }) name = "upload"
+        return name
+    }
+
+    private fun uniqueTarget(dir: File, name: String): File {
+        var target = File(dir, name)
+        if (!target.exists()) return target
+        val dot = name.lastIndexOf('.')
+        val stem = if (dot > 0) name.substring(0, dot) else name
+        val ext = if (dot > 0) name.substring(dot) else ""
+        var n = 1
+        while (true) {
+            target = File(dir, "$stem ($n)$ext")
+            if (!target.exists()) return target
+            n++
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -19,6 +19,10 @@ import org.mozilla.geckoview.GeckoView
 import org.mozilla.geckoview.StorageController
 import org.mozilla.geckoview.WebResponse
 import org.mozilla.geckoview.WebExtension
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.mozilla.geckoview.MediaSession as GeckoMediaSession
 
 data class ProxyConfig(
@@ -37,6 +41,9 @@ class GeckoViewEngine(
 
     companion object {
         private const val TAG = "GeckoViewEngine"
+
+        /** Cache dir (under cacheDir) holding materialized file-picker uploads (#638). */
+        private const val UPLOAD_CACHE_DIR = "gecko_uploads"
 
         @Volatile
         private var sharedRuntime: GeckoRuntime? = null
@@ -413,6 +420,12 @@ class GeckoViewEngine(
 
     private var bridgeScope: kotlinx.coroutines.CoroutineScope? = null
 
+    /**
+     * Drives the off-main copy + @UiThread confirm for picked files (#638). Cancelled on
+     * destroy() so a pending upload cannot outlive the engine.
+     */
+    private var filePromptScope: kotlinx.coroutines.CoroutineScope? = null
+
     override fun createView(
         context: Context,
         config: WebViewConfig,
@@ -619,9 +632,7 @@ class GeckoViewEngine(
                 val valueCallback = android.webkit.ValueCallback<Array<android.net.Uri>> { uris ->
                     when {
                         uris.isNullOrEmpty() -> finish(prompt.dismiss())
-                        prompt.type == GeckoSession.PromptDelegate.FilePrompt.Type.MULTIPLE ->
-                            finish(prompt.confirm(context, uris))
-                        else -> finish(prompt.confirm(context, uris[0]))
+                        else -> deliverPickedFiles(prompt, uris) { finish(it) }
                     }
                 }
 
@@ -636,6 +647,47 @@ class GeckoViewEngine(
                     finish(prompt.dismiss())
                 }
                 return result
+            }
+        }
+    }
+
+    /**
+     * FilePrompt.confirm() resolves Uris to local path strings and silently uploads nothing
+     * when the provider refuses to expose one (#638: galleries, cloud, vendor pickers), so
+     * content:// picks are first copied into a cache dir by GeckoUploadMaterializer (same
+     * approach as Firefox's android-components). The copy runs on IO; confirm() is annotated
+     * @UiThread and resumes on main. A failed materialization still confirms with the original
+     * Uris — upstream resolution may succeed where the copy could not.
+     */
+    private fun deliverPickedFiles(
+        prompt: GeckoSession.PromptDelegate.FilePrompt,
+        uris: Array<android.net.Uri>,
+        finish: (GeckoSession.PromptDelegate.PromptResponse) -> Unit
+    ) {
+        val scope = filePromptScope ?: kotlinx.coroutines.MainScope().also { filePromptScope = it }
+        scope.launch {
+            val prepared = runCatching {
+                withContext(Dispatchers.IO) {
+                    GeckoUploadMaterializer.prepare(
+                        uris,
+                        java.io.File(context.cacheDir, UPLOAD_CACHE_DIR),
+                        context.contentResolver
+                    )
+                }
+            }.onFailure { AppLogger.w(TAG, "File upload materialization failed: ${it.message}") }
+                .getOrDefault(uris)
+            try {
+                if (prompt.type == GeckoSession.PromptDelegate.FilePrompt.Type.MULTIPLE) {
+                    finish(prompt.confirm(context, prepared))
+                } else {
+                    finish(prompt.confirm(context, prepared[0]))
+                }
+            } catch (e: Exception) {
+                AppLogger.w(TAG, "FilePrompt confirm failed: ${e.message}")
+                // Free the page's input state instead of leaving the upload pending forever.
+                try {
+                    finish(prompt.dismiss())
+                } catch (_: Exception) { }
             }
         }
     }
@@ -907,6 +959,10 @@ class GeckoViewEngine(
         geckoView = null
         callback = null
         lastConfig = null
+        filePromptScope?.cancel()
+        filePromptScope = null
+        runCatching { GeckoUploadMaterializer.purgeAll(java.io.File(context.cacheDir, UPLOAD_CACHE_DIR)) }
+            .onFailure { AppLogger.w(TAG, "Upload cache purge failed: ${it.message}") }
     }
 
     override fun clearCache(includeDiskFiles: Boolean) {

--- a/app/src/test/java/com/webtoapp/core/engine/GeckoUploadMaterializerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/engine/GeckoUploadMaterializerTest.kt
@@ -1,0 +1,121 @@
+package com.webtoapp.core.engine
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.ByteArrayInputStream
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoUploadMaterializerTest {
+
+    private lateinit var context: Context
+    private lateinit var uploadsDir: File
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        uploadsDir = File(context.cacheDir, "gecko_uploads_test").apply { mkdirs() }
+    }
+
+    private fun registerUpload(uri: Uri, bytes: ByteArray) {
+        shadowOf(context.contentResolver).registerInputStream(uri, ByteArrayInputStream(bytes))
+    }
+
+    private fun contentUri(id: Int): Uri = Uri.parse("content://media/external/images/media/$id")
+
+    @Test
+    fun `content uri is materialized into a file uri carrying the picked bytes`() {
+        val uri = contentUri(1)
+        registerUpload(uri, "hello upload".toByteArray())
+
+        val prepared = GeckoUploadMaterializer.prepare(
+            arrayOf(uri), uploadsDir, context.contentResolver
+        )
+
+        assertEquals(1, prepared.size)
+        assertEquals("file", prepared[0].scheme)
+        val copy = File(prepared[0].path!!)
+        assertTrue(copy.isFile)
+        // No display name resolves under the bare shadow resolver, so the fallback name applies.
+        assertTrue(copy.name.startsWith("upload"))
+        assertEquals("hello upload", copy.readText())
+    }
+
+    @Test
+    fun `unreadable content uri falls back to the original uri`() {
+        val uri = contentUri(2)
+
+        val prepared = GeckoUploadMaterializer.prepare(
+            arrayOf(uri), uploadsDir, context.contentResolver
+        )
+
+        assertEquals(listOf(uri), prepared.toList())
+    }
+
+    @Test
+    fun `non-content schemes pass through untouched`() {
+        val fileUri = Uri.fromFile(File.createTempFile("direct", ".txt"))
+        val mailtoUri = Uri.parse("mailto:someone@example.com")
+
+        val prepared = GeckoUploadMaterializer.prepare(arrayOf(fileUri, mailtoUri), uploadsDir, null)
+
+        assertEquals(listOf(fileUri, mailtoUri), prepared.toList())
+    }
+
+    @Test
+    fun `same-named copies are deduplicated without clobbering each other`() {
+        val first = contentUri(4)
+        val second = contentUri(5)
+        registerUpload(first, "first".toByteArray())
+        registerUpload(second, "second".toByteArray())
+
+        val prepared = GeckoUploadMaterializer.prepare(
+            arrayOf(first, second), uploadsDir, context.contentResolver
+        )
+
+        assertFalse(prepared[0].path == prepared[1].path)
+        assertEquals("first", File(prepared[0].path!!).readText())
+        assertEquals("second", File(prepared[1].path!!).readText())
+    }
+
+    @Test
+    fun `stale uploads are purged but fresh ones kept`() {
+        val now = System.currentTimeMillis()
+        val stale = File(uploadsDir, "stale.jpg")
+            .apply { writeText("old"); setLastModified(now - GeckoUploadMaterializer.UPLOAD_TTL_MS - 60_000L) }
+        val fresh = File(uploadsDir, "fresh.jpg").apply { writeText("new") }
+
+        GeckoUploadMaterializer.purgeStale(uploadsDir, now)
+
+        assertFalse(stale.exists())
+        assertTrue(fresh.exists())
+    }
+
+    @Test
+    fun `sanitize strips separators, blanks and dot-only names`() {
+        assertEquals("upload", GeckoUploadMaterializer.sanitizeUploadFileName(null))
+        assertEquals("upload", GeckoUploadMaterializer.sanitizeUploadFileName("   "))
+        assertEquals("upload", GeckoUploadMaterializer.sanitizeUploadFileName("..."))
+        val nasty = GeckoUploadMaterializer.sanitizeUploadFileName("../../etc/passwd")
+        assertFalse(nasty.contains('/'))
+        assertEquals("report 2026_.pdf", GeckoUploadMaterializer.sanitizeUploadFileName("report 2026?.pdf"))
+    }
+
+    @Test
+    fun `over-long names keep their extension`() {
+        val longName = "${"a".repeat(150)}.pdf"
+        val sanitized = GeckoUploadMaterializer.sanitizeUploadFileName(longName)
+
+        assertTrue(sanitized.length <= 100)
+        assertTrue(sanitized.endsWith(".pdf"))
+    }
+}


### PR DESCRIPTION
Fixes #638

## Problem

With the GeckoView engine, tapping a file-picker on a page opens the system chooser and a file can be picked, but nothing happens afterwards: no upload, no change event, no callback. The same page and file work fine on the System WebView engine (report #638). Edge and Firefox on the same device also work, so it is not an upstream engine defect.

## Root cause

The shell bridges GeckoView's `FilePrompt` onto the System-WebView `ValueCallback`/`FileChooserParams` contract (`GeckoViewEngine.onFilePrompt` → `ShellPermissionDelegate.handleFileChooser`). The SAF-based chooser always returns `content://` Uris, which were passed straight to `prompt.confirm(context, uri)`.

Upstream `FilePrompt.confirm()` never reads streams — it resolves each Uri into a **local path string** (`_data` column / `externalstorage` document ids, see `IntentUtils.resolveDocumentUri/resolveContentUri`) and puts that string array into the prompt result. When resolution fails — galleries, cloud providers and most vendor pickers refuse to expose `_data`, especially on Android 10+ — upstream logs at DEBUG level only and still confirms with `null` paths, so the page receives nothing. That is exactly the silent "picker closed, no reaction" symptom.

Firefox itself avoids this: android-components' `GeckoPromptDelegate` copies every picked `content://` through ContentResolver into a cache-backed temp file first (`toFileUri`) and hands the resulting `file://` Uri to `confirm()`.

## Fix

Mirror Firefox's approach in the shell bridge:

- New `GeckoUploadMaterializer` copies each `content://` pick into `cacheDir/gecko_uploads/` under its sanitized provider display name (path-traversal safe, extension-preserving for over-long names, de-duplicated on collision) and swaps it for a `file://` Uri.
- Copy failures fall back to the original Uri so one unreadable item cannot sink the whole selection; upstream path resolution may still succeed where the copy could not.
- Copies must outlive the picker dialog because pages upload asynchronously: stale files are purged lazily after a 1-hour TTL when the next prompt opens, and the whole cache is wiped in `destroy()`.
- New `deliverPickedFiles()` runs the copy on `Dispatchers.IO` (`confirm()` is annotated `@UiThread`) and confirms on main; if `confirm()` throws, the prompt is dismissed so the page's input state cannot hang forever.

System WebView behavior is untouched — this only changes the Gecko delivery leg inside `GeckoViewEngine`.

## Testing

- New Robolectric tests `GeckoUploadMaterializerTest` (7 cases): byte-exact materialization, unreadable-provider fallback, non-content passthrough, same-name collision de-duplication, TTL purge, filename sanitization/traversal safety, over-long name keeps extension. All pass locally (`testStandardDebugUnitTest --tests 'com.webtoapp.core.engine.*'`).
- Full `:app:compileStandardDebugKotlin` clean; shell template rebuilt via `:shell:assembleRelease :app:syncShellTemplateApk`.
- Real-device follow-up for the reporter: please re-test with both gallery and Files sources on the HONOR/Android 10 device from #638 once a build with this fix is available.