### PR TITLE
feat(find): raise the IME when the find-in-page bar opens

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/FindInPageBar.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/FindInPageBar.kt
@@ -11,12 +11,14 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -63,9 +65,15 @@ fun FindInPageBar(
         }
     }
 
-    // Cursor ready as soon as the bar opens.
+    // Cursor and IME ready as soon as the bar opens (#652): requestFocus alone leaves the
+    // keyboard hidden, so wait for focus to land before raising the IME.
+    val keyboard = LocalSoftwareKeyboardController.current
     LaunchedEffect(webView) {
-        if (webView != null) inputFocusRequester.requestFocus()
+        if (webView != null) {
+            inputFocusRequester.requestFocus()
+            withFrameNanos { }
+            if (inputFocused) keyboard?.show()
+        }
     }
 
     // Live search as the query changes (debounced), like Chrome's find bar.
@@ -187,6 +195,7 @@ fun FindInPageBar(
             IconButton(
                 onClick = {
                     query = ""
+                    keyboard?.hide()
                     onClose()
                 },
                 modifier = Modifier.size(36.dp)


### PR DESCRIPTION
Resolves #652

## What

When the user taps the find-in-page button, the bar opened with the cursor already blinking in the input, but the keyboard stayed hidden until a second tap on the field. This PR raises the IME automatically on bar open and hides it when the bar is dismissed.

## Why it happened

`FindInPageBar` (from #614) only called `FocusRequester.requestFocus()` on open. On Android, focus delivery and IME display are independent: a text field gaining runtime focus after window layout does not automatically summon the keyboard unless the window uses a `stateVisible` soft-input mode — hence "cursor ready, keyboard not".

## How

- In the open `LaunchedEffect`, after `requestFocus()` wait one frame (`withFrameNanos`) and only call `LocalSoftwareKeyboardController.show()` once focus has actually landed (`inputFocused == true`). The one-frame wait avoids the early `show()` being swallowed during window/layout transitions.
- The close button now calls `hide()` before `onClose()` so dismissing the bar doesn't leave the keyboard stranded.
- Deliberately **not** wired into the post-search focus re-claim path fixed in #649: the keyboard must pop only on bar open, never re-appear when the user collapses it mid-search.

Both mount points share this component, so generated apps (`ShellActivity` → `ShellScaffoldLayout`) and host preview (`WebViewActivity`) get the behavior at once. No new user-visible strings; i18n untouched.

## Testing

- `:app:compileStandardDebugKotlin` clean.
- IME scheduling can't be meaningfully asserted under Robolectric; manual verification checklist: opening the bar pops the keyboard; closing via × retracts it; manually collapsing the keyboard mid-search does not pop it back.