### PR TITLE
fix(preview): find-in-page button ignored the slim toolbar config

### DIFF
--- a/app/src/main/java/com/webtoapp/data/model/ToolbarVisibility.kt
+++ b/app/src/main/java/com/webtoapp/data/model/ToolbarVisibility.kt
@@ -26,7 +26,9 @@ data class ToolbarButtonVisibility(
  * toolbar item in its own right: a toolbar customized down to only that button
  * must still render. Both the host preview and the exported shell gate the slim
  * toolbar on this predicate — keep them on the shared function so the two paths
- * cannot drift apart again.
+ * cannot drift apart again. The console/find flags have NO defaults on purpose:
+ * every caller must pass them explicitly, so a new flag can never be silently
+ * treated as "on" by one path and not the other.
  */
 fun hasAnySlimToolbarItem(
     toolbarShowTitle: Boolean,
@@ -35,13 +37,15 @@ fun hasAnySlimToolbarItem(
     toolbarShowForward: Boolean,
     toolbarShowRefresh: Boolean,
     toolbarShowConsole: Boolean,
-    toolbarShowFind: Boolean = true
+    toolbarShowFind: Boolean
 ): Boolean = toolbarShowTitle || toolbarShowUrl || toolbarShowBack || toolbarShowForward ||
     toolbarShowRefresh || toolbarShowConsole || toolbarShowFind
 
 /**
  * Resolves which toolbar buttons are visible given the hide-toggle state and the
  * customized toolbar content flags. See [ToolbarButtonVisibility] for the contract.
+ * The console/find flags have NO defaults on purpose — same anti-drift rule as
+ * [hasAnySlimToolbarItem].
  */
 fun resolveToolbarButtons(
     hideBrowserToolbar: Boolean,
@@ -51,8 +55,8 @@ fun resolveToolbarButtons(
     toolbarShowBack: Boolean,
     toolbarShowForward: Boolean,
     toolbarShowRefresh: Boolean,
-    toolbarShowConsole: Boolean = true,
-    toolbarShowFind: Boolean = true
+    toolbarShowConsole: Boolean,
+    toolbarShowFind: Boolean
 ): ToolbarButtonVisibility {
     val customizedSlim = hideBrowserToolbar && browserToolbarCustomized
     return ToolbarButtonVisibility(

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2803,6 +2803,10 @@ fun WebViewScreen(
     val showToolbarInPreview = !hideToolbar || webApp?.webViewConfig?.showToolbarInFullscreen == true
 
     val toolbarCfg = webApp?.webViewConfig
+    // Native find-in-page drives WebView.findAllAsync — system WebView only.
+    // Declared here (not inside the toolbar actions) so the slim-toolbar predicate
+    // below can discount the find item on non-system engines, mirroring the shell.
+    val findInPageSupported = (webApp?.apkExportConfig?.engineType ?: "SYSTEM_WEBVIEW") == "SYSTEM_WEBVIEW"
     val hasAnyToolbarItem = toolbarCfg?.let {
         hasAnySlimToolbarItem(
             toolbarShowTitle = it.toolbarShowTitle,
@@ -2810,7 +2814,8 @@ fun WebViewScreen(
             toolbarShowBack = it.toolbarShowBack,
             toolbarShowForward = it.toolbarShowForward,
             toolbarShowRefresh = it.toolbarShowRefresh,
-            toolbarShowConsole = it.toolbarShowConsole
+            toolbarShowConsole = it.toolbarShowConsole,
+            toolbarShowFind = it.toolbarShowFind && findInPageSupported
         )
     } == true
     val showSlimToolbar = hideBrowserToolbar && toolbarCfg?.browserToolbarCustomized == true && hasAnyToolbarItem
@@ -2827,7 +2832,8 @@ fun WebViewScreen(
             toolbarShowBack = it.toolbarShowBack,
             toolbarShowForward = it.toolbarShowForward,
             toolbarShowRefresh = it.toolbarShowRefresh,
-            toolbarShowConsole = it.toolbarShowConsole
+            toolbarShowConsole = it.toolbarShowConsole,
+            toolbarShowFind = it.toolbarShowFind
         )
     }
 
@@ -2919,7 +2925,6 @@ fun WebViewScreen(
                         }
                         // Find-in-page button: opens the native bottom find bar. System
                         // WebView only — findAllAsync has no GeckoView equivalent here.
-                        val findInPageSupported = (webApp?.apkExportConfig?.engineType ?: "SYSTEM_WEBVIEW") == "SYSTEM_WEBVIEW"
                         if ((isTestMode || browserToolbarVisibility?.showFind == true) && (isTestMode || findInPageSupported)) {
                             com.webtoapp.ui.design.WtaIconButton(
                                 onClick = { showFindBar = !showFindBar },

--- a/app/src/test/java/com/webtoapp/data/model/ToolbarVisibilityTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/ToolbarVisibilityTest.kt
@@ -17,7 +17,9 @@ class ToolbarVisibilityTest {
             toolbarShowUrl = false,
             toolbarShowBack = false,
             toolbarShowForward = false,
-            toolbarShowRefresh = false
+            toolbarShowRefresh = false,
+            toolbarShowConsole = true,
+            toolbarShowFind = true
         )
 
         assertThat(visibility.showTitle).isTrue()
@@ -37,7 +39,9 @@ class ToolbarVisibilityTest {
             toolbarShowUrl = false,
             toolbarShowBack = false,
             toolbarShowForward = true,
-            toolbarShowRefresh = false
+            toolbarShowRefresh = false,
+            toolbarShowConsole = true,
+            toolbarShowFind = true
         )
 
         assertThat(visibility.showTitle).isTrue()
@@ -59,7 +63,9 @@ class ToolbarVisibilityTest {
             toolbarShowUrl = false,
             toolbarShowBack = false,
             toolbarShowForward = false,
-            toolbarShowRefresh = false
+            toolbarShowRefresh = false,
+            toolbarShowConsole = true,
+            toolbarShowFind = true
         )
 
         assertThat(visibility.showTitle).isFalse()
@@ -80,7 +86,8 @@ class ToolbarVisibilityTest {
             toolbarShowBack = true,
             toolbarShowForward = true,
             toolbarShowRefresh = true,
-            toolbarShowConsole = false
+            toolbarShowConsole = false,
+            toolbarShowFind = true
         )
 
         assertThat(visibility.showConsoleButton).isFalse()
@@ -97,6 +104,7 @@ class ToolbarVisibilityTest {
             toolbarShowBack = true,
             toolbarShowForward = true,
             toolbarShowRefresh = true,
+            toolbarShowConsole = true,
             toolbarShowFind = false
         )
 
@@ -113,6 +121,7 @@ class ToolbarVisibilityTest {
             toolbarShowBack = false,
             toolbarShowForward = false,
             toolbarShowRefresh = false,
+            toolbarShowConsole = true,
             toolbarShowFind = false
         )
 
@@ -129,7 +138,8 @@ class ToolbarVisibilityTest {
             toolbarShowBack = false,
             toolbarShowForward = false,
             toolbarShowRefresh = false,
-            toolbarShowConsole = false
+            toolbarShowConsole = false,
+            toolbarShowFind = true
         )
 
         assertThat(visibility.showConsoleButton).isTrue()
@@ -146,7 +156,9 @@ class ToolbarVisibilityTest {
             toolbarShowUrl = false,
             toolbarShowBack = false,
             toolbarShowForward = false,
-            toolbarShowRefresh = false
+            toolbarShowRefresh = false,
+            toolbarShowConsole = true,
+            toolbarShowFind = true
         )
 
         assertThat(visibility.showTitle).isTrue()
@@ -166,7 +178,8 @@ class ToolbarVisibilityTest {
             toolbarShowBack = false,
             toolbarShowForward = false,
             toolbarShowRefresh = false,
-            toolbarShowConsole = true
+            toolbarShowConsole = true,
+            toolbarShowFind = false
         )
 
         assertThat(hasContent).isTrue()


### PR DESCRIPTION
## Problem

With **Hide Browser Toolbar** on and every *Toolbar Content* item switched off (find included), the preview still showed a top bar containing exactly one control: the find-in-page button.

## Root cause

Two gaps in the host preview path (`WebViewActivity`); the exported shell (`ShellScaffoldLayout`) was already correct, which is why the two paths disagreed:

1. The preview's `hasAnySlimToolbarItem(...)` and `resolveToolbarButtons(...)` calls did **not** pass `toolbarShowFind`. That parameter defaulted to `true`, so the slim-toolbar gate always saw "content" and `showFind` always evaluated true.
2. `findInPageSupported` was declared inside the toolbar-actions composable, so the slim predicate could not discount the find item on non-system engines like the shell does.

## Fix

- Pass `toolbarShowFind` in both preview call sites; hoist `findInPageSupported` next to `toolbarCfg` and mirror the shell's `toolbarShowFind && findInPageSupported` slim gating.
- **Structural fix against recurrence:** remove the `= true` defaults on `toolbarShowConsole` / `toolbarShowFind` from both shared functions in `ToolbarVisibility.kt`. Every caller must now pass them explicitly — the compiler rejects the exact omission that caused this bug.
- `ToolbarVisibilityTest` updated to pass every flag explicitly.

## Testing

- `ToolbarVisibilityTest` and `HideBrowserToolbarToggleTest` green; `:app:compileStandardDebugKotlin` clean.
- Manual scenario this fixes: hide-toolbar on + all items off → preview shows no top bar at all; find toggle on → only the find button appears.