### PR TITLE
fix(site): keep the hero download button inline with the action row

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -273,6 +273,30 @@
   margin-top: 20px;
 }
 
+/*
+ * On homepages the LatestRelease slot sits right after the hero actions
+ * container; tuck it into the same row (button then version caption),
+ * inheriting the actions row's wrap + centering. The -6px margin cancels
+ * .actions' own -6px gutter so the two rows line up seamlessly.
+ */
+.VPHero .wta-release {
+  display: inline-flex;
+  margin: -6px;
+  margin-top: -6px;
+  padding-top: 0;
+  align-self: center;
+}
+
+.VPHero.has-image .wta-release {
+  justify-content: center;
+}
+
+@media (min-width: 960px) {
+  .VPHero.has-image .wta-release {
+    justify-content: flex-start;
+  }
+}
+
 .wta-release-btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Follow-up to #682. On the homepage the LatestRelease download button (rendered through the `home-hero-actions-after` slot) sat on its own row below the three hero action buttons, because the slot renders after VPHero's block-level `.actions` container and `.wta-release` is itself block-level.

This makes `.VPHero .wta-release` an inline-flex with a negative margin that cancels `.actions`' `-6px` gutter, and mirrors the actions row's `justify-content` behavior (center under 960px when the hero has an image, `flex-start` at ≥960px), so the download button visually continues the same row, with the version caption next to it. On narrow viewports the group wraps naturally.

The getting-started install block lives outside `.VPHero`, so its stacked layout is unchanged.

## Verification

- `npx vitepress build` in `docs/` succeeds.
- Preview server screenshots (headless Chrome):
  - ZH + EN homepages at 1990px: download button now sits inline to the right of the hero action buttons, caption beside it.
  - 640px and 375px viewports: row wraps gracefully, no clipping.
  - getting-started page: layout unchanged (regression check).

Fixes #684