### PR TITLE
fix(editor): hide-toolbar first enable defaults every toolbar item off

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/viewmodel/EditState.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/EditState.kt
@@ -119,9 +119,10 @@ fun EditState.withRuntimePermissionsSyncedFromFeatures(): EditState {
  * Applies the "hide browser toolbar" toggle to a [WebViewConfig].
  *
  * Enabling the toggle for the first time enters a customized slim-toolbar mode: it
- * clears every toolbar-content flag and marks the toolbar as customized so the user
- * picks which items to show. Disabling the toggle returns to the normal full toolbar:
- * it restores every toolbar-content flag to `true` and clears the customized marker.
+ * clears EVERY toolbar-content flag (console and find included — #654 follow-up) and
+ * marks the toolbar as customized so the user picks which items to show from a
+ * uniformly-off slate. Disabling the toggle returns to the normal full toolbar: it
+ * restores every toolbar-content flag to `true` and clears the customized marker.
  *
  * The restore on disable is what keeps the "hide toolbar" toggle from leaving a
  * normal-mode app with every toolbar button hidden (a state where only the console
@@ -135,6 +136,8 @@ fun WebViewConfig.withHideBrowserToolbar(enabled: Boolean): WebViewConfig = when
         toolbarShowBack = false,
         toolbarShowForward = false,
         toolbarShowRefresh = false,
+        toolbarShowConsole = false,
+        toolbarShowFind = false,
         browserToolbarCustomized = true
     )
     !enabled -> copy(
@@ -144,6 +147,8 @@ fun WebViewConfig.withHideBrowserToolbar(enabled: Boolean): WebViewConfig = when
         toolbarShowBack = true,
         toolbarShowForward = true,
         toolbarShowRefresh = true,
+        toolbarShowConsole = true,
+        toolbarShowFind = true,
         browserToolbarCustomized = false
     )
     else -> copy(hideBrowserToolbar = enabled)

--- a/app/src/test/java/com/webtoapp/ui/viewmodel/HideBrowserToolbarToggleTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/viewmodel/HideBrowserToolbarToggleTest.kt
@@ -18,6 +18,9 @@ class HideBrowserToolbarToggleTest {
         assertThat(result.toolbarShowBack).isFalse()
         assertThat(result.toolbarShowForward).isFalse()
         assertThat(result.toolbarShowRefresh).isFalse()
+        // Console and find default OFF like every other item — no special-cased survivors.
+        assertThat(result.toolbarShowConsole).isFalse()
+        assertThat(result.toolbarShowFind).isFalse()
     }
 
     @Test
@@ -30,6 +33,8 @@ class HideBrowserToolbarToggleTest {
             toolbarShowBack = false,
             toolbarShowForward = false,
             toolbarShowRefresh = false,
+            toolbarShowConsole = false,
+            toolbarShowFind = false,
             browserToolbarCustomized = true
         )
         val result = config.withHideBrowserToolbar(false)
@@ -41,6 +46,8 @@ class HideBrowserToolbarToggleTest {
         assertThat(result.toolbarShowBack).isTrue()
         assertThat(result.toolbarShowForward).isTrue()
         assertThat(result.toolbarShowRefresh).isTrue()
+        assertThat(result.toolbarShowConsole).isTrue()
+        assertThat(result.toolbarShowFind).isTrue()
     }
 
     @Test


### PR DESCRIPTION
## Problem

Turning on **Hide Browser Toolbar** for the first time opened the *Toolbar Content* section with an asymmetric slate: the five navigation toggles defaulted OFF, but **Show Console Button** and **Show Find in Page Button** defaulted ON — leftovers of the old "console/zoom are toolbar items in their own right" special case. The user had to manually switch both off to get the expected clean start.

## Root cause

`WebViewConfig.withHideBrowserToolbar(true)` (first-enable branch) cleared only `toolbarShowTitle/Url/Back/Forward/Refresh`; `toolbarShowConsole` and `toolbarShowFind` kept their `true` defaults. The disable branch had the mirror-image gap: it restored only the five navigation flags, leaving console/find wherever they happened to be.

## Fix

- First enable: clear **all seven** toolbar-content flags and mark the toolbar customized — a uniformly-off slate; the user opts items in. With every flag off, `hasAnySlimToolbarItem` correctly hides the slim toolbar entirely.
- Disable: restore **all seven** flags to `true` so the switches match normal-mode behavior (where the flags are ignored and the full toolbar renders).

## Testing

- `HideBrowserToolbarToggleTest` extended: first-enable asserts console/find OFF; disable-test input now pollutes console/find too and asserts both restored to `true`.
- `ToolbarVisibilityTest` green (all-off slim toolbar hides entirely); `:app:compileStandardDebugKotlin` clean.

Host-only change (`ui/viewmodel` is outside the shell sync set) — no shell template impact.