### PR TITLE
Docs: add latest-release download button to hero and getting-started

### DIFF
--- a/docs/.vitepress/theme/CustomLayout.vue
+++ b/docs/.vitepress/theme/CustomLayout.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import DefaultTheme from 'vitepress/theme'
+import { useData } from 'vitepress'
+import LatestRelease from './LatestRelease.vue'
+
+const { Layout } = DefaultTheme
+const { frontmatter } = useData()
+</script>
+
+<template>
+  <Layout>
+    <template #home-hero-actions-after>
+      <LatestRelease v-if="frontmatter.layout === 'home' && frontmatter.hero" />
+    </template>
+  </Layout>
+</template>

--- a/docs/.vitepress/theme/LatestRelease.vue
+++ b/docs/.vitepress/theme/LatestRelease.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useData } from 'vitepress'
+
+const REPO = 'shiaho777/web-to-app'
+const RELEASES_PAGE = `https://github.com/${REPO}/releases`
+
+const { lang } = useData()
+const isZh = computed(() => lang.value.startsWith('zh'))
+
+// Fallback target until the API resolves (or if it fails): the releases page.
+const href = ref(RELEASES_PAGE)
+const tag = ref('')
+const detected = ref(false)
+
+onMounted(async () => {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+      headers: { Accept: 'application/vnd.github+json' }
+    })
+    if (!res.ok) return
+    const release: any = await res.json()
+    const asset = (release.assets ?? []).find((a: any) =>
+      typeof a.name === 'string' && a.name.toLowerCase().endsWith('.apk')
+    )
+    href.value = asset?.browser_download_url || release.html_url || RELEASES_PAGE
+    tag.value = release.tag_name ?? ''
+    detected.value = true
+  } catch {
+    // Rate-limited or offline: keep the releases-page fallback.
+  }
+})
+
+const buttonLabel = computed(() =>
+  tag.value
+    ? `${isZh.value ? '下载' : 'Download'} ${tag.value}`
+    : isZh.value
+      ? '下载最新版 APK'
+      : 'Download latest APK'
+)
+
+const metaLabel = computed(() =>
+  detected.value
+    ? isZh.value
+      ? '版本号自动检测自 GitHub Releases'
+      : 'Version auto-detected from GitHub Releases'
+    : ''
+)
+</script>
+
+<template>
+  <div class="wta-release">
+    <a class="wta-release-btn" :href="href" target="_blank" rel="noreferrer">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M12 3v12" />
+        <path d="m7 10 5 5 5-5" />
+        <path d="M4 21h16" />
+      </svg>
+      <span>{{ buttonLabel }}</span>
+    </a>
+    <span v-if="metaLabel" class="wta-release-meta">{{ metaLabel }}</span>
+  </div>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -259,3 +259,83 @@
 .VPFeature.link:hover {
   border-color: var(--vp-c-text-1);
 }
+
+/*
+ * Hero download button, rendered through the home-hero-actions-after slot.
+ * Shares the black-pill grammar of the brand buttons above.
+ */
+.wta-release {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px 12px;
+  margin-top: 20px;
+}
+
+.wta-release-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 20px;
+  line-height: 38px;
+  border: 1px solid transparent;
+  border-radius: 20px;
+  background-color: #171717;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: background-color 0.25s;
+}
+
+.wta-release-btn:hover {
+  background-color: #262626;
+}
+
+.dark .wta-release-btn {
+  background-color: #2e2e2e;
+}
+
+.dark .wta-release-btn:hover {
+  background-color: #3a3a3a;
+}
+
+.wta-release-btn svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.wta-release-meta {
+  font-size: 12px;
+  color: var(--vp-c-text-3);
+}
+
+/* Install-download block for guide pages. */
+.wta-install {
+  margin: 16px 0;
+  padding: 20px 24px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background-color: var(--vp-c-bg-soft);
+}
+
+.wta-install p {
+  margin: 0 0 12px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.wta-install p:last-child {
+  margin-bottom: 0;
+  font-weight: 400;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+}
+
+.wta-install .wta-release {
+  justify-content: flex-start;
+  margin-top: 4px;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,7 +1,13 @@
 import DefaultTheme from 'vitepress/theme'
 import type { Theme } from 'vitepress'
+import LatestRelease from './LatestRelease.vue'
+import CustomLayout from './CustomLayout.vue'
 import './custom.css'
 
 export default {
-  extends: DefaultTheme
+  extends: DefaultTheme,
+  Layout: CustomLayout,
+  enhanceApp({ app }) {
+    app.component('LatestRelease', LatestRelease)
+  }
 } satisfies Theme

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -6,6 +6,16 @@ This walkthrough takes you from a fresh install to your first signed APK. At eac
 
 Install the WebToApp builder on a device running **Android 6.0 (API 23) or newer**.
 
+<div class="wta-install">
+
+**Download the builder**
+
+<LatestRelease variant="install" />
+
+Get the APK from [GitHub Releases](https://github.com/shiaho777/web-to-app/releases) and install it like any other APK. The button auto-detects the newest version.
+
+</div>
+
 On launch, `WebToAppApplication` starts in **builder mode** (`SHELL_RUNTIME_ONLY = false`): it initializes the i18n strings, the Room database, and the dependency graph, then shows **My Apps** — the home screen that lists every app you create. See [Main Screen](/guide/main-screen/my-apps).
 
 ## 2. Create an app definition

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -6,6 +6,16 @@
 
 在运行 **Android 6.0(API 23)或更高版本** 的设备上安装 WebToApp 构建器。
 
+<div class="wta-install">
+
+**下载构建器**
+
+<LatestRelease variant="install" />
+
+从 [GitHub Releases](https://github.com/shiaho777/web-to-app/releases) 获取 APK,像普通应用一样安装即可。按钮会自动检测最新版本。
+
+</div>
+
 启动时,`WebToAppApplication` 以 **构建器模式**(`SHELL_RUNTIME_ONLY = false`)启动:初始化 i18n 字符串、Room 数据库和依赖图,然后显示 **我的应用** —— 即列出你所创建的全部应用的主页。见[主界面](/zh/guide/main-screen/my-apps)。
 
 ## 2. 创建一个应用定义


### PR DESCRIPTION
Closes #681

## Summary

- Add `LatestRelease.vue`: queries `api.github.com/repos/shiaho777/web-to-app/releases/latest` on mount and links to the newest `.apk` asset; falls back to the releases page (versionless label) when the API fails.
- Add `CustomLayout.vue` theme override filling VitePress's `home-hero-actions-after` slot — both homepages (EN + ZH) now show a **Download latest APK / 下载最新版 APK** button under the hero action buttons, with an auto-detected-version caption once the API resolves. (The slot can't be filled from markdown; a Layout override is required.)
- Getting-started **Install and launch** section (EN + ZH): a "Download the builder" card with the same button, left-aligned via the `.wta-install` context styles.
- Styling follows the flat/monochrome direction (#675/#676) and the black button grammar from #678 (VPButton medium: 38px line-height, 20px radius; #171717/#262626 light, #2e2e2e/#3a3a3a dark).

## Verification

- `vitepress build` green; SSR output renders the button inside the hero `.actions` container on both locales (before the hero image, after the three action buttons).
- Getting-started SSRs the `wta-install` card on both locales.
- Headless-Chrome screenshots of all four pages against the local preview server confirm layout; component degrades gracefully without API access.