### PR TITLE
docs(home): enrich homepage with steps, app-type and toolbox grids, stats + CTA

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -43,3 +43,219 @@
   --vp-button-alt-hover-text: #ffffff;
   --vp-button-alt-active-text: #ffffff;
 }
+
+/*
+ * Homepage content below the features grid. The markdown lives inside
+ * VPHomeContent's 1280px container; .wta-home narrows to 1152px so the
+ * custom sections line up with the features grid above.
+ */
+.wta-home {
+  max-width: 1152px;
+  margin: 0 auto;
+  padding: 8px 0 48px;
+}
+
+.wta-home h2 {
+  margin-top: 56px;
+  margin-bottom: 20px;
+  padding-top: 0;
+  border-top: none;
+  font-size: 28px;
+}
+
+/* Three-step getting started: numbered cards in a responsive row. */
+.wta-steps {
+  counter-reset: wta-step;
+}
+
+.wta-steps ol {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (max-width: 959px) {
+  .wta-steps ol {
+    grid-template-columns: 1fr;
+  }
+}
+
+.wta-steps li {
+  counter-increment: wta-step;
+  position: relative;
+  padding: 20px 20px 16px 62px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background-color: var(--vp-c-bg-soft);
+}
+
+.wta-steps li::before {
+  content: counter(wta-step);
+  position: absolute;
+  left: 18px;
+  top: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background-color: #171717;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.dark .wta-steps li::before {
+  background-color: #2e2e2e;
+}
+
+.wta-steps li p {
+  margin: 0 0 8px;
+}
+
+.wta-steps li p:last-child {
+  margin-bottom: 0;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+}
+
+.wta-steps li a {
+  font-weight: 500;
+  text-decoration: none;
+}
+
+/* Tile grids: app types and toolbox, mirroring the features card language. */
+.wta-types {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+@media (max-width: 959px) {
+  .wta-types {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 639px) {
+  .wta-types {
+    grid-template-columns: 1fr;
+  }
+}
+
+.wta-types > div {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background-color: var(--vp-c-bg-soft);
+  padding: 16px 20px;
+  transition: border-color 0.25s, background-color 0.25s;
+}
+
+.wta-types > div:hover {
+  border-color: var(--vp-c-text-1);
+}
+
+.wta-types p {
+  margin: 0;
+  padding: 4px 0;
+  line-height: 1.7;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+}
+
+.wta-types p > a {
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.25s;
+}
+
+.wta-types p > a:hover {
+  color: var(--vp-c-brand-1);
+}
+
+/* Stat strip: number + label pairs in a flat row. */
+.wta-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+@media (max-width: 767px) {
+  .wta-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.wta-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 12px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background-color: var(--vp-c-bg-soft);
+}
+
+.wta-stat b {
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--vp-c-text-1);
+}
+
+.wta-stat span {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+}
+
+/* Closing call-to-action. */
+.wta-cta {
+  margin-top: 56px;
+  padding: 32px 24px;
+  text-align: center;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background-color: var(--vp-c-bg-soft);
+}
+
+.wta-cta p {
+  margin: 0 0 16px;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.wta-cta a {
+  display: inline-block;
+  padding: 6px 20px;
+  border-radius: 20px;
+  background-color: #171717;
+  color: #ffffff !important;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.25s;
+}
+
+.wta-cta a:hover {
+  background-color: #262626;
+}
+
+.dark .wta-cta a {
+  background-color: #2e2e2e;
+}
+
+.dark .wta-cta a:hover {
+  background-color: #3a3a3a;
+}
+
+/* Feature cards: calmer hover that matches the flat look. */
+.VPFeature.link:hover {
+  border-color: var(--vp-c-text-1);
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,3 +39,157 @@ features:
     title: 10 UI languages
     details: Chinese, English, Arabic (RTL), Portuguese, Spanish, French, German, Russian, Japanese, and Korean — switch anytime in Settings.
 ---
+
+<div class="wta-home">
+
+## From URL to a signed APK in three steps
+
+<div class="wta-steps">
+
+1. **Pick a type**
+
+   Choose from [12 app types](/guide/app-types/) — a plain [Web](/guide/app-types/web) wrapper, [HTML](/guide/app-types/html) or [Frontend](/guide/app-types/frontend) builds, or on-device [Node.js](/guide/app-types/nodejs), [PHP](/guide/app-types/php), [Python](/guide/app-types/python), [Go](/guide/app-types/go), [WordPress](/guide/app-types/wordpress) servers.
+
+2. **Fill in the basics**
+
+   A name, a URL or a project, an icon — then save. Every type shares the same [configuration cards](/guide/config/) for network, privacy, appearance, and runtimes.
+
+3. **Build and share**
+
+   [Build APK](/guide/app-actions/build-apk) signs on-device with V1/V2/V3, then [share](/guide/app-actions/share-apk) it or [export a Play-ready AAB](/guide/app-actions/export-apk). No PC, no build queue.
+
+</div>
+
+## Twelve app types, one builder
+
+<div class="wta-types">
+
+<div class="wta-tile">
+
+[**Web and Multi-Web**](/guide/app-types/multi-web)
+
+URL wrappers, tabbed hubs, portals, and link feeds.
+
+</div>
+
+<div class="wta-tile">
+
+[**HTML and Offline Pack**](/guide/app-types/html)
+
+Package local HTML or zip builds, or scrape a site into a self-contained offline APK.
+
+</div>
+
+<div class="wta-tile">
+
+[**Frontend**](/guide/app-types/frontend)
+
+Ship React, Vue, or Vite builds as a localhost-served APK.
+
+</div>
+
+<div class="wta-tile">
+
+[**Server runtimes**](/guide/app-types/nodejs)
+
+fork+exec Node.js, PHP, Python, or Go binaries that serve on a local port.
+
+</div>
+
+<div class="wta-tile">
+
+[**WordPress**](/guide/app-types/wordpress)
+
+A full portable WordPress site with PHP and SQLite running on-device.
+
+</div>
+
+<div class="wta-tile">
+
+[**Media and Gallery**](/guide/app-types/media)
+
+Image and video players, albums, and portfolios as standalone apps.
+
+</div>
+
+</div>
+
+## A toolbox behind the editor
+
+<div class="wta-types">
+
+<div class="wta-tile">
+
+[**Agent**](/guide/more-features/agent)
+
+A tool-calling assistant with 57 built-in tools that can build, edit, and operate the whole app.
+
+</div>
+
+<div class="wta-tile">
+
+[**Extension modules**](/guide/more-features/extension-modules)
+
+Inject JS/CSS, userscripts, or MV3 Chrome extensions into any generated app.
+
+</div>
+
+<div class="wta-tile">
+
+[**Hosts ad-block**](/guide/more-features/hosts-adblock)
+
+20 built-in filter lists and per-app subscriptions, compiled into the shipped APK.
+
+</div>
+
+<div class="wta-tile">
+
+[**Linux environment**](/guide/more-features/linux-environment)
+
+A Termux-style environment with real toolchains for building and running projects.
+
+</div>
+
+<div class="wta-tile">
+
+[**Port manager**](/guide/more-features/port-manager)
+
+Conflict policies, real stop handlers, and DNS bridging for every local server runtime.
+
+</div>
+
+<div class="wta-tile">
+
+[**App modifier**](/guide/more-features/app-modifier)
+
+Clone and rebrand installed APKs, batch-import definitions, export templates.
+
+</div>
+
+</div>
+
+## Under the hood
+
+<div class="wta-stats">
+
+<div class="wta-stat"><b>12</b><span>app types</span></div>
+
+<div class="wta-stat"><b>57</b><span>agent tools</span></div>
+
+<div class="wta-stat"><b>10</b><span>UI languages</span></div>
+
+<div class="wta-stat"><b>20</b><span>ad-filter lists</span></div>
+
+</div>
+
+The builder does its own binary patching — AXML/ARSC rewriting, permission pruning, AES-256-GCM resource encryption, 16 KB page-aligned native libraries — and keeps a low targetSdk shell so fork+exec runtimes keep working. The [developer docs](/developer/architecture) cover the full export pipeline.
+
+<div class="wta-cta">
+
+Ready to build your first APK?
+
+[Get started](/guide/getting-started)
+
+</div>
+
+</div>

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -39,3 +39,157 @@ features:
     title: 10 种界面语言
     details: 中文、英文、阿拉伯文(RTL)、葡萄牙文、西班牙文、法文、德文、俄文、日文、韩文 —— 在设置中随时切换。
 ---
+
+<div class="wta-home">
+
+## 从 URL 到签名 APK,只需三步
+
+<div class="wta-steps">
+
+1. **选择类型**
+
+   从 [12 种应用类型](/zh/guide/app-types/)里选 —— 普通的 [Web](/zh/guide/app-types/web) 封装、[HTML](/zh/guide/app-types/html) 或 [Frontend](/zh/guide/app-types/frontend) 构建,或是设备端运行的 [Node.js](/zh/guide/app-types/nodejs)、[PHP](/zh/guide/app-types/php)、[Python](/zh/guide/app-types/python)、[Go](/zh/guide/app-types/go)、[WordPress](/zh/guide/app-types/wordpress) 服务器。
+
+2. **填写基本信息**
+
+   名称、URL 或项目、图标 —— 保存即可。所有类型共享同一套[配置卡片](/zh/guide/config/):网络、隐私、外观、运行时。
+
+3. **构建并分享**
+
+   [构建 APK](/zh/guide/app-actions/build-apk) 用 V1/V2/V3 在设备上完成签名,再[分享](/zh/guide/app-actions/share-apk)出去或[导出 Play 级 AAB](/zh/guide/app-actions/export-apk)。无需电脑,没有构建队列。
+
+</div>
+
+## 十二种类型,一个构建器
+
+<div class="wta-types">
+
+<div class="wta-tile">
+
+[**Web 与 Multi-Web**](/zh/guide/app-types/multi-web)
+
+URL 封装、多标签页枢纽、门户与链接流。
+
+</div>
+
+<div class="wta-tile">
+
+[**HTML 与离线包**](/zh/guide/app-types/html)
+
+打包本地 HTML 或 zip 构建,或抓取整站生成自包含的离线 APK。
+
+</div>
+
+<div class="wta-tile">
+
+[**Frontend**](/zh/guide/app-types/frontend)
+
+把 React、Vue、Vite 构建产物发布成 localhost 服务的 APK。
+
+</div>
+
+<div class="wta-tile">
+
+[**服务端运行时**](/zh/guide/app-types/nodejs)
+
+fork+exec Node.js、PHP、Python、Go 原生二进制,在本地端口提供服务。
+
+</div>
+
+<div class="wta-tile">
+
+[**WordPress**](/zh/guide/app-types/wordpress)
+
+完整的便携 WordPress 站点,PHP 与 SQLite 都跑在设备上。
+
+</div>
+
+<div class="wta-tile">
+
+[**媒体与相册**](/zh/guide/app-types/media)
+
+图片和视频播放器、相册集、作品集,打包成独立应用。
+
+</div>
+
+</div>
+
+## 编辑器背后的工具箱
+
+<div class="wta-types">
+
+<div class="wta-tile">
+
+[**Agent**](/zh/guide/more-features/agent)
+
+内置 57 个工具的调用式助手,可以构建、编辑、操作整个应用。
+
+</div>
+
+<div class="wta-tile">
+
+[**扩展模块**](/zh/guide/more-features/extension-modules)
+
+向任何生成的应用注入 JS/CSS、油猴脚本或 MV3 Chrome 扩展。
+
+</div>
+
+<div class="wta-tile">
+
+[**Hosts 去广告**](/zh/guide/more-features/hosts-adblock)
+
+内置 20 个过滤列表和按应用的订阅规则,编译进导出的 APK。
+
+</div>
+
+<div class="wta-tile">
+
+[**Linux 环境**](/zh/guide/more-features/linux-environment)
+
+Termux 风格的设备端环境,带有构建和运行项目所需的真实工具链。
+
+</div>
+
+<div class="wta-tile">
+
+[**端口管理**](/zh/guide/more-features/port-manager)
+
+冲突策略、真实停止处理器,以及所有本地服务运行时的 DNS 桥接。
+
+</div>
+
+<div class="wta-tile">
+
+[**应用修改器**](/zh/guide/more-features/app-modifier)
+
+克隆和重打包已安装的 APK、批量导入定义、导出模板。
+
+</div>
+
+</div>
+
+## 深入底层
+
+<div class="wta-stats">
+
+<div class="wta-stat"><b>12</b><span>种应用类型</span></div>
+
+<div class="wta-stat"><b>57</b><span>个 Agent 工具</span></div>
+
+<div class="wta-stat"><b>10</b><span>种界面语言</span></div>
+
+<div class="wta-stat"><b>20</b><span>个去广告列表</span></div>
+
+</div>
+
+构建器自己做二进制手术 —— AXML/ARSC 重写、权限裁剪、AES-256-GCM 资源加密、16 KB 页对齐的原生库 —— 并让 shell 保持低 targetSdk,使 fork+exec 运行时持续可用。[开发者文档](/zh/developer/architecture)覆盖了完整的导出管线。
+
+<div class="wta-cta">
+
+准备好构建你的第一个 APK 了吗?
+
+[快速开始](/zh/guide/getting-started)
+
+</div>
+
+</div>


### PR DESCRIPTION
Closes #679

## What

Extend both the EN and ZH docs-site homepages beyond the hero + six feature cards with four new sections, plus the layout styles to render them.

## Sections added

1. **Three steps** — numbered 3-card row (pick a type → fill in the basics → build and share), each card linking into the relevant app-types / app-actions guide pages.
2. **Twelve app types** — tile grid grouping all 12 `AppType` values into 6 linked tiles: Web & Multi-Web, HTML & Offline Pack, Frontend, Server runtimes (Node/PHP/Python/Go), WordPress, Media & Gallery.
3. **Toolbox** — second tile grid: Agent, Extension modules, Hosts ad-block, Linux environment, Port manager, App modifier.
4. **Under the hood + CTA** — 4-stat strip (12 app types · 57 agent tools · 10 UI languages · 20 ad-filter lists), a paragraph on AXML/ARSC patching, AES-256-GCM, 16KB alignment and low targetSdk linking to the architecture doc, and a closing call-to-action to Getting Started.

## Styling

`custom.css` gains layout classes that reuse the VitePress feature-card grammar (1px `--vp-c-divider` border, 12px radius, `--vp-c-bg-soft` fill) so the new sections blend with the existing features grid:

- CSS-counter numbered step cards (black circle badge, matching the #678 button black).
- 3-column tile grids (→ 2 col ≤959px, → 1 col ≤639px) with border-color hover.
- 4-column stat strip (→ 2 col ≤767px).
- Centered CTA band reusing the black pill button.
- Feature cards' hover switched from brand color to plain text color for the flat/monochrome direction of #675/#677.

EN and ZH content mirror 1:1; all internal link targets verified to exist.

## Verification

- `npx vitepress build` passes.
- Light + dark screenshots of both `/` and `/zh/` at 1280px checked, including section-level crops of the new grids.