### PR TITLE
fix(editor): app name field matches the URL field's outlined style

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/components/AppNameTextField.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/AppNameTextField.kt
@@ -14,8 +14,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import com.webtoapp.core.i18n.RandomAppNameGenerator
 import com.webtoapp.core.i18n.Strings
-import com.webtoapp.ui.design.WtaTextField
 
+/**
+ * App-name input styled as an outlined field so it matches the website-URL field
+ * on the same screen (floating label on the stroke, same corner radius).
+ */
 @Composable
 fun AppNameTextField(
     value: String,
@@ -24,13 +27,13 @@ fun AppNameTextField(
     placeholder: String? = null,
     imeAction: ImeAction = ImeAction.Next
 ) {
-    WtaTextField(
+    PremiumTextField(
         value = value,
         onValueChange = onValueChange,
         modifier = modifier.fillMaxWidth(),
-        label = Strings.labelAppName,
-        placeholder = placeholder ?: Strings.inputAppName,
-        leadingIcon = Icons.Outlined.Badge,
+        label = { Text(Strings.labelAppName) },
+        placeholder = { Text(placeholder ?: Strings.inputAppName) },
+        leadingIcon = { Icon(Icons.Outlined.Badge, null) },
         trailingIcon = {
             IconButton(
                 onClick = { onValueChange(RandomAppNameGenerator.generate()) }
@@ -54,12 +57,13 @@ fun AppNameTextFieldSimple(
     modifier: Modifier = Modifier,
     placeholder: String? = null
 ) {
-    WtaTextField(
+    PremiumTextField(
         value = value,
         onValueChange = onValueChange,
         modifier = modifier.fillMaxWidth(),
-        label = Strings.labelAppName,
-        placeholder = placeholder ?: Strings.inputAppName,
+        label = { Text(Strings.labelAppName) },
+        placeholder = { Text(placeholder ?: Strings.inputAppName) },
+        leadingIcon = { Icon(Icons.Outlined.Badge, null) },
         trailingIcon = {
             IconButton(
                 onClick = { onValueChange(RandomAppNameGenerator.generate()) }


### PR DESCRIPTION
Closes #668

## What changed

`AppNameTextField` / `AppNameTextFieldSimple` now render through `PremiumTextField` (outlined) instead of `WtaTextField` (filled), so the app-name input matches the website-URL input sitting next to it:

- Same stroke border and symmetric `WtaRadius.Control` corners (the old filled style had 10dp top / 4dp bottom asymmetric corners)
- Same floating label on the border gap (the old style kept the label inside the box)
- Same leading-icon sizing as the URL field's `Icon(Icons.Outlined.Link, null)` call — the new leading icon uses the same default-size pattern
- Trailing random-name dice button kept as-is
- `AppNameTextFieldSimple` also gains the leading `Badge` icon, so all six app-name call sites (web / media / gallery / frontend / HTML / app modifier) now look identical

Component API adaptation: `WtaTextField` takes `label`/`placeholder` as `String?` and `leadingIcon` as `ImageVector`; `PremiumTextField` takes composable lambdas, so the strings are wrapped in `{ Text(...) }` and the icon in `{ Icon(Icons.Outlined.Badge, null) }`.

## Why this is safe

- Host-only file: `AppNameTextField.kt` is not in the `syncShellRuntimeSources` whitelist, so no shell template rebuild and no export-path impact.
- Public signatures of both composables are unchanged; all six call sites compile untouched.

## Verification

- `./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache` — BUILD SUCCESSFUL
- Emulator check: app-name field now shares the URL field's outlined grammar (border, radius, floating label, icon size) on the create-app screen