### PR TITLE
Docs: black action buttons instead of brand blue

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -2,6 +2,7 @@
  * WebToApp brand theme.
  * Accent is a confident blue that reads well in both light and dark mode.
  * deliberately flat: no hero glow, no gradient text — plain color only.
+ * Buttons stay black in both themes: dark background, light text.
  */
 :root {
   --vp-c-brand-1: #2563eb;
@@ -23,4 +24,22 @@
   --vp-home-hero-name-color: var(--vp-c-brand-1);
   --vp-home-hero-image-background-image: none;
   --vp-home-hero-image-filter: none;
+}
+
+/* Buttons: black in light and dark mode instead of the blue accent. */
+:root,
+.dark {
+  --vp-button-brand-bg: #171717;
+  --vp-button-brand-hover-bg: #262626;
+  --vp-button-brand-active-bg: #262626;
+  --vp-button-brand-text: #ffffff;
+  --vp-button-brand-hover-text: #ffffff;
+  --vp-button-brand-active-text: #ffffff;
+
+  --vp-button-alt-bg: #2b2b2b;
+  --vp-button-alt-hover-bg: #383838;
+  --vp-button-alt-active-bg: #383838;
+  --vp-button-alt-text: #ffffff;
+  --vp-button-alt-hover-text: #ffffff;
+  --vp-button-alt-active-text: #ffffff;
 }


### PR DESCRIPTION
Closes #677.

## What
Override the VitePress button custom properties in `docs/.vitepress/theme/custom.css` so the homepage hero action buttons (`theme: brand` and `theme: alt`) render in neutral black instead of the blue brand accent, identically in light and dark mode:

- brand: `#171717` bg, `#262626` hover/active, white text
- alt: `#2b2b2b` bg, `#383838` hover/active, white text

The overrides live under a combined `:root, .dark` selector, so no separate dark-mode rules are needed. The blue accent is untouched everywhere else (links, hero title), continuing the flat monochrome direction from #676.

## Verification
- `npx vitepress build` passes; compiled CSS in `dist/assets` contains the new `--vp-button-*` values.
- Headless-Chrome screenshots of the built site (light + dark via `--force-dark-mode --blink-settings=preferredColorScheme=2`) confirm black buttons with white text in both themes on EN and ZH homepages.