### PR TITLE
fix: bump version on rebuild and honour an absolute activation expiry

### DIFF
--- a/app/src/main/java/com/webtoapp/core/activation/ActivationCode.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/ActivationCode.kt
@@ -26,8 +26,23 @@ data class ActivationCode(
     val note: String? = null,
 
     @SerializedName("createdAt")
-    val createdAt: Long = System.currentTimeMillis()
+    val createdAt: Long = System.currentTimeMillis(),
+
+    /**
+     * Absolute expiry (epoch millis) baked into the code itself.
+     *
+     * A relative [timeLimitMs] is measured from first activation and lives only
+     * in local state, so clearing app data resets the clock. This field travels
+     * with the code, so it survives a wipe and is the one offline anchor a user
+     * cannot reset. Null means no absolute limit; older codes simply omit it.
+     */
+    @SerializedName("expiresAt")
+    val expiresAt: Long? = null
 ) {
+
+    fun isExpiredAt(timeMillis: Long = System.currentTimeMillis()): Boolean =
+        expiresAt != null && timeMillis > expiresAt
+
     companion object {
         private val gson = com.webtoapp.util.GsonProvider.gson
 

--- a/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
@@ -212,6 +212,14 @@ class ActivationManager(private val context: Context) {
         appId: Long,
         deviceId: String
     ): ActivationResult {
+        // An absolute expiry travels with the code, so it still holds after the
+        // local state was wiped. Check it before anything that reads that state,
+        // otherwise clearing data would reset the clock.
+        if (code.isExpiredAt()) {
+            AppLogger.w(TAG, "Activation rejected: code expired (absolute), app=$appId")
+            return ActivationResult.Expired
+        }
+
         val currentStatus = getActivationStatus(appId)
 
         if (currentStatus.isActivated) {
@@ -301,12 +309,16 @@ class ActivationManager(private val context: Context) {
 
     suspend fun saveActivationStatus(appId: Long, code: ActivationCode, deviceId: String) {
         val currentTime = System.currentTimeMillis()
-        val expireTime = when (code.type) {
+        val relativeExpiry = when (code.type) {
             ActivationCodeType.TIME_LIMITED, ActivationCodeType.COMBINED -> {
                 code.timeLimitMs?.let { currentTime + it }
             }
             else -> null
         }
+        // Whichever limit comes first wins, so an absolute expiry also caps a
+        // relative one. Writing it into local state is what makes the startup
+        // check (ActivationStatus.isExpired) honour it without a re-activation.
+        val expireTime = listOfNotNull(relativeExpiry, code.expiresAt).minOrNull()
 
         context.activationDataStore.edit { preferences ->
             preferences[booleanPreferencesKey("activated_$appId")] = true
@@ -319,8 +331,17 @@ class ActivationManager(private val context: Context) {
                 preferences[intPreferencesKey("usage_count_$appId")] = 0
             }
             preferences[stringPreferencesKey("code_type_$appId")] = code.type.name
+            // Recorded so state is complete and callers can audit where a code
+            // was redeemed. Deliberately NOT enforced: a changed device id
+            // (new phone, reflash, factory reset) would lock out paying users,
+            // while enforcement would only ever stop a partial-state wipe.
+            preferences[stringPreferencesKey("device_id_$appId")] = deviceId
         }
-        AppLogger.i(TAG, "Activation status saved: app=$appId, type=${code.type}")
+        AppLogger.i(
+            TAG,
+            "Activation status saved: app=$appId, type=${code.type}, " +
+                "expireTime=$expireTime, absoluteExpiry=${code.expiresAt}"
+        )
     }
 
     suspend fun saveActivationStatus(appId: Long, activated: Boolean) {
@@ -370,7 +391,8 @@ class ActivationManager(private val context: Context) {
         timeLimitMs: Long? = null,
         usageLimit: Int? = null,
         note: String? = null,
-        length: Int = DEFAULT_CODE_LENGTH
+        length: Int = DEFAULT_CODE_LENGTH,
+        expiresAt: Long? = null
     ): ActivationCode {
         val code = generateActivationCode(length)
         return ActivationCode(
@@ -378,7 +400,8 @@ class ActivationManager(private val context: Context) {
             type = type,
             timeLimitMs = timeLimitMs,
             usageLimit = usageLimit,
-            note = note
+            note = note,
+            expiresAt = expiresAt
         )
     }
 
@@ -391,7 +414,8 @@ class ActivationManager(private val context: Context) {
         type: ActivationCodeType = ActivationCodeType.PERMANENT,
         timeLimitMs: Long? = null,
         usageLimit: Int? = null,
-        length: Int = DEFAULT_CODE_LENGTH
+        length: Int = DEFAULT_CODE_LENGTH,
+        expiresAt: Long? = null
     ): List<ActivationCode> {
         return (1..count).map { index ->
             generateActivationCode(
@@ -399,7 +423,8 @@ class ActivationManager(private val context: Context) {
                 timeLimitMs = timeLimitMs,
                 usageLimit = usageLimit,
                 note = "${Strings.batchGeneratedNote} #$index",
-                length = length
+                length = length,
+                expiresAt = expiresAt
             )
         }
     }

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -99,6 +99,122 @@ class ApkBuilder(private val context: Context) {
             "PYTHON_APP" -> setOf("libpython3.so", "libmusl-linker.so")
             else -> emptySet()
         }
+
+        private const val DEFAULT_VERSION_NAME = "1.0.0"
+
+        /**
+         * The package name this app will actually ship with: an explicit custom
+         * package when it is set and well-formed, otherwise the name-derived one.
+         *
+         * This rule used to be copy-pasted in three places (here, the build
+         * pipeline and the export screen). That drift is the root cause of
+         * issue #672: the screen could not reproduce a derived package name, so
+         * it never found the already-installed app and never bumped the version.
+         */
+        fun resolvePackageName(webApp: WebApp): String {
+            val custom = webApp.apkExportConfig?.customPackageName?.takeIf {
+                it.isNotBlank() && it.matches(PACKAGE_NAME_REGEX)
+            }
+            return custom ?: generatePackageName(webApp.name)
+        }
+
+        fun generatePackageName(appName: String): String {
+            val raw = appName.hashCode().let {
+                if (it < 0) (-it).toString(36) else it.toString(36)
+            }.take(4).padStart(4, '0')
+
+            val segment = normalizePackageSegment(raw)
+
+            return "com.w2a.$segment"
+        }
+
+        private fun normalizePackageSegment(segment: String): String {
+            if (segment.isEmpty()) return "a"
+
+            val chars = segment.lowercase().toCharArray()
+
+            chars[0] = when {
+                chars[0] in 'a'..'z' -> chars[0]
+                chars[0] in '0'..'9' -> ('a' + (chars[0] - '0'))
+                else -> 'a'
+            }
+
+            return String(chars)
+        }
+
+        /** Installed versionCode for [packageName], or null when not installed. */
+        fun findInstalledVersionCode(context: Context, packageName: String): Long? {
+            if (packageName.isBlank()) return null
+            return try {
+                val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    context.packageManager.getPackageInfo(
+                        packageName,
+                        PackageManager.PackageInfoFlags.of(0)
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    context.packageManager.getPackageInfo(packageName, 0)
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    info.longVersionCode
+                } else {
+                    @Suppress("DEPRECATION")
+                    info.versionCode.toLong()
+                }
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        /**
+         * Android refuses to install over an existing package unless versionCode
+         * is strictly greater, so rebuilds targeting an already-installed
+         * package bump the version. An explicit higher version set by the user
+         * is left alone — we only step in when the build would not install.
+         */
+        internal fun withInstallAwareVersion(context: Context, webApp: WebApp): WebApp {
+            val (code, name) = suggestedVersionForInstall(context, webApp) ?: return webApp
+            val config = webApp.apkExportConfig
+                ?: com.webtoapp.data.model.ApkExportConfig()
+            return webApp.copy(
+                apkExportConfig = config.copy(
+                    customVersionCode = code,
+                    customVersionName = name
+                )
+            )
+        }
+
+        /**
+         * The version this build should ship with when the target package is
+         * already installed, or null when nothing has to change. Shared by the
+         * export screen (so the suggested version matches what the build will
+         * actually use) and by the build itself (so agent tools and batch export
+         * bump identically).
+         */
+        fun suggestedVersionForInstall(context: Context, webApp: WebApp): Pair<Int, String>? {
+            val installed = findInstalledVersionCode(context, resolvePackageName(webApp))
+                ?: return null
+            val config = webApp.apkExportConfig
+            val configured = config?.customVersionCode ?: 1
+            if (configured > installed) return null
+
+            val bumpedCode = (installed + 1).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+            val currentName = config?.customVersionName?.takeIf { it.isNotBlank() }
+                ?: DEFAULT_VERSION_NAME
+            return bumpedCode to bumpVersionName(currentName)
+        }
+
+        /**
+         * Bumps the last numeric segment ("1.0.0" -> "1.0.1", "v2.1" -> "v2.2").
+         * Anything not ending in digits (for example "1.0.0-beta") is returned
+         * untouched rather than mangled into a version nobody asked for.
+         */
+        internal fun bumpVersionName(current: String): String {
+            val match = Regex("""^(.*?)(\d+)$""").find(current.trim()) ?: return current
+            val (prefix, number) = match.destructured
+            val bumped = number.toLongOrNull()?.plus(1) ?: return current
+            return "$prefix$bumped"
+        }
     }
 
     private val template = ApkTemplate(context)
@@ -124,11 +240,7 @@ class ApkBuilder(private val context: Context) {
     }
 
     fun clearIncrementalCache(webApp: WebApp) {
-        val customPkg = webApp.apkExportConfig?.customPackageName?.takeIf {
-            it.isNotBlank() && it.matches(PACKAGE_NAME_REGEX)
-        }
-        val packageName = customPkg ?: generatePackageName(webApp.name)
-        buildCache.clear(webApp, packageName)
+        buildCache.clear(webApp, resolvePackageName(webApp))
     }
 
     fun clearAllIncrementalCaches() {
@@ -171,10 +283,33 @@ class ApkBuilder(private val context: Context) {
         }
     }
 
+    /**
+     * Every build goes through here, so version bumping lives here too. Doing it
+     * at the entry point means the agent tools and batch export get the same
+     * behaviour as the export screen, and the incremental cache fingerprints the
+     * final version rather than the pre-bump one.
+     */
     suspend fun buildApk(
         webApp: WebApp,
         forceFullRebuild: Boolean = false,
         onProgress: (Int, String) -> Unit = { _, _ -> }
+    ): BuildResult = withContext(Dispatchers.IO) {
+        val versioned = withInstallAwareVersion(context, webApp)
+        if (versioned !== webApp) {
+            AppLogger.i(
+                "ApkBuilder",
+                "Bumped version for ${resolvePackageName(webApp)}: " +
+                    "${webApp.apkExportConfig?.customVersionCode ?: 1} -> " +
+                    "${versioned.apkExportConfig?.customVersionCode}"
+            )
+        }
+        buildApkInternal(versioned, forceFullRebuild, onProgress)
+    }
+
+    private suspend fun buildApkInternal(
+        webApp: WebApp,
+        forceFullRebuild: Boolean,
+        onProgress: (Int, String) -> Unit
     ): BuildResult = withContext(Dispatchers.IO) {
         var currentStage = BuildStage.PREPARE
         var currentPackageName: String? = null
@@ -262,12 +397,12 @@ class ApkBuilder(private val context: Context) {
             AppLogger.d("ApkBuilder", "  appType=${webApp.appType}")
 
             logger.section("Generate Package Name")
-            val customPkg = webApp.apkExportConfig?.customPackageName?.takeIf {
-                it.isNotBlank() &&
-                it.matches(PACKAGE_NAME_REGEX)
-            }
-            val packageName = customPkg ?: generatePackageName(webApp.name)
+            val packageName = resolvePackageName(webApp)
             currentPackageName = packageName
+
+            val customPkg = webApp.apkExportConfig?.customPackageName?.takeIf {
+                it.isNotBlank() && it.matches(PACKAGE_NAME_REGEX)
+            }
 
             if (webApp.apkExportConfig?.customPackageName?.isNotBlank() == true && customPkg == null) {
                 logger.warn("Custom package name format invalid, using auto-generated: $packageName")
@@ -3200,31 +3335,6 @@ builtins.__import__ = _w2a_import
 
     private fun copyEntry(zipIn: ZipFile, zipOut: ZipOutputStream, entry: ZipEntry) {
         ZipUtils.copyEntry(zipIn, zipOut, entry)
-    }
-
-    private fun generatePackageName(appName: String): String {
-
-        val raw = appName.hashCode().let {
-            if (it < 0) (-it).toString(36) else it.toString(36)
-        }.take(4).padStart(4, '0')
-
-        val segment = normalizePackageSegment(raw)
-
-        return "com.w2a.$segment"
-    }
-
-    private fun normalizePackageSegment(segment: String): String {
-        if (segment.isEmpty()) return "a"
-
-        val chars = segment.lowercase().toCharArray()
-
-        chars[0] = when {
-            chars[0] in 'a'..'z' -> chars[0]
-            chars[0] in '0'..'9' -> ('a' + (chars[0] - '0'))
-            else -> 'a'
-        }
-
-        return String(chars)
     }
 
     private fun sanitizeFileName(name: String): String {

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -751,6 +751,8 @@ object Strings {
     val invalidTimeLimitConfig: String get() = StringsA.invalidTimeLimitConfig
     val invalidUsageLimitConfig: String get() = StringsA.invalidUsageLimitConfig
     val validityDays: String get() = StringsA.validityDays
+    val activationCodeExpiryDays: String get() = StringsA.activationCodeExpiryDays
+    val activationCodeValidUntil: String get() = StringsA.activationCodeValidUntil
     val usageCount: String get() = StringsA.usageCount
     val noteOptional: String get() = StringsA.noteOptional
     val vipUserOnly: String get() = StringsA.vipUserOnly
@@ -14378,6 +14380,30 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Срок действия (дни)"
         AppLanguage.JAPANESE -> "有効期間（日）"
         AppLanguage.KOREAN -> "유효기간 (일)"
+    }
+    val activationCodeExpiryDays: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "截止天数（自生成日起，留空永久）"
+        AppLanguage.ENGLISH -> "Expires in (days from creation, blank = never)"
+        AppLanguage.ARABIC -> "ينتهي بعد (أيام من الإنشاء، فارغ = أبدًا)"
+        AppLanguage.PORTUGUESE -> "Expira em (dias desde a criação, vazio = nunca)"
+        AppLanguage.SPANISH -> "Caduca en (días desde la creación, vacío = nunca)"
+        AppLanguage.FRENCH -> "Expire dans (jours depuis la création, vide = jamais)"
+        AppLanguage.GERMAN -> "Läuft ab in (Tage ab Erstellung, leer = nie)"
+        AppLanguage.RUSSIAN -> "Истекает через (дней с создания, пусто = никогда)"
+        AppLanguage.JAPANESE -> "有効期限（生成日からの日数、空欄は無期限）"
+        AppLanguage.KOREAN -> "만료 기간(생성일부터 일수, 비우면 무제한)"
+    }
+    val activationCodeValidUntil: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "截止 %s"
+        AppLanguage.ENGLISH -> "Until %s"
+        AppLanguage.ARABIC -> "حتى %s"
+        AppLanguage.PORTUGUESE -> "Até %s"
+        AppLanguage.SPANISH -> "Hasta %s"
+        AppLanguage.FRENCH -> "Jusqu'au %s"
+        AppLanguage.GERMAN -> "Bis %s"
+        AppLanguage.RUSSIAN -> "До %s"
+        AppLanguage.JAPANESE -> "期限 %s"
+        AppLanguage.KOREAN -> "만료 %s"
     }
 
     val usageCount: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -1047,6 +1047,14 @@ private fun EnhancedActivationCodeItem(
                     }
                 }
 
+                code.expiresAt?.let { expiresAt ->
+                    val formatted = java.text.SimpleDateFormat(
+                        "yyyy-MM-dd",
+                        java.util.Locale.getDefault()
+                    ).format(java.util.Date(expiresAt))
+                    add("📅 ${Strings.activationCodeValidUntil.replace("%s", formatted)}")
+                }
+
                 code.note?.takeIf { it.isNotBlank() }?.let { note ->
                     add("📝 $note")
                 }
@@ -1080,6 +1088,7 @@ private fun AddActivationCodeDialog(
     var codeType by remember { mutableStateOf(ActivationCodeType.PERMANENT) }
     var timeLimitDays by remember { mutableStateOf("7") }
     var usageLimit by remember { mutableStateOf("100") }
+    var expiryDays by remember { mutableStateOf("") }
     var note by remember { mutableStateOf("") }
     var customCode by remember { mutableStateOf("") }
     var useCustomCode by remember { mutableStateOf(false) }
@@ -1265,6 +1274,25 @@ private fun AddActivationCodeDialog(
                 }
 
                 PremiumTextField(
+                    value = expiryDays,
+                    onValueChange = {
+                        if (it.all { char -> char.isDigit() }) {
+                            expiryDays = it
+                        }
+                    },
+                    label = { Text(Strings.activationCodeExpiryDays) },
+                    placeholder = { Text("365") },
+                    leadingIcon = {
+                        Icon(Icons.Outlined.Event, null, modifier = Modifier.size(18.dp))
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                        keyboardType = androidx.compose.ui.text.input.KeyboardType.Number
+                    )
+                )
+
+                PremiumTextField(
                     value = note,
                     onValueChange = { note = it },
                     label = { Text(Strings.noteOptional) },
@@ -1296,6 +1324,12 @@ private fun AddActivationCodeDialog(
                         else -> null
                     }
 
+                    // Counted from generation, not from first activation, so the
+                    // deadline survives a data wipe on the user's device.
+                    val expiresAt = expiryDays.toLongOrNull()
+                        ?.takeIf { it > 0 }
+                        ?.let { System.currentTimeMillis() + TimeUnit.DAYS.toMillis(it) }
+
                     val code = if (useCustomCode && customCode.isNotBlank()) {
                         val trimmed = customCode.trim()
                         if (trimmed.length < com.webtoapp.core.activation.ActivationManager.MIN_CODE_LENGTH) {
@@ -1307,7 +1341,8 @@ private fun AddActivationCodeDialog(
                             type = codeType,
                             timeLimitMs = timeLimitMs,
                             usageLimit = usageLimitInt,
-                            note = note.takeIf { it.isNotBlank() }
+                            note = note.takeIf { it.isNotBlank() },
+                            expiresAt = expiresAt
                         )
                     } else {
                         val activationManager = com.webtoapp.WebToAppApplication.getInstance()
@@ -1317,7 +1352,8 @@ private fun AddActivationCodeDialog(
                             timeLimitMs = timeLimitMs,
                             usageLimit = usageLimitInt,
                             note = note.takeIf { it.isNotBlank() },
-                            length = codeLength.toInt()
+                            length = codeLength.toInt(),
+                            expiresAt = expiresAt
                         )
                     }
 
@@ -1346,6 +1382,7 @@ private fun BatchGenerateDialog(
     var batchCount by remember { mutableStateOf("5") }
     var timeLimitDays by remember { mutableStateOf("7") }
     var usageLimit by remember { mutableStateOf("100") }
+    var expiryDays by remember { mutableStateOf("") }
     var codeLength by remember { mutableStateOf(com.webtoapp.core.activation.ActivationManager.DEFAULT_CODE_LENGTH.toFloat()) }
 
     AlertDialog(
@@ -1477,6 +1514,18 @@ private fun BatchGenerateDialog(
                         )
                     )
                 }
+
+                PremiumTextField(
+                    value = expiryDays,
+                    onValueChange = { if (it.all { c -> c.isDigit() }) expiryDays = it },
+                    label = { Text(Strings.activationCodeExpiryDays) },
+                    leadingIcon = { Icon(Icons.Outlined.Event, null, modifier = Modifier.size(18.dp)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                        keyboardType = androidx.compose.ui.text.input.KeyboardType.Number
+                    )
+                )
             }
         },
         confirmButton = {
@@ -1493,6 +1542,9 @@ private fun BatchGenerateDialog(
                             usageLimit.toIntOrNull()
                         else -> null
                     }
+                    val expiresAt = expiryDays.toLongOrNull()
+                        ?.takeIf { it > 0 }
+                        ?.let { System.currentTimeMillis() + TimeUnit.DAYS.toMillis(it) }
 
                     val activationManager = com.webtoapp.WebToAppApplication.getInstance()
                         .activationManager
@@ -1501,7 +1553,8 @@ private fun BatchGenerateDialog(
                         type = codeType,
                         timeLimitMs = timeLimitMs,
                         usageLimit = usageLimitInt,
-                        length = codeLength.toInt()
+                        length = codeLength.toInt(),
+                        expiresAt = expiresAt
                     )
                     onConfirm(codes)
                 }

--- a/app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt
@@ -185,20 +185,19 @@ private fun BuildApkContent(
     var selectedEngineType by remember(webApp.id) {
         mutableStateOf(webApp.apkExportConfig?.engineType ?: "SYSTEM_WEBVIEW")
     }
-    val updatePackageName = webApp.apkExportConfig?.customPackageName
-        ?.takeIf { it.isNotBlank() && it.matches(com.webtoapp.util.AppConstants.PACKAGE_NAME_REGEX) }
+    // Resolve the package exactly the way the builder does. That rule used to
+    // live inside ApkBuilder, so the screen could not reproduce a derived
+    // package name, never found the installed app, and never bumped the version.
+    val resolvedPackageName = com.webtoapp.core.apkbuilder.ApkBuilder.resolvePackageName(webApp)
     val baseVersionCode = webApp.apkExportConfig?.customVersionCode ?: 1
-    var installedVersionCode by remember(updatePackageName) { mutableStateOf<Long?>(null) }
-    LaunchedEffect(updatePackageName, uiReady) {
-        if (!uiReady || updatePackageName == null) return@LaunchedEffect
-        installedVersionCode = withContext(Dispatchers.IO) {
-            findInstalledVersionCode(context, updatePackageName)
-        }
+    var suggestedVersion by remember(resolvedPackageName) {
+        mutableStateOf<Pair<Int, String>?>(null)
     }
-    val suggestedUpdateVersionCode = if (updatePackageName != null) {
-        (maxOf(baseVersionCode.toLong(), installedVersionCode ?: 0L) + 1L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
-    } else {
-        baseVersionCode
+    LaunchedEffect(resolvedPackageName, baseVersionCode, uiReady) {
+        if (!uiReady) return@LaunchedEffect
+        suggestedVersion = withContext(Dispatchers.IO) {
+            com.webtoapp.core.apkbuilder.ApkBuilder.suggestedVersionForInstall(context, webApp)
+        }
     }
     val engineFileManager = remember { com.webtoapp.core.engine.download.EngineFileManager(context) }
     var isGeckoDownloaded by remember { mutableStateOf(false) }
@@ -223,8 +222,12 @@ private fun BuildApkContent(
                 notificationConfig = notificationConfig,
                 engineType = selectedEngineType
             ).let { exportConfig ->
-                if (updatePackageName != null && (exportConfig.customVersionCode ?: 1) < suggestedUpdateVersionCode) {
-                    exportConfig.copy(customVersionCode = suggestedUpdateVersionCode)
+                val suggested = suggestedVersion
+                if (suggested != null && (exportConfig.customVersionCode ?: 1) < suggested.first) {
+                    exportConfig.copy(
+                        customVersionCode = suggested.first,
+                        customVersionName = suggested.second
+                    )
                 } else {
                     exportConfig
                 }
@@ -615,7 +618,7 @@ private fun BuildApkContent(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
-                    if (updatePackageName != null) {
+                    if (suggestedVersion != null) {
                         Surface(
                             shape = RoundedCornerShape(WtaRadius.Control),
                             color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f)
@@ -633,8 +636,8 @@ private fun BuildApkContent(
                                     tint = MaterialTheme.colorScheme.primary
                                 )
                                 Text(
-                                    Strings.updateApkGuide.replace("%s", updatePackageName)
-                                        .replace("%d", suggestedUpdateVersionCode.toString()),
+                                    Strings.updateApkGuide.replace("%s", resolvedPackageName)
+                                        .replace("%d", (suggestedVersion?.first ?: baseVersionCode).toString()),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onPrimaryContainer
                                 )
@@ -877,27 +880,6 @@ private fun resolveBuildIsolationDefault(
     return config ?: com.webtoapp.core.privacy.IsolationConfig.DISABLED
 }
 
-private fun findInstalledVersionCode(context: android.content.Context, packageName: String): Long? {
-    return try {
-        val packageInfo = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-            context.packageManager.getPackageInfo(
-                packageName,
-                android.content.pm.PackageManager.PackageInfoFlags.of(0)
-            )
-        } else {
-            @Suppress("DEPRECATION")
-            context.packageManager.getPackageInfo(packageName, 0)
-        }
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
-            packageInfo.longVersionCode
-        } else {
-            @Suppress("DEPRECATION")
-            packageInfo.versionCode.toLong()
-        }
-    } catch (_: Exception) {
-        null
-    }
-}
 
 @Composable
 private fun BuildSummaryCard(

--- a/app/src/test/java/com/webtoapp/core/activation/ActivationExpiryTest.kt
+++ b/app/src/test/java/com/webtoapp/core/activation/ActivationExpiryTest.kt
@@ -1,0 +1,141 @@
+package com.webtoapp.core.activation
+
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+
+/**
+ * Guards the offline half of issue #672.
+ *
+ * A relative time limit is measured from first activation and only lives in
+ * local state, so clearing app data reset the clock and the code activated
+ * again. An absolute expiry travels with the code and is checked before local
+ * state is read, so it survives the wipe.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ActivationExpiryTest {
+
+    private lateinit var manager: ActivationManager
+    private lateinit var context: android.content.Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        manager = ActivationManager(context)
+        runBlocking { manager.resetActivation(APP_ID) }
+    }
+
+    private fun preferences() = runBlocking {
+        context.activationDataStore.data.first()
+    }
+
+    @Test
+    fun `code without an absolute expiry never expires`() {
+        val code = ActivationCode(code = "PLAIN123", type = ActivationCodeType.PERMANENT)
+        assertThat(code.isExpiredAt()).isFalse()
+        assertThat(code.isExpiredAt(Long.MAX_VALUE)).isFalse()
+    }
+
+    @Test
+    fun `code past its absolute expiry is rejected with no local state`() = runBlocking {
+        val expired = ActivationCode(
+            code = "EXPIRED1",
+            type = ActivationCodeType.PERMANENT,
+            expiresAt = System.currentTimeMillis() - 1_000
+        )
+
+        // The bug: local state is empty (as after a data wipe), so the old code
+        // path skipped every check and returned Success.
+        val result = manager.verifyActivationCodeWithObjects(APP_ID, "EXPIRED1", listOf(expired))
+
+        assertThat(result).isEqualTo(ActivationResult.Expired)
+    }
+
+    @Test
+    fun `code before its absolute expiry still activates`() = runBlocking {
+        val valid = ActivationCode(
+            code = "FUTURE12",
+            type = ActivationCodeType.PERMANENT,
+            expiresAt = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30)
+        )
+
+        val result = manager.verifyActivationCodeWithObjects(APP_ID, "FUTURE12", listOf(valid))
+
+        assertThat(result).isInstanceOf(ActivationResult.Success::class.java)
+    }
+
+    @Test
+    fun `absolute expiry is written into state so the startup check honours it`() = runBlocking {
+        val expiresAt = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(10)
+        val code = ActivationCode(
+            code = "STATE123",
+            type = ActivationCodeType.PERMANENT,
+            expiresAt = expiresAt
+        )
+
+        manager.saveActivationStatus(APP_ID, code, "device-under-test")
+
+        assertThat(preferences()[longPreferencesKey("expire_time_$APP_ID")]).isEqualTo(expiresAt)
+    }
+
+    @Test
+    fun `absolute expiry caps a longer relative window`() = runBlocking {
+        val expiresAt = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(3)
+        val code = ActivationCode(
+            code = "BOTH1234",
+            type = ActivationCodeType.TIME_LIMITED,
+            timeLimitMs = TimeUnit.DAYS.toMillis(30),
+            expiresAt = expiresAt
+        )
+
+        manager.saveActivationStatus(APP_ID, code, "device-under-test")
+
+        assertThat(preferences()[longPreferencesKey("expire_time_$APP_ID")]).isEqualTo(expiresAt)
+    }
+
+    @Test
+    fun `device id is persisted so the stored state is complete`() = runBlocking {
+        val code = ActivationCode(code = "DEVICE12", type = ActivationCodeType.PERMANENT)
+
+        manager.saveActivationStatus(APP_ID, code, "device-abc")
+
+        assertThat(preferences()[stringPreferencesKey("device_id_$APP_ID")]).isEqualTo("device-abc")
+    }
+
+    @Test
+    fun `legacy json without expiresAt stays permanent`() {
+        val parsed = ActivationCode.fromJson("""{"code":"LEGACY12","type":"PERMANENT"}""")
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.expiresAt).isNull()
+        assertThat(parsed.isExpiredAt()).isFalse()
+    }
+
+    @Test
+    fun `expiresAt survives a json round trip`() {
+        val expiresAt = 1_800_000_000_000L
+        val original = ActivationCode(
+            code = "ROUND123",
+            type = ActivationCodeType.PERMANENT,
+            expiresAt = expiresAt
+        )
+
+        val restored = ActivationCode.fromJson(original.toJson())
+
+        assertThat(restored?.expiresAt).isEqualTo(expiresAt)
+    }
+
+    private companion object {
+        const val APP_ID = 7L
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuilderVersionTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuilderVersionTest.kt
@@ -1,0 +1,129 @@
+package com.webtoapp.core.apkbuilder
+
+import android.content.pm.PackageInfo
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.ApkExportConfig
+import com.webtoapp.data.model.WebApp
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Covers the two rules behind issue #672: the package name has one derivation
+ * rule shared by the UI and the builder, and a rebuild over an installed
+ * package ends up with a strictly greater versionCode.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ApkBuilderVersionTest {
+
+    private fun app(
+        name: String = "My Site",
+        packageName: String? = null,
+        versionCode: Int? = null,
+        versionName: String? = null
+    ): WebApp = WebApp(
+        id = 1L,
+        name = name,
+        url = "https://example.com",
+        apkExportConfig = ApkExportConfig(
+            customPackageName = packageName,
+            customVersionCode = versionCode,
+            customVersionName = versionName
+        )
+    )
+
+    private fun install(packageName: String, versionCode: Long) {
+        val info = PackageInfo().apply {
+            this.packageName = packageName
+            @Suppress("DEPRECATION")
+            this.versionCode = versionCode.toInt()
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                this.longVersionCode = versionCode
+            }
+        }
+        shadowOf(ApplicationProvider.getApplicationContext<android.app.Application>().packageManager)
+            .installPackage(info)
+    }
+
+    @Test
+    fun `derived package name is stable for the same app name`() {
+        val first = ApkBuilder.resolvePackageName(app("My Site"))
+        val second = ApkBuilder.resolvePackageName(app("My Site"))
+        assertThat(first).isEqualTo(second)
+        assertThat(first).startsWith("com.w2a.")
+    }
+
+    @Test
+    fun `custom package name wins when it is well formed`() {
+        val resolved = ApkBuilder.resolvePackageName(app(packageName = "com.example.demo"))
+        assertThat(resolved).isEqualTo("com.example.demo")
+    }
+
+    @Test
+    fun `malformed custom package name falls back to the derived one`() {
+        val resolved = ApkBuilder.resolvePackageName(app(packageName = "not a package name"))
+        assertThat(resolved).isEqualTo(ApkBuilder.generatePackageName("My Site"))
+    }
+
+    @Test
+    fun `nothing is bumped when the target package is not installed`() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val webApp = app("Uninstalled App")
+        assertThat(ApkBuilder.suggestedVersionForInstall(context, webApp)).isNull()
+        assertThat(ApkBuilder.withInstallAwareVersion(context, webApp)).isSameInstanceAs(webApp)
+    }
+
+    @Test
+    fun `rebuild over an installed derived package bumps code and name`() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val webApp = app("My Site")
+        install(ApkBuilder.resolvePackageName(webApp), 3)
+
+        val suggested = ApkBuilder.suggestedVersionForInstall(context, webApp)
+        assertThat(suggested).isNotNull()
+        assertThat(suggested!!.first).isEqualTo(4)
+        assertThat(suggested.second).isEqualTo("1.0.1")
+
+        val bumped = ApkBuilder.withInstallAwareVersion(context, webApp)
+        assertThat(bumped.apkExportConfig?.customVersionCode).isEqualTo(4)
+        assertThat(bumped.apkExportConfig?.customVersionName).isEqualTo("1.0.1")
+    }
+
+    @Test
+    fun `an explicit higher version set by the user is left alone`() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val webApp = app("My Site", versionCode = 100)
+        install(ApkBuilder.resolvePackageName(webApp), 3)
+
+        assertThat(ApkBuilder.suggestedVersionForInstall(context, webApp)).isNull()
+    }
+
+    @Test
+    fun `an explicit version that cannot be installed still gets bumped`() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val webApp = app("My Site", versionCode = 5, versionName = "2.1.7")
+        install(ApkBuilder.resolvePackageName(webApp), 5)
+
+        val suggested = ApkBuilder.suggestedVersionForInstall(context, webApp)
+        assertThat(suggested!!.first).isEqualTo(6)
+        assertThat(suggested.second).isEqualTo("2.1.8")
+    }
+
+    @Test
+    fun `version name bump only touches the last numeric segment`() {
+        assertThat(ApkBuilder.bumpVersionName("1.0.0")).isEqualTo("1.0.1")
+        assertThat(ApkBuilder.bumpVersionName("1.0")).isEqualTo("1.1")
+        assertThat(ApkBuilder.bumpVersionName("v2.9")).isEqualTo("v2.10")
+        assertThat(ApkBuilder.bumpVersionName("7")).isEqualTo("8")
+    }
+
+    @Test
+    fun `version name without a numeric tail is left untouched`() {
+        assertThat(ApkBuilder.bumpVersionName("1.0.0-beta")).isEqualTo("1.0.0-beta")
+        assertThat(ApkBuilder.bumpVersionName("nightly")).isEqualTo("nightly")
+    }
+}


### PR DESCRIPTION
Fixes #672

Two independent issues from the same report, kept as two commits.

## 1. Version number not incremented on rebuild

Android refuses to install over an existing package unless `versionCode` is strictly greater, but a rebuild kept shipping `versionCode = 1`, so rebuilding an app under the same name produced an APK that would not install.

The bump already existed but was gated on the user having typed a custom package name. The name-derived package rule lived in `ApkBuilder` as a private method, so the export screen could not reproduce it, never found the installed app, and never bumped. That same rule was copy-pasted in three places.

- `ApkBuilder.resolvePackageName` is now the single source of truth.
- The bump moved to the build entry point (`buildApk`), so it covers every caller — export screen, agent tools, batch export — instead of just the screen. It also runs before the incremental cache computes its fingerprint, so a bumped version is never served from a cached APK built with the old one. Behaviour inside the original method body is unchanged.
- The version is raised only when the target package is installed **and** the configured version would not install over it. An explicitly higher version set by the user is left alone.
- `versionName` is bumped alongside it (`1.0.0` → `1.0.1`). Anything not ending in digits (`1.0.0-beta`) is left untouched instead of being mangled.

## 2. Local activation did not survive a data wipe

A time-limited code measured its window from first activation and kept the deadline only in local state, so clearing app data restarted the clock and the same code activated again. Validation only checked expiry and usage limits inside `if (currentStatus.isActivated)` — and that flag is exactly what a wipe clears.

Added an **absolute expiry on the code itself** (`ActivationCode.expiresAt`). It travels with the code rather than with local state, is checked before local state is read, so it holds after a wipe, and is written into state too so the startup check honours it without re-activation. When both a relative and an absolute limit exist, whichever comes first wins.

The field is nullable and lives in a JSON column (`activationCodeList` goes through a `TypeConverter`), so **no Room migration** is needed and existing codes are unaffected. Set it in days when generating codes, single or batch.

Also fixed: the device id was computed and passed into validation but never persisted, even though `resetActivation` deletes that key and `getActivationStatusSync` reads it. It is now written — but deliberately **not enforced**, with the reasoning in a comment: binding state is local, so a second device simply has none and enforcement would not stop sharing, only lock out users who changed phones, reflashed, or factory-reset.

### What this does not do

Local verification is still not tamper-proof and cannot be. With activation state on a device the user controls, the reset is always theirs. This closes the reported "wipe and reuse forever" hole; it does not survive someone setting the device clock back. Remote verification (ECDSA + nonce) remains the answer for real enforcement.

## Testing

- New `ApkBuilderVersionTest` (9 cases): derived package stability, custom name precedence, malformed fallback, no bump when not installed, bump when installed, explicit higher version untouched, install-blocking version still bumped, `versionName` shapes.
- New `ActivationExpiryTest` (8 cases): absolutely expired code rejected with no local state (the reported scenario), unexpired code still activates, absolute expiry written to state, absolute caps a longer relative window, device id persisted, legacy JSON without the field stays permanent, JSON round trip.
- Full suite: 956 tests, 0 failures.