### PR TITLE
docs: qualify :app Gradle tasks with the standard flavor

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -91,9 +91,9 @@ both `:app` and `:shell` to compile.
 Run the checks before submitting:
 
 ```bash
-./gradlew :app:compileDebugKotlin
+./gradlew :app:compileStandardDebugKotlin
 ./gradlew :shell:compileDebugKotlin
-./gradlew :app:testDebugUnitTest
+./gradlew :app:testStandardDebugUnitTest
 ```
 
 > Native code (`node_launcher`, `go_exec_loader`, the APK optimizer) builds
@@ -187,7 +187,7 @@ an hour as authoritative; the refresh button always bypasses the cache.
 - Branch from `main`. Keep PRs focused — one logical change per PR.
 - Describe the user-visible effect in the PR body, not just the code change.
 - If your PR touches the build system, native code, or APK packaging, attach
-  the output of `./gradlew :app:assembleDebug` (or note the failure if it
+  the output of `./gradlew :app:assembleStandardDebug` (or note the failure if it
   fails on your machine).
 - CI runs on every PR. A green CI is required before merge.
 
@@ -288,9 +288,9 @@ cd web-to-app
 提交前请跑通：
 
 ```bash
-./gradlew :app:compileDebugKotlin
+./gradlew :app:compileStandardDebugKotlin
 ./gradlew :shell:compileDebugKotlin
-./gradlew :app:testDebugUnitTest
+./gradlew :app:testStandardDebugUnitTest
 ```
 
 > 原生代码（`node_launcher`、`go_exec_loader`、APK 优化器）按 ABI 经 CMake
@@ -358,7 +358,7 @@ cd web-to-app
 
 - 从 `main` 分出分支，每个 PR 只解决一件事
 - PR 描述写"用户看得到的效果"，不只是代码 diff
-- 改动涉及构建系统、原生代码或 APK 打包时，附上 `./gradlew :app:assembleDebug`
+- 改动涉及构建系统、原生代码或 APK 打包时，附上 `./gradlew :app:assembleStandardDebug`
   的结果
 - CI 必须绿色才会合并
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,7 +318,7 @@ The editor screens have an established card language. **Find the neighboring car
 
 ```bash
 ./gradlew :shell:assembleRelease :app:syncShellTemplateApk --no-configuration-cache
-./gradlew :app:compileDebugKotlin -x syncCloneHostDex --no-configuration-cache
+./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache
 ./gradlew :app:checkConfigFieldDrift --no-configuration-cache
 python3 scripts/check_config_field_drift.py
 ```

--- a/docs/developer/recipes.md
+++ b/docs/developer/recipes.md
@@ -68,7 +68,7 @@ See [Config Field Drift](/developer/config-drift).
 
 ```bash
 ./gradlew :shell:assembleRelease :app:syncShellTemplateApk --no-configuration-cache
-./gradlew :app:compileDebugKotlin -x syncCloneHostDex --no-configuration-cache
+./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache
 ./gradlew :app:checkConfigFieldDrift --no-configuration-cache
 python3 scripts/check_config_field_drift.py
 ```

--- a/docs/zh/developer/recipes.md
+++ b/docs/zh/developer/recipes.md
@@ -68,7 +68,7 @@
 
 ```bash
 ./gradlew :shell:assembleRelease :app:syncShellTemplateApk --no-configuration-cache
-./gradlew :app:compileDebugKotlin -x syncCloneHostDex --no-configuration-cache
+./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache
 ./gradlew :app:checkConfigFieldDrift --no-configuration-cache
 python3 scripts/check_config_field_drift.py
 ```


### PR DESCRIPTION
Closes #669

## What changed

The repo ships two product flavors (`standard` / `gplay`), so bare `Debug` variant task names on `:app` are ambiguous and Gradle fails outright:

```
Cannot locate tasks that match ':app:compileDebugKotlin' as task 'compileDebugKotlin' is ambiguous in project ':app'.
```

CI already runs Standard-qualified names; this aligns the docs with it (10 occurrences across 4 files):

| File | Fix |
|---|---|
| `AGENTS.md` | `:app:compileDebugKotlin` → `:app:compileStandardDebugKotlin` |
| `docs/developer/recipes.md` | same |
| `docs/zh/developer/recipes.md` | same |
| `.github/CONTRIBUTING.md` | `compileStandardDebugKotlin` ×2, `testStandardDebugUnitTest` ×2, `assembleStandardDebug` ×2 (EN + ZH sections) |

## Explicitly not changed

- `.github/workflows/android-ci.yml` — already correct
- `:shell:compileDebugKotlin` — the `shell` module has no flavors; the task name is unique
- `:app:checkConfigFieldDrift` / `:app:syncShellTemplateApk` — custom tasks without variant suffixes
- Historical session notes under `.zcode/`

## Verification

- Full-repo grep over tracked `*.md`/`*.yml`/`*.kts`/`*.py`: zero remaining flavor-ambiguous `:app` task references
- `./gradlew :app:tasks --all` confirms `testStandardDebugUnitTest` exists
- `./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache` — BUILD SUCCESSFUL