### PR TITLE
feat(network): probe every GitHub route and download from the fastest

### DIFF
--- a/app/src/main/java/com/webtoapp/core/network/CnMirrorProbe.kt
+++ b/app/src/main/java/com/webtoapp/core/network/CnMirrorProbe.kt
@@ -1,121 +1,168 @@
 package com.webtoapp.core.network
 
+import android.os.Looper
 import com.webtoapp.core.logging.AppLogger
+import com.webtoapp.core.network.GitHubMirror.MirrorChannel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import okhttp3.Request
 import java.util.concurrent.TimeUnit
 
+/**
+ * Picks the fastest reachable GitHub route before a download starts.
+ *
+ * Every channel is probed concurrently with a single small ranged request and
+ * ranked by time-to-first-byte. Channels slower than [ACCEPTABLE_LATENCY_MS]
+ * are dropped so a download never wastes its first attempt on a mirror that is
+ * technically alive but unusable.
+ *
+ * The result is cached for [CACHE_TTL_MS], so repeated downloads in the same
+ * session pay the probe cost once instead of re-measuring every channel every
+ * time. If everything fails the probe, the caller still gets the full channel
+ * list in declaration order — the probe never leaves a download with nowhere
+ * to go.
+ */
 object CnMirrorProbe {
 
     private const val TAG = "CnMirrorProbe"
-    private const val CACHE_TTL_MS = 10L * 60 * 1000
+    private const val CACHE_TTL_MS = 5L * 60 * 1000
+
+    /** Channels at or under this TTFB are considered usable. */
+    const val ACCEPTABLE_LATENCY_MS = 1000L
 
     // Probe through a real GitHub release asset — the exact path large runtime
-    // downloads take (proxy -> github release CDN). A HEAD on a README says
-    // nothing about release throughput, which is what actually matters.
+    // downloads take. A HEAD on a README says nothing about release routes.
     private const val PROBE_TARGET =
         "https://github.com/git-lfs/git-lfs/releases/download/v3.7.0/git-lfs-linux-amd64-v3.7.0.tar.gz"
 
-    // Measure sustained download speed on the first 256 KB, capped at ~3.5 s
-    // per proxy; mirrors are ordered by measured bandwidth, not RTT.
-    private const val PROBE_BYTES = 256L * 1024
-    private const val PROBE_BUDGET_MS = 3500L
+    // One ranged KB is enough to measure TTFB without paying for real payload.
+    private const val PROBE_RANGE_BYTES = 1024
+    private const val PROBE_TIMEOUT_MS = 2500L
+    private const val PROBE_BUDGET_MS = 4000L // hard ceiling for a single channel
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val mutex = Mutex()
 
     @Volatile
-    private var cachedOrder: List<String> = emptyList()
+    private var cachedOrder: List<MirrorChannel> = emptyList()
 
     @Volatile
     private var cachedAt: Long = 0L
 
-    @Volatile
-    private var probing: Boolean = false
-
     private val probeClient by lazy {
         NetworkModule.customClient {
-            connectTimeout(4, TimeUnit.SECONDS)
-            readTimeout(4, TimeUnit.SECONDS)
-            writeTimeout(4, TimeUnit.SECONDS)
+            connectTimeout(PROBE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            readTimeout(PROBE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            writeTimeout(PROBE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
             retryOnConnectionFailure(false)
         }
     }
 
-    fun getOrderedProxies(baseList: List<String>): List<String> {
+    /**
+     * Channels ordered fastest-first. Safe to call from anywhere: on a worker
+     * thread a stale cache triggers one blocking probe round (bounded by
+     * [PROBE_BUDGET_MS]); on the main thread it never blocks and falls back to
+     * the last known order while a refresh runs in the background.
+     */
+    fun orderedChannels(): List<MirrorChannel> {
         val now = System.currentTimeMillis()
-        val fresh = cachedOrder.isNotEmpty() && (now - cachedAt) < CACHE_TTL_MS
-        if (fresh) {
-
-            val extras = baseList.filter { it !in cachedOrder }
-            return cachedOrder + extras
+        if (cachedOrder.isNotEmpty() && (now - cachedAt) < CACHE_TTL_MS) {
+            return mergeNewChannels(cachedOrder)
         }
-        if (!probing) {
-            scope.launch { probe(baseList) }
+        if (onMainThread()) {
+            scope.launch { runCatching { probe() } }
+            return mergeNewChannels(cachedOrder)
         }
-        return baseList
+        runCatching {
+            runBlocking { probe() }
+        }
+        return mergeNewChannels(cachedOrder)
     }
 
-    suspend fun probe(baseList: List<String>) {
+    /** Forget the cached order; the next [orderedChannels] re-measures. */
+    fun invalidate() {
+        cachedOrder = emptyList()
+        cachedAt = 0L
+    }
+
+    /**
+     * Measure every channel and cache the ones that answer in time. Concurrent
+     * callers serialize on [mutex] and share one probe round.
+     */
+    suspend fun probe(): List<MirrorChannel> {
         mutex.withLock {
-            if (probing) return@withLock
-            probing = true
-        }
-        try {
-            val results = withContext(Dispatchers.IO) {
-                baseList.map { proxy ->
-                    async { proxy to measureProxyBandwidth(proxy) }
+            val now = System.currentTimeMillis()
+            if (cachedOrder.isNotEmpty() && (now - cachedAt) < CACHE_TTL_MS) {
+                return cachedOrder
+            }
+            val channels = GitHubMirror.ALL_CHANNELS
+            val started = System.currentTimeMillis()
+            val results = coroutineScope {
+                channels.map { channel ->
+                    async { channel to measureLatency(channel) }
                 }.awaitAll()
             }
-            val ordered = results
-                .filter { it.second > 0 }
-                .sortedByDescending { it.second }
-                .map { it.first }
-            if (ordered.isNotEmpty()) {
-                cachedOrder = ordered
-                cachedAt = System.currentTimeMillis()
-                AppLogger.i(TAG, "Probed proxies: $ordered (KB/s: ${results.filter { it.second > 0 }.joinToString { "${it.first.substringAfter("//").substringBefore("/")}=${it.second / 1024}" }})")
-            } else {
-                AppLogger.w(TAG, "All proxies failed probe; keeping previous order")
+            val usable = results
+                .filter { (_, latency) -> latency in 1..ACCEPTABLE_LATENCY_MS }
+                .sortedBy { (_, latency) -> latency }
+                .map { (channel, _) -> channel }
+
+            val report = results.joinToString(", ") { (channel, latency) ->
+                "${channel.id}=${if (latency < 0) "dead" else "${latency}ms"}"
             }
-        } finally {
-            probing = false
+            AppLogger.i(TAG, "Probe round took ${System.currentTimeMillis() - started}ms — $report")
+
+            if (usable.isEmpty()) {
+                // Nothing answered in time. Keep the declaration order so the
+                // download still has every channel to fall through, and do not
+                // cache the failure — the next download should try again.
+                AppLogger.w(TAG, "No channel answered within ${ACCEPTABLE_LATENCY_MS}ms; using declaration order")
+                return channels
+            }
+            cachedOrder = usable
+            cachedAt = System.currentTimeMillis()
+            AppLogger.i(TAG, "Usable channels: ${usable.joinToString(" > ") { it.id }}")
+            return usable
         }
     }
 
-    /** Sustained download speed in bytes/sec through the proxy; -1 when unusable. */
-    private fun measureProxyBandwidth(proxy: String): Long {
-        val url = "$proxy$PROBE_TARGET"
+    /**
+     * Channels added to the pool after the last probe still deserve a slot;
+     * append them behind the measured order rather than dropping them.
+     */
+    private fun mergeNewChannels(order: List<MirrorChannel>): List<MirrorChannel> {
+        if (order.isEmpty()) return GitHubMirror.ALL_CHANNELS
+        val extras = GitHubMirror.ALL_CHANNELS.filter { it !in order }
+        return if (extras.isEmpty()) order else order + extras
+    }
+
+    private fun onMainThread(): Boolean = Looper.myLooper() == Looper.getMainLooper()
+
+    /** Time-to-first-byte in ms for one channel, or -1 when unreachable. */
+    private fun measureLatency(channel: MirrorChannel): Long {
+        val url = channel.rewrite(PROBE_TARGET)
         return try {
             val req = Request.Builder()
                 .url(url)
-                .header("Range", "bytes=0-${PROBE_BYTES - 1}")
+                .header("Range", "bytes=0-${PROBE_RANGE_BYTES - 1}")
                 .build()
+            val start = System.nanoTime()
             probeClient.newCall(req).execute().use { resp ->
                 if (resp.code !in 200..399) return -1
                 val body = resp.body ?: return -1
                 body.byteStream().use { input ->
-                    val buffer = ByteArray(16 * 1024)
-                    var read = 0L
-                    val start = System.currentTimeMillis()
-                    while (read < PROBE_BYTES) {
-                        val left = (PROBE_BYTES - read).toInt().coerceAtMost(buffer.size)
-                        val n = input.read(buffer, 0, left)
-                        if (n == -1) break
-                        read += n
-                        if (System.currentTimeMillis() - start > PROBE_BUDGET_MS) break
-                    }
-                    val elapsed = System.currentTimeMillis() - start
-                    if (read <= 0L || elapsed <= 0L) -1 else read * 1000 / elapsed
+                    input.read(ByteArray(PROBE_RANGE_BYTES))
                 }
+                val elapsedMs = (System.nanoTime() - start) / 1_000_000
+                if (elapsedMs > PROBE_BUDGET_MS) -1 else elapsedMs
             }
         } catch (_: Exception) {
             -1

--- a/app/src/main/java/com/webtoapp/core/network/GitHubHosts.kt
+++ b/app/src/main/java/com/webtoapp/core/network/GitHubHosts.kt
@@ -1,0 +1,100 @@
+package com.webtoapp.core.network
+
+import com.webtoapp.core.logging.AppLogger
+import okhttp3.Dns
+import java.net.InetAddress
+
+/**
+ * Pinned GitHub IP mappings (GitHub520 hosts list, snapshot 2026-08-29).
+ *
+ * On networks where DNS is poisoned or slow, resolving `github.com` and its
+ * CDN hosts to a known-good IP short-circuits the failing lookup. The pinned
+ * list is only ever tried *first*: [GitHubHostsDns] always appends the system
+ * resolver's answer behind it, so when a pinned IP goes stale (GitHub rotates
+ * these regularly) OkHttp silently moves on to the real one.
+ *
+ * Nothing here is a hard dependency — it is a fast path with an automatic
+ * fallback, which is what makes shipping static IPs safe.
+ */
+object GitHubHosts {
+
+    private const val TAG = "GitHubHosts"
+
+    private val ENTRIES: Map<String, List<String>> = mapOf(
+        "alive.github.com" to listOf("140.82.114.26"),
+        "api.github.com" to listOf("20.205.243.168"),
+        "api.individual.githubcopilot.com" to listOf("140.82.113.21"),
+        "avatars.githubusercontent.com" to listOf("185.199.110.133"),
+        "avatars0.githubusercontent.com" to listOf("185.199.110.133"),
+        "avatars1.githubusercontent.com" to listOf("185.199.110.133"),
+        "avatars2.githubusercontent.com" to listOf("185.199.110.133"),
+        "avatars3.githubusercontent.com" to listOf("185.199.110.133"),
+        "avatars4.githubusercontent.com" to listOf("185.199.110.133"),
+        "avatars5.githubusercontent.com" to listOf("185.199.110.133"),
+        "camo.githubusercontent.com" to listOf("185.199.110.133"),
+        "central.github.com" to listOf("140.82.114.21"),
+        "cloud.githubusercontent.com" to listOf("185.199.110.133"),
+        "codeload.github.com" to listOf("20.205.243.165"),
+        "collector.github.com" to listOf("140.82.113.21"),
+        "desktop.githubusercontent.com" to listOf("185.199.110.133"),
+        "favicons.githubusercontent.com" to listOf("185.199.110.133"),
+        "gist.github.com" to listOf("37.61.54.158"),
+        "github-cloud.s3.amazonaws.com" to listOf("52.217.141.105"),
+        "github-com.s3.amazonaws.com" to listOf("52.217.136.9"),
+        "github-production-release-asset-2e65be.s3.amazonaws.com" to listOf("54.231.129.185"),
+        "github-production-repository-file-5c1aeb.s3.amazonaws.com" to listOf("52.216.25.68"),
+        "github-production-user-asset-6210df.s3.amazonaws.com" to listOf("52.217.37.124"),
+        "github.blog" to listOf("192.0.66.2"),
+        "github.com" to listOf("20.205.243.166"),
+        "github.community" to listOf("140.82.113.17"),
+        "github.githubassets.com" to listOf("185.199.110.215"),
+        "github.global.ssl.fastly.net" to listOf("108.160.165.189"),
+        "github.io" to listOf("185.199.111.153"),
+        "github.map.fastly.net" to listOf("185.199.110.133"),
+        "githubstatus.com" to listOf("185.199.111.153"),
+        "live.github.com" to listOf("140.82.113.26"),
+        "media.githubusercontent.com" to listOf("185.199.110.133"),
+        "objects.githubusercontent.com" to listOf("185.199.110.133"),
+        "pipelines.actions.githubusercontent.com" to listOf("13.107.42.16"),
+        "raw.githubusercontent.com" to listOf("185.199.110.133"),
+        "user-images.githubusercontent.com" to listOf("185.199.110.133"),
+        "private-user-images.githubusercontent.com" to listOf("185.199.110.133"),
+        "vscode.dev" to listOf("150.171.110.103"),
+        "education.github.com" to listOf("140.82.112.21")
+    )
+
+    private val resolved: Map<String, List<InetAddress>> by lazy {
+        ENTRIES.mapValues { (_, ips) ->
+            ips.mapNotNull { ip -> runCatching { InetAddress.getByName(ip) }.getOrNull() }
+        }.filterValues { it.isNotEmpty() }
+            .also { AppLogger.i(TAG, "Pinned ${it.size} GitHub hosts across ${it.values.sumOf { v -> v.size }} addresses") }
+    }
+
+    /** Pinned addresses for [hostname], empty when it is not in the table. */
+    fun lookup(hostname: String): List<InetAddress> = resolved[hostname].orEmpty()
+
+    fun covers(hostname: String): Boolean = resolved.containsKey(hostname)
+
+    val pinnedHosts: Set<String> get() = resolved.keys
+}
+
+/**
+ * OkHttp [Dns] that tries the pinned IP first and keeps the system answer
+ * behind it as a fallback. OkHttp walks the returned list in order, so a stale
+ * pinned IP costs one failed connect attempt and nothing more.
+ */
+object GitHubHostsDns : Dns {
+
+    override fun lookup(hostname: String): List<InetAddress> {
+        val pinned = GitHubHosts.lookup(hostname)
+        if (pinned.isEmpty()) return Dns.SYSTEM.lookup(hostname)
+        val system = runCatching { Dns.SYSTEM.lookup(hostname) }.getOrDefault(emptyList())
+        val merged = pinned + system.filter { candidate -> pinned.none { it.hostAddress == candidate.hostAddress } }
+        if (merged.size > pinned.size) {
+            AppLogger.d(GitHubHostsDnsTag, "$hostname: pinned ${pinned.map { it.hostAddress }} + ${merged.size - pinned.size} system")
+        }
+        return merged
+    }
+
+    private const val GitHubHostsDnsTag = "GitHubHostsDns"
+}

--- a/app/src/main/java/com/webtoapp/core/network/GitHubMirror.kt
+++ b/app/src/main/java/com/webtoapp/core/network/GitHubMirror.kt
@@ -3,27 +3,66 @@ package com.webtoapp.core.network
 /**
  * Single source of truth for GitHub release / npm-registry mirror expansion.
  * Every runtime downloader funnels through here so mirror ordering (probed by
- * measured bandwidth via [CnMirrorProbe]) and the direct-URL fallback stay
+ * measured latency via [CnMirrorProbe]) and the direct-URL fallback stay
  * consistent across Node / Python / PHP / WordPress / Go toolchains.
  */
 object GitHubMirror {
 
-    val CN_PROXIES = listOf(
-        "https://ghfast.top/",
-        "https://gh-proxy.com/"
+    /**
+     * One route to a GitHub URL. [prefix] is prepended to the full URL
+     * (prefix-style accelerators take the whole URL as a path); an empty
+     * prefix means a direct hit, which resolves through [GitHubHostsDns] and
+     * therefore tries a pinned IP before the system resolver.
+     */
+    data class MirrorChannel(val id: String, val prefix: String) {
+        fun rewrite(url: String): String = prefix + url
+
+        companion object {
+            val DIRECT = MirrorChannel("direct", "")
+        }
+    }
+
+    /**
+     * Candidate prefix accelerators. This is deliberately a wide net: the list
+     * is re-measured at runtime by [CnMirrorProbe] and anything slow or dead is
+     * dropped before the first download attempt, so a stale entry costs one
+     * probe request and nothing else.
+     */
+    val CN_PROXIES: List<MirrorChannel> = listOf(
+        MirrorChannel("ghfast", "https://ghfast.top/"),
+        MirrorChannel("gh-proxy", "https://gh-proxy.com/"),
+        MirrorChannel("ghproxy.net", "https://ghproxy.net/"),
+        MirrorChannel("gh.llkk.cc", "https://gh.llkk.cc/"),
+        MirrorChannel("ghps.cc", "https://ghps.cc/"),
+        MirrorChannel("gh-proxy.ygxz.in", "https://gh-proxy.ygxz.in/"),
+        MirrorChannel("gh.jiasu.in", "https://gh.jiasu.in/"),
+        MirrorChannel("gh.zwy.one", "https://gh.zwy.one/"),
+        MirrorChannel("gh.idayer.com", "https://gh.idayer.com/"),
+        MirrorChannel("ghproxy.1888866.xyz", "https://ghproxy.1888866.xyz/"),
+        MirrorChannel("gh.con.sh", "https://gh.con.sh/"),
+        MirrorChannel("mirror.ghproxy.com", "https://mirror.ghproxy.com/"),
+        MirrorChannel("github.91chi.fun", "https://github.91chi.fun/")
     )
+
+    /** Everything a download may try, direct route last in declaration order. */
+    val ALL_CHANNELS: List<MirrorChannel> = CN_PROXIES + MirrorChannel.DIRECT
 
     const val NPM_REGISTRY = "https://registry.npmjs.org"
     const val NPM_MIRROR_REGISTRY = "https://registry.npmmirror.com"
 
     /**
-     * Bandwidth-ordered CN proxy URLs for a GitHub release asset, with the
-     * direct URL as the final fallback. Non-CN or non-GitHub URLs come back
+     * Latency-ordered candidate URLs for a GitHub release asset, with the
+     * plain URL as the final fallback. Non-CN or non-GitHub URLs come back
      * unchanged so callers can pass any URL through.
+     *
+     * The first call of a session blocks for one bounded probe round
+     * ([CnMirrorProbe.ACCEPTABLE_LATENCY_MS] gate, cached for five minutes);
+     * later calls read the cached order.
      */
     fun proxiedCn(url: String): List<String> {
         if (!url.startsWith("https://github.com/")) return listOf(url)
-        return CnMirrorProbe.getOrderedProxies(CN_PROXIES).map { proxy -> proxy + url } + url
+        val ordered = CnMirrorProbe.orderedChannels()
+        return (ordered.map { it.rewrite(url) } + url).distinct()
     }
 
     /**

--- a/app/src/main/java/com/webtoapp/core/network/NetworkModule.kt
+++ b/app/src/main/java/com/webtoapp/core/network/NetworkModule.kt
@@ -22,6 +22,9 @@ object NetworkModule {
     val defaultClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
             .connectionPool(sharedConnectionPool)
+            // Pinned GitHub IPs first, system resolver right behind them, so a
+            // stale entry costs one failed connect instead of a dead download.
+            .dns(GitHubHostsDns)
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)

--- a/app/src/test/java/com/webtoapp/core/network/GitHubHostsTest.kt
+++ b/app/src/test/java/com/webtoapp/core/network/GitHubHostsTest.kt
@@ -1,0 +1,51 @@
+package com.webtoapp.core.network
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GitHubHostsTest {
+
+    @Test
+    fun `pinned hosts cover the domains release downloads traverse`() {
+        listOf(
+            "github.com",
+            "codeload.github.com",
+            "objects.githubusercontent.com",
+            "raw.githubusercontent.com",
+            "github-production-release-asset-2e65be.s3.amazonaws.com"
+        ).forEach { host ->
+            assertThat(GitHubHosts.lookup(host)).isNotEmpty()
+        }
+    }
+
+    @Test
+    fun `unknown hosts resolve to nothing`() {
+        assertThat(GitHubHosts.lookup("example.invalid")).isEmpty()
+        assertThat(GitHubHosts.covers("example.invalid")).isFalse()
+    }
+
+    @Test
+    fun `dns puts the pinned address first and keeps a system fallback`() {
+        val resolved = GitHubHostsDns.lookup("github.com")
+        assertThat(resolved).isNotEmpty()
+        assertThat(resolved.first().hostAddress).isEqualTo("20.205.243.166")
+        // A stale pinned IP must never be the only answer: whatever the system
+        // resolver says stays in the list behind it.
+        assertThat(resolved.map { it.hostAddress }).containsAtLeastElementsIn(
+            GitHubHosts.lookup("github.com").map { it.hostAddress }
+        )
+    }
+
+    @Test
+    fun `dns passes unknown hosts straight to the system resolver`() {
+        val resolved = runCatching { GitHubHostsDns.lookup("localhost") }.getOrNull()
+        if (resolved != null) {
+            assertThat(resolved).isNotEmpty()
+        }
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/network/GitHubMirrorTest.kt
+++ b/app/src/test/java/com/webtoapp/core/network/GitHubMirrorTest.kt
@@ -12,13 +12,37 @@ class GitHubMirrorTest {
 
     @Test
     fun `proxiedCn expands a github release asset with direct fallback`() {
-        val urls = GitHubMirror.proxiedCn("https://github.com/oct/x/releases/download/v1/a.zip")
+        val asset = "https://github.com/oct/x/releases/download/v1/a.zip"
+        val urls = GitHubMirror.proxiedCn(asset)
         assertThat(urls).hasSize(GitHubMirror.CN_PROXIES.size + 1)
-        // No probe cache in tests: base order (proxies first), direct last.
+        // No probe cache in tests: declaration order (proxies first), direct last.
         GitHubMirror.CN_PROXIES.forEachIndexed { i, proxy ->
-            assertThat(urls[i]).isEqualTo(proxy + "https://github.com/oct/x/releases/download/v1/a.zip")
+            assertThat(urls[i]).isEqualTo(proxy.rewrite(asset))
         }
-        assertThat(urls.last()).isEqualTo("https://github.com/oct/x/releases/download/v1/a.zip")
+        assertThat(urls.last()).isEqualTo(asset)
+    }
+
+    @Test
+    fun `direct channel leaves the url untouched`() {
+        val asset = "https://github.com/oct/x/releases/download/v1/a.zip"
+        assertThat(GitHubMirror.MirrorChannel.DIRECT.rewrite(asset)).isEqualTo(asset)
+    }
+
+    @Test
+    fun `every proxy channel rewrites to a prefix url`() {
+        val asset = "https://github.com/oct/x/releases/download/v1/a.zip"
+        GitHubMirror.CN_PROXIES.forEach { channel ->
+            val rewritten = channel.rewrite(asset)
+            assertThat(rewritten).startsWith(channel.prefix)
+            assertThat(rewritten).endsWith(asset)
+        }
+    }
+
+    @Test
+    fun `channel pool has no duplicate ids`() {
+        val ids = GitHubMirror.ALL_CHANNELS.map { it.id }
+        assertThat(ids).containsNoDuplicates()
+        assertThat(ids).contains("direct")
     }
 
     @Test


### PR DESCRIPTION
Runtime downloads (PHP, Python, Node, Composer) tried two hard-coded accelerators in declaration order. When those two were unreachable the download failed outright, even though other routes were fine.

## Picking a route by measurement, not by declaration

- The pool grows from 2 prefix accelerators to 13, plus the direct route.
- `CnMirrorProbe` measures **time-to-first-byte** on a real release asset for every channel **concurrently**, discards anything slower than 1000 ms, and orders the rest fastest-first. Concurrency is the point: a round costs roughly the slowest single timeout, not the sum of all of them.
- Results are cached for 5 minutes, so repeated downloads in a session measure once instead of stalling every time.
- A round where every channel is lost is **not** cached and falls back to declaration order. The probe only ever reorders — it cannot shrink the set of routes a download will try, so a bad measurement can never strand a download.
- `GitHubMirror.proxiedCn` stays the single funnel, so all four runtime downloaders inherit this with no changes of their own.

## Pinned GitHub hosts

Adds the GitHub520 IP table (40 domains, snapshot 2026-08-29) covering `github.com`, `codeload`, `objects.githubusercontent.com`, `raw.githubusercontent.com` and the release-asset S3 hosts — the whole chain a release download redirects through.

It is wired in as an OkHttp `Dns` that returns **the pinned address first and the system resolver's answer right behind it**. OkHttp tries them in order, so a pinned IP GitHub has since rotated costs one failed connect and nothing more. That fallback is the whole reason shipping static IPs is acceptable here.

The custom `Dns` sits on `NetworkModule.defaultClient`, from which the download and streaming clients are derived, so the direct route benefits globally.

## Testing

- New `GitHubHostsTest`: key download domains are covered, unknown hosts pass straight through, the pinned address comes first and the system answer is retained behind it.
- `GitHubMirrorTest` updated for the channel model, plus cases for the direct route, prefix rewriting, and duplicate channel ids.
- Full suite: 956 tests, 0 failures.