### PR TITLE
feat(zoom): browser-level page zoom + build-time initial zoom setting

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3755,6 +3755,7 @@ private fun com.webtoapp.data.model.WebViewConfig.toWebViewBlock(context: androi
         toolbarShowConsole = toolbarShowConsole,
         toolbarShowZoom = toolbarShowZoom,
         toolbarShowFind = toolbarShowFind,
+        initialPageZoomPercent = initialPageZoomPercent,
         browserToolbarCustomized = browserToolbarCustomized,
         showStatusBarInFullscreen = showStatusBarInFullscreen,
         showNavigationBarInFullscreen = showNavigationBarInFullscreen,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -115,6 +115,7 @@ data class ApkConfig(
     val toolbarShowConsole: Boolean get() = webView.toolbarShowConsole
     val toolbarShowZoom: Boolean get() = webView.toolbarShowZoom
     val toolbarShowFind: Boolean get() = webView.toolbarShowFind
+    val initialPageZoomPercent: Int get() = webView.initialPageZoomPercent
     val browserToolbarCustomized: Boolean get() = webView.browserToolbarCustomized
     val showStatusBarInFullscreen: Boolean get() = webView.showStatusBarInFullscreen
     val showNavigationBarInFullscreen: Boolean get() = webView.showNavigationBarInFullscreen
@@ -482,6 +483,7 @@ data class WebViewBlock(
     val toolbarShowConsole: Boolean = true,
     val toolbarShowZoom: Boolean = true,
     val toolbarShowFind: Boolean = true,
+    val initialPageZoomPercent: Int = 100,
     val browserToolbarCustomized: Boolean = false,
     val showStatusBarInFullscreen: Boolean = false,
     val showNavigationBarInFullscreen: Boolean = false,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -179,6 +179,7 @@ internal object ApkConfigJsonFactory {
         "toolbarShowConsole" to webView.toolbarShowConsole,
         "toolbarShowZoom" to webView.toolbarShowZoom,
         "toolbarShowFind" to webView.toolbarShowFind,
+        "initialPageZoomPercent" to webView.initialPageZoomPercent,
         "browserToolbarCustomized" to webView.browserToolbarCustomized,
         "showStatusBarInFullscreen" to webView.showStatusBarInFullscreen,
         "showNavigationBarInFullscreen" to webView.showNavigationBarInFullscreen,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -999,6 +999,8 @@ object Strings {
     val console: String get() = StringsA.console
     val pageZoomLabel: String get() = StringsA.pageZoomLabel
     val pageZoomReset: String get() = StringsA.pageZoomReset
+    val initialPageZoomLabel: String get() = StringsA.initialPageZoomLabel
+    val initialPageZoomHint: String get() = StringsA.initialPageZoomHint
     val noConsoleMessages: String get() = StringsA.noConsoleMessages
     val inputJavaScript: String get() = StringsA.inputJavaScript
     val preparingDownload: String get() = StringsA.preparingDownload
@@ -17591,6 +17593,32 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Сбросить"
         AppLanguage.JAPANESE -> "リセット"
         AppLanguage.KOREAN -> "재설정"
+    }
+
+    val initialPageZoomLabel: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "初始页面缩放"
+        AppLanguage.ENGLISH -> "Initial Page Zoom"
+        AppLanguage.ARABIC -> "تكبير الصفحة الابتدائي"
+        AppLanguage.PORTUGUESE -> "Zoom Inicial da Página"
+        AppLanguage.SPANISH -> "Zoom inicial de página"
+        AppLanguage.FRENCH -> "Zoom de page initial"
+        AppLanguage.GERMAN -> "Anfänglicher Seitenzoom"
+        AppLanguage.RUSSIAN -> "Начальный масштаб страницы"
+        AppLanguage.JAPANESE -> "初期ページズーム"
+        AppLanguage.KOREAN -> "초기 페이지 확대"
+    }
+
+    val initialPageZoomHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "应用启动时的整页缩放比例；用户仍可在运行时通过工具栏调整"
+        AppLanguage.ENGLISH -> "Whole-page zoom applied at app start; users can still adjust it from the toolbar"
+        AppLanguage.ARABIC -> "تكبير الصفحة الكاملة عند بدء التطبيق؛ لا يزال بإمكان المستخدمين تعديله من شريط الأدوات"
+        AppLanguage.PORTUGUESE -> "Zoom de página inteira aplicado ao iniciar o aplicativo; os usuários ainda podem ajustá-lo pela barra de ferramentas"
+        AppLanguage.SPANISH -> "Zoom de página completa aplicado al iniciar la aplicación; los usuarios aún pueden ajustarlo desde la barra de herramientas"
+        AppLanguage.FRENCH -> "Zoom de page entière appliqué au démarrage de l'application ; les utilisateurs peuvent toujours l'ajuster depuis la barre d'outils"
+        AppLanguage.GERMAN -> "Ganzseitiger Zoom beim Start der App; Nutzer können ihn weiterhin über die Symbolleiste anpassen"
+        AppLanguage.RUSSIAN -> "Масштаб всей страницы при запуске приложения; пользователи могут изменить его через панель инструментов"
+        AppLanguage.JAPANESE -> "アプリ起動時のページ全体のズーム率。ユーザーはツールバーから後で調整できます"
+        AppLanguage.KOREAN -> "앱 시작 시 적용되는 전체 페이지 확대/축소; 사용자는 도구 모음에서 조정할 수 있습니다"
     }
 
     val noConsoleMessages: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -1148,6 +1148,9 @@ data class WebViewShellConfig(
         @SerializedName("toolbarShowFind")
         val toolbarShowFind: Boolean = true,
 
+        @SerializedName("initialPageZoomPercent")
+        val initialPageZoomPercent: Int = 100,
+
     @SerializedName("browserToolbarCustomized")
     val browserToolbarCustomized: Boolean = false,
 

--- a/app/src/main/java/com/webtoapp/core/webview/PageZoom.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/PageZoom.kt
@@ -1,0 +1,84 @@
+package com.webtoapp.core.webview
+
+import android.webkit.WebView
+import com.webtoapp.core.logging.AppLogger
+
+/**
+ * Browser-level page zoom (#654). Scales the whole page — text, images and layout boxes
+ * together, like Chrome/Edge page zoom — by setting CSS `zoom` on the document element.
+ *
+ * This deliberately replaces the previous mechanism ([WebSettings.setTextZoom]) for
+ * overrides: textZoom re-renders only glyphs and never touches media or spacing, which is
+ * exactly what #654 reported. CSS zoom on :root reflows the whole layout, and mobile
+ * WebViews have shipped it (non-standard but universally supported by Chromium) for years,
+ * down to old provider builds.
+ *
+ * Two zoom sources compose:
+ *  - Build-time default: [com.webtoapp.data.model.WebViewConfig.initialPageZoomPercent]
+ *    chosen in the editor, embedded into shell config.
+ *  - Runtime override: [PageZoomStore] value set from the toolbar dialog at app runtime;
+ *    wins over the build-time default when present (>0).
+ *
+ * The resolved percent is applied on every onPageFinished (idempotent), so it survives
+ * client redirects and same-Window navigations; live changes from the toolbar apply the
+ * script immediately to the current DOM instead of forcing a reload (CSS zoom relayouts
+ * synchronously). GeckoView has no WebView settings surface — callers gate on engine type
+ * and this object stays inert there.
+ */
+object PageZoom {
+
+    const val DEFAULT_PERCENT = 100
+
+    /** Chrome-like stops; anything outside is clamped rather than rejected. */
+    const val MIN_PERCENT = 25
+    const val MAX_PERCENT = 300
+
+    fun normalize(percent: Int): Int = percent.coerceIn(MIN_PERCENT, MAX_PERCENT)
+
+    /**
+     * Effective percent for a freshly created/loaded WebView: a stored runtime override
+     * (>0) always wins over the build-time default.
+     */
+    fun resolvePercent(configuredPercent: Int, runtimeOverridePercent: Int): Int {
+        if (runtimeOverridePercent > 0) return normalize(runtimeOverridePercent)
+        if (configuredPercent > 0 && configuredPercent != DEFAULT_PERCENT) {
+            return normalize(configuredPercent)
+        }
+        return DEFAULT_PERCENT
+    }
+
+    /**
+     * JS that applies [percent] to the loaded document. Pass [DEFAULT_PERCENT] to clear any
+     * previously applied zoom. Idempotent; safe to evaluate repeatedly on the same page.
+     */
+    fun jsApplyScript(percent: Int): String {
+        if (percent <= 0 || percent == DEFAULT_PERCENT) {
+            return "(function(){try{document.documentElement.style.removeProperty('zoom');}catch(e){}})();"
+        }
+        val p = normalize(percent)
+        return "(function(){try{document.documentElement.style.setProperty('zoom','$p%','important');" +
+            "if(document.documentElement.style.zoom!=='$p%'){document.documentElement.style.zoom='$p%';}}catch(e){}})();"
+    }
+
+    /**
+     * Applies [percent] to an already-loaded [webView]. Percent == [DEFAULT_PERCENT] clears
+     * any previously applied zoom (needed after a runtime reset); repeated calls with an
+     * unchanged percent are skipped via the internal last-applied map so the onPageFinished
+     * hook costs nothing on pages that never asked for zoom.
+     */
+    private val lastAppliedByView = java.util.WeakHashMap<WebView, Int>()
+
+    fun applyToLoaded(webView: WebView?, percent: Int) {
+        if (webView == null) return
+        val target = if (percent <= 0) DEFAULT_PERCENT else normalize(percent)
+        synchronized(lastAppliedByView) {
+            if (lastAppliedByView[webView] == target && target != DEFAULT_PERCENT) return
+            lastAppliedByView[webView] = target
+        }
+        try {
+            webView.evaluateJavascript(jsApplyScript(target), null)
+        } catch (e: Exception) {
+            AppLogger.w("PageZoom", "apply failed", e)
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1208,6 +1208,14 @@ class WebViewManager(
     @Volatile
     private var currentMainFrameUrl: String? = null
 
+    /**
+     * Resolved browser-level page zoom percent for the WebView being configured
+     * (build-time default resolved against the runtime PageZoomStore override).
+     * Applied on every onPageFinished via [PageZoom.applyToLoaded]; 100 = no zoom.
+     */
+    @Volatile
+    private var currentConfiguredPageZoom: Int = com.webtoapp.core.webview.PageZoom.DEFAULT_PERCENT
+
     private val cookieFlushRunnable = Runnable {
         try { CookieManager.getInstance().flush() } catch (_: Exception) {}
     }
@@ -1548,14 +1556,24 @@ class WebViewManager(
 
             com.webtoapp.core.perf.NativePerfEngine.optimizeWebViewSettings(this)
 
-            // Runtime per-app page zoom (textZoom), persisted across cold starts via
-            // PageZoomStore. Applied AFTER the viewport/dark-mode settings above (which may
-            // pin textZoom to 100 in DESKTOP mode) so the user override wins. 0 = no override.
+            // Runtime per-app page zoom, persisted across cold starts via PageZoomStore.
+            // Browser-level (CSS zoom on :root), not textZoom — textZoom only rescales glyphs
+            // and never touches images/layout (#654). Applied AFTER viewport settings; a
+            // stored runtime override wins over the build-time initial zoom. 0 = no override.
             val runtimeZoomOverride = com.webtoapp.core.webview.PageZoomStore
                 .getZoomPercent(context, context.packageName)
-            if (runtimeZoomOverride > 0) {
-                settings.textZoom = runtimeZoomOverride
-                AppLogger.d("WebViewManager", "Applied runtime page zoom: textZoom=$runtimeZoomOverride%")
+            val effectivePageZoom = com.webtoapp.core.webview.PageZoom.resolvePercent(
+                configuredPercent = config.initialPageZoomPercent,
+                runtimeOverridePercent = runtimeZoomOverride
+            )
+            if (effectivePageZoom != com.webtoapp.core.webview.PageZoom.DEFAULT_PERCENT) {
+                AppLogger.d(
+                    "WebViewManager",
+                    "Initial browser page zoom: $effectivePageZoom% (configured=${config.initialPageZoomPercent}, runtime=$runtimeZoomOverride)"
+                )
+                // Applies at onPageFinished via PageZoom.applyToLoaded (DOM must exist for the
+                // :root style to survive the next navigation).
+                currentConfiguredPageZoom = effectivePageZoom
             }
 
             if (config.initialScale > 0) {
@@ -2213,6 +2231,10 @@ class WebViewManager(
                 currentMainFrameUrl = url ?: currentMainFrameUrl
                 val elapsed = System.currentTimeMillis() - diagPageStartTime
                 AppLogger.d("WebViewManager", "Page finished: +${elapsed}ms blocked=$diagBlockedCount errors=$diagErrorCount")
+
+                // Browser-level page zoom must re-apply on every finished navigation: the
+                // :root style dies with each document. Idempotent + de-duplicated in PageZoom.
+                com.webtoapp.core.webview.PageZoom.applyToLoaded(view, currentConfiguredPageZoom)
 
                 if (url != null && url.startsWith("file://")) {
                     fileRetryCount = 0

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -297,6 +297,9 @@ data class WebViewConfig(
     val toolbarShowConsole: Boolean = true,
     val toolbarShowZoom: Boolean = true,
     val toolbarShowFind: Boolean = true,
+    // Build-time browser-level page zoom default in percent (100 = no zoom, #654). Runtime
+    // overrides from the toolbar dialog still win over this via PageZoomStore.
+    val initialPageZoomPercent: Int = 100,
     val browserToolbarCustomized: Boolean = false,
     val hideToolbar: Boolean = false,
     val showStatusBarInFullscreen: Boolean = false,

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -1003,6 +1003,27 @@ fun BrowserAdvancedConfigCard(
                                 onCheckedChange = { onConfigChange(config.copy(zoomEnabled = it)) }
                             )
                             WtaSectionDivider()
+                            var initialZoomDialogOpen by remember { mutableStateOf(false) }
+                            WtaChoiceRow(
+                                title = Strings.initialPageZoomLabel,
+                                subtitle = Strings.initialPageZoomHint,
+                                value = "${if (config.initialPageZoomPercent <= 0) 100 else config.initialPageZoomPercent}%",
+                                onClick = { initialZoomDialogOpen = true }
+                            )
+                            if (initialZoomDialogOpen) {
+                                com.webtoapp.ui.shell.ZoomPresetsDialog(
+                                    currentZoom = config.initialPageZoomPercent,
+                                    onSelect = { percent ->
+                                        onConfigChange(config.copy(
+                                            // 0 means "reset" from the runtime dialog; the
+                                            // editor stores the concrete default (100) instead.
+                                            initialPageZoomPercent = if (percent > 0) percent else 100
+                                        ))
+                                    },
+                                    onDismiss = { initialZoomDialogOpen = false }
+                                )
+                            }
+                            WtaSectionDivider()
                             WtaToggleRow(
                                 title = Strings.fullscreenVideoSetting,
                                 subtitle = Strings.fullscreenVideoSettingHint,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -142,10 +142,9 @@ fun BoxScope.ShellScaffoldLayout(
     }
     val onZoomChange: (Int) -> Unit = { percent ->
         pageZoomPercent = percent
-        // textZoom only takes effect on the next page layout, so a live page needs a reload
-        // to reflect the change immediately (Chromium does not relayout for setTextZoom).
-        webViewRef?.settings?.textZoom = if (percent > 0) percent else 100
-        webViewRef?.reload()
+        // Browser-level zoom (CSS zoom on :root) relayouts synchronously — apply to the
+        // live DOM immediately instead of the old textZoom + reload dance (#654).
+        webViewRef?.let { com.webtoapp.core.webview.PageZoom.applyToLoaded(it, percent) }
         PageZoomStore.setZoomPercent(context, config.packageName, percent)
     }
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -78,6 +78,7 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         popupBlockerToggleEnabled = config.webViewConfig.popupBlockerToggleEnabled,
 
         initialScale = config.webViewConfig.initialScale,
+        initialPageZoomPercent = config.webViewConfig.initialPageZoomPercent,
         viewportMode = try { com.webtoapp.data.model.ViewportMode.valueOf(config.webViewConfig.viewportMode) } catch (e: Exception) { com.webtoapp.data.model.ViewportMode.DEFAULT },
         customViewportWidth = config.webViewConfig.customViewportWidth,
         newWindowBehavior = try { com.webtoapp.data.model.NewWindowBehavior.valueOf(config.webViewConfig.newWindowBehavior) } catch (e: Exception) { com.webtoapp.data.model.NewWindowBehavior.SAME_WINDOW },

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2950,11 +2950,10 @@ fun WebViewScreen(
                                     currentZoom = pageZoomPercent,
                                     onSelect = { percent ->
                                         pageZoomPercent = percent
-                                        // textZoom only takes effect on the next page layout,
-                                        // so a live page needs a reload to reflect the change
-                                        // immediately (Chromium does not relayout for setTextZoom).
-                                        webViewRef?.settings?.textZoom = if (percent > 0) percent else 100
-                                        webViewRef?.reload()
+                                        // Browser-level zoom (CSS zoom on :root) relayouts
+                                        // synchronously — apply to the live DOM directly
+                                        // instead of the old textZoom + reload dance (#654).
+                                        webViewRef?.let { com.webtoapp.core.webview.PageZoom.applyToLoaded(it, percent) }
                                         PageZoomStore.setZoomPercent(context, previewAppPackage, percent)
                                     },
                                     onDismiss = { zoomDialogOpen = false }

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
@@ -202,7 +202,8 @@ class WebViewConfigBooleanCoverageTest {
                 swipeRefreshZone = com.webtoapp.data.model.SwipeRefreshZone.ANYWHERE,
                 autoRefreshIntervalSec = 120,
                 blobInterceptThresholdMb = 10,
-                screenAwakeTimeoutMinutes = 15
+                screenAwakeTimeoutMinutes = 15,
+                initialPageZoomPercent = 125
             )
         )
         val shell = roundTrip(app)
@@ -227,6 +228,7 @@ class WebViewConfigBooleanCoverageTest {
         readShell("autoRefreshIntervalSec", 120)
         readShell("blobInterceptThresholdMb", 10)
         readShell("screenAwakeTimeoutMinutes", 15)
+        readShell("initialPageZoomPercent", 125)
     }
 
     // ────────────────────────────────────────────────────────────

--- a/app/src/test/java/com/webtoapp/core/webview/PageZoomTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/PageZoomTest.kt
@@ -1,0 +1,59 @@
+package com.webtoapp.core.webview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PageZoomTest {
+
+    @Test
+    fun `normalize clamps into the supported percent window`() {
+        assertEquals(25, PageZoom.normalize(1))
+        assertEquals(150, PageZoom.normalize(150))
+        assertEquals(300, PageZoom.normalize(9999))
+    }
+
+    @Test
+    fun `runtime override wins over build-time default`() {
+        assertEquals(
+            125,
+            PageZoom.resolvePercent(configuredPercent = 75, runtimeOverridePercent = 125)
+        )
+    }
+
+    @Test
+    fun `build-time default applies when no runtime override exists`() {
+        assertEquals(
+            75,
+            PageZoom.resolvePercent(configuredPercent = 75, runtimeOverridePercent = 0)
+        )
+        assertEquals(
+            100,
+            PageZoom.resolvePercent(configuredPercent = 100, runtimeOverridePercent = 0)
+        )
+        // Legacy configs may carry a stored "reset" (0): treat as no zoom.
+        assertEquals(
+            100,
+            PageZoom.resolvePercent(configuredPercent = 0, runtimeOverridePercent = 0)
+        )
+    }
+
+    @Test
+    fun `apply script sets important root zoom`() {
+        val script = PageZoom.jsApplyScript(75)
+        assertTrue(script.contains("75%"))
+        assertTrue(script.contains("'important'"))
+        assertFalse(script.contains("removeProperty"))
+    }
+
+    @Test
+    fun `default percent clears applied root zoom`() {
+        val script = PageZoom.jsApplyScript(PageZoom.DEFAULT_PERCENT)
+        assertTrue(script.contains("removeProperty('zoom')"))
+        assertFalse(script.contains("setProperty"))
+    }
+}


### PR DESCRIPTION
Resolves #654

## What

Both follow-ups from #654 to the per-app zoom shipped in v2.4.0 (#404/#460):

1. **Browser-level page zoom.** The runtime override used to write `WebSettings.textZoom`, which rescales only glyphs — images, media and spacing never moved, which is exactly what #654 reported against the Open Chamber WebUI comparison. Zoom now applies **CSS `zoom` on the document element** (`PageZoom` helper), which reflows the whole page like Chrome/Edge page zoom. Chromium has shipped root zoom for years (down to old provider builds), so no version gate is needed.
   - Applied on every `onPageFinished` (the `:root` style dies with each document; re-application is idempotent and de-duplicated per WebView).
   - Toolbar zoom changes now hit the live DOM immediately (CSS zoom relayouts synchronously) — the old textZoom + full-reload dance is gone, which also preserves scroll/SPA state.
2. **Build-time initial zoom.** New `WebViewConfig.initialPageZoomPercent` (default `100`) flows the full export chain: editor card → `ApkConfig` → `ApkConfigJsonFactory` → `WebViewShellConfig` → `ShellWebViewConfig` → `WebViewManager`, resolved against the `PageZoomStore` runtime override (runtime override wins). A wrapped PWA can now ship with a zoom default and never touch the toolbar — which fullscreen mode hides (#654 part 1).

## Placement decision

The editor control lives in **Advanced Settings → Content Display**, directly under the pinch-zoom toggle — not in the toolbar-content section, because it is a rendering default rather than a toolbar-button toggle. Reuses the same `ZoomPresetsDialog` chrome stops as the runtime toolbar (50–150%, 100% stored concretely as the default). New strings cover all ten languages.

## Scope notes

- System WebView only, by construction: GeckoView never goes through `WebViewManager.configureWebView`'s WebSettings path and has no equivalent settings surface. Same practical scope as the v2.4.0 textZoom override.
- Known trade-off inherited from root-level CSS zoom: `position:fixed`/sticky elements can misalign on some sites at non-100% zoom; worth iterating with site reports.
- DESKTOP mode's `textZoom = 100` pin is untouched for non-zoom users; a resolved zoom ≠ 100 takes precedence as before.

## Testing

- New `PageZoomTest`: normalize clamping, resolve precedence (runtime override > build-time default > none), apply/clear script shapes.
- `initialPageZoomPercent` added to the `key non-Boolean WebViewConfig fields survive the export round-trip` spot-check — which caught a missing `WebApp.toApkConfig` mapping during development (the exact preview-works/export-broken class the coverage net exists for).
- `checkConfigFieldDrift` green; `:app:compileStandardDebugKotlin` clean; i18n consistency suites green; shell template rebuilt (`:shell:assembleRelease` + `syncShellTemplateApk`).