### PR TITLE
fix(editor): toolbar card follows the standard card grammar

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2346,7 +2346,6 @@ object Strings {
     val statusBarLightModeLabel: String get() = StringsC.statusBarLightModeLabel
     val statusBarDarkModeLabel: String get() = StringsC.statusBarDarkModeLabel
     val browserToolbarLabel: String get() = StringsC.browserToolbarLabel
-    val browserToolbarHint: String get() = StringsC.browserToolbarHint
     val toolbarShowTitleLabel: String get() = StringsC.toolbarShowTitleLabel
     val toolbarShowTitleHint: String get() = StringsC.toolbarShowTitleHint
     val toolbarShowUrlLabel: String get() = StringsC.toolbarShowUrlLabel
@@ -34251,19 +34250,6 @@ object StringsC {
         AppLanguage.RUSSIAN -> "Панель инструментов"
         AppLanguage.JAPANESE -> "ツールバー"
         AppLanguage.KOREAN -> "도구 모음"
-    }
-
-    val browserToolbarHint: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "开启后显示浏览器工具栏，可单独开关各按钮；关闭时页面全屏显示"
-        AppLanguage.ENGLISH -> "Show the browser toolbar with per-button toggles. Off keeps the page fullscreen"
-        AppLanguage.ARABIC -> "يعرض شريط أدوات المتصفح مع مفاتيح لكل زر. عند الإيقاف تبقى الصفحة بملء الشاشة"
-        AppLanguage.PORTUGUESE -> "Mostra a barra de ferramentas do navegador com botões individuais. Desligada, a página fica em tela cheia"
-        AppLanguage.SPANISH -> "Muestra la barra de herramientas del navegador con botones individuales. Apagada, la página queda a pantalla completa"
-        AppLanguage.FRENCH -> "Affiche la barre d'outils du navigateur avec des boutons individuels. Désactivée, la page reste en plein écran"
-        AppLanguage.GERMAN -> "Zeigt die Browser-Symbolleiste mit einzelnen Schaltern. Aus bleibt die Seite Vollbild"
-        AppLanguage.RUSSIAN -> "Показывает панель инструментов браузера с отдельными кнопками. Выключено — страница во весь экран"
-        AppLanguage.JAPANESE -> "ブラウザツールバーを表示し、ボタンごとに切り替えられます。オフの場合はページが全画面表示になります"
-        AppLanguage.KOREAN -> "브라우저 도구 모음을 표시하고 버튼별로 켜고 끌 수 있습니다. 끄면 페이지가 전체 화면으로 표시됩니다"
     }
 
     val toolbarShowTitleLabel: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -2280,75 +2280,76 @@ fun BrowserToolbarCard(
         WtaToggleRow(
             icon = Icons.Outlined.WebAsset,
             title = Strings.browserToolbarLabel,
-            subtitle = Strings.browserToolbarHint,
             checked = enabled,
             onCheckedChange = onEnabledChange
         )
-        WtaSectionDivider()
-        WtaToggleRow(
-            title = Strings.toolbarShowTitleLabel,
-            subtitle = Strings.toolbarShowTitleHint,
-            checked = webViewConfig.toolbarShowTitle,
-            enabled = enabled,
-            onCheckedChange = {
-                onWebViewConfigChange(webViewConfig.copy(toolbarShowTitle = it))
+
+        AnimatedVisibility(
+            visible = enabled,
+            enter = CardExpandTransition,
+            exit = CardCollapseTransition
+        ) {
+            Column {
+                WtaSectionDivider()
+                WtaToggleRow(
+                    title = Strings.toolbarShowTitleLabel,
+                    subtitle = Strings.toolbarShowTitleHint,
+                    checked = webViewConfig.toolbarShowTitle,
+                    onCheckedChange = {
+                        onWebViewConfigChange(webViewConfig.copy(toolbarShowTitle = it))
+                    }
+                )
+                WtaSectionDivider()
+                WtaToggleRow(
+                    title = Strings.toolbarShowUrlLabel,
+                    subtitle = Strings.toolbarShowUrlHint,
+                    checked = webViewConfig.toolbarShowUrl,
+                    onCheckedChange = {
+                        onWebViewConfigChange(webViewConfig.copy(toolbarShowUrl = it))
+                    }
+                )
+                WtaSectionDivider()
+                WtaToggleRow(
+                    title = Strings.toolbarShowBackLabel,
+                    checked = webViewConfig.toolbarShowBack,
+                    onCheckedChange = {
+                        onWebViewConfigChange(webViewConfig.copy(toolbarShowBack = it))
+                    }
+                )
+                WtaSectionDivider()
+                WtaToggleRow(
+                    title = Strings.toolbarShowForwardLabel,
+                    checked = webViewConfig.toolbarShowForward,
+                    onCheckedChange = {
+                        onWebViewConfigChange(webViewConfig.copy(toolbarShowForward = it))
+                    }
+                )
+                WtaSectionDivider()
+                WtaToggleRow(
+                    title = Strings.toolbarShowRefreshLabel,
+                    checked = webViewConfig.toolbarShowRefresh,
+                    onCheckedChange = {
+                        onWebViewConfigChange(webViewConfig.copy(toolbarShowRefresh = it))
+                    }
+                )
+                WtaSectionDivider()
+                WtaToggleRow(
+                    title = Strings.toolbarShowConsoleLabel,
+                    checked = webViewConfig.toolbarShowConsole,
+                    onCheckedChange = {
+                        onWebViewConfigChange(webViewConfig.copy(toolbarShowConsole = it))
+                    }
+                )
+                WtaSectionDivider()
+                WtaToggleRow(
+                    title = Strings.toolbarShowFindLabel,
+                    checked = webViewConfig.toolbarShowFind,
+                    onCheckedChange = {
+                        onWebViewConfigChange(webViewConfig.copy(toolbarShowFind = it))
+                    }
+                )
             }
-        )
-        WtaSectionDivider()
-        WtaToggleRow(
-            title = Strings.toolbarShowUrlLabel,
-            subtitle = Strings.toolbarShowUrlHint,
-            checked = webViewConfig.toolbarShowUrl,
-            enabled = enabled,
-            onCheckedChange = {
-                onWebViewConfigChange(webViewConfig.copy(toolbarShowUrl = it))
-            }
-        )
-        WtaSectionDivider()
-        WtaToggleRow(
-            title = Strings.toolbarShowBackLabel,
-            checked = webViewConfig.toolbarShowBack,
-            enabled = enabled,
-            onCheckedChange = {
-                onWebViewConfigChange(webViewConfig.copy(toolbarShowBack = it))
-            }
-        )
-        WtaSectionDivider()
-        WtaToggleRow(
-            title = Strings.toolbarShowForwardLabel,
-            checked = webViewConfig.toolbarShowForward,
-            enabled = enabled,
-            onCheckedChange = {
-                onWebViewConfigChange(webViewConfig.copy(toolbarShowForward = it))
-            }
-        )
-        WtaSectionDivider()
-        WtaToggleRow(
-            title = Strings.toolbarShowRefreshLabel,
-            checked = webViewConfig.toolbarShowRefresh,
-            enabled = enabled,
-            onCheckedChange = {
-                onWebViewConfigChange(webViewConfig.copy(toolbarShowRefresh = it))
-            }
-        )
-        WtaSectionDivider()
-        WtaToggleRow(
-            title = Strings.toolbarShowConsoleLabel,
-            checked = webViewConfig.toolbarShowConsole,
-            enabled = enabled,
-            onCheckedChange = {
-                onWebViewConfigChange(webViewConfig.copy(toolbarShowConsole = it))
-            }
-        )
-        WtaSectionDivider()
-        WtaToggleRow(
-            title = Strings.toolbarShowFindLabel,
-            checked = webViewConfig.toolbarShowFind,
-            enabled = enabled,
-            onCheckedChange = {
-                onWebViewConfigChange(webViewConfig.copy(toolbarShowFind = it))
-            }
-        )
+        }
     }
 }
 


### PR DESCRIPTION
Follow-up to #666. The new Toolbar card broke two card-grammar rules that every other toggle-headed card (reference: `FullscreenModeCard`) follows:

1. The header row carried a long subtitle — headers are icon + title only.
2. The seven item rows were always visible; sub-content must sit behind `AnimatedVisibility(visible = enabled)` with the shared `CardExpandTransition` / `CardCollapseTransition` — collapsed when the master is off, expanded when on.

Both corrected; the per-item enable-disabling hack is gone (rows simply don't render while the toolbar is off). Unused `browserToolbarHint` string removed. Behavior (master flips all flags, per-item trimming while on) unchanged from #666.