### PR TITLE
docs(activation): add a deployable Cloudflare Worker reference server

### DIFF
--- a/.github/docs/remote-activation.md
+++ b/.github/docs/remote-activation.md
@@ -195,6 +195,26 @@ openssl ecparam -name prime256v1 -genkey -noout -out ec_private.pem
 openssl ec -in ec_private.pem -pubout -out ec_public.pem
 ```
 
+## Ready-to-deploy option (Cloudflare Worker)
+
+If you would rather not run a server at all, there is a complete reference
+worker in
+[`examples/remote-activation-worker/`](../../examples/remote-activation-worker/README.md):
+codes held in Workers KV (revocable without rebuilding the APK), signed
+responses, device binding, optional AES-256-GCM URL delivery, and a
+`GET /` self-check that hands you the public key to paste into the app. It
+deploys with `npx wrangler deploy` and ships a test that verifies responses the
+way the client does.
+
+One caveat it documents, because it applies to any server you write: **the
+request does not say whether the app expects a delivered URL**, so the server
+cannot discover it. A code that carries a `url` must be paired with an app that
+has "Deliver target URL" enabled, and a code without one with an app that has it
+disabled — otherwise the two sides sign different payloads and every activation
+fails.
+
+The Node example below is the same contract for your own infrastructure.
+
 ## Reference server (Node.js, no framework)
 
 ```js

--- a/examples/remote-activation-worker/README.md
+++ b/examples/remote-activation-worker/README.md
@@ -1,0 +1,136 @@
+# Remote activation — reference verification server
+
+A Cloudflare Worker that speaks the contract described in
+[`.github/docs/remote-activation.md`](../../.github/docs/remote-activation.md).
+It is the "I don't want to build a backend" answer to remote activation: copy,
+paste, deploy.
+
+What you get:
+
+- Codes held in Workers KV, revocable and rotatable without rebuilding an APK
+- Every response signed with **EC P-256 / SHA-256**, so a fake server or a
+  man-in-the-middle cannot forge an `ok: true`
+- Nonce echo (replay protection) and device binding for one-seat codes
+- Optional dynamic URL delivery, with or without AES-256-GCM encryption
+
+## 1. Generate a signing key
+
+The app verifies responses with the public half; the Worker signs with the
+private half.
+
+```bash
+# private key, PKCS#8, single-line Base64 — this is the Worker's SIGNING_KEY
+openssl ecparam -genkey -name prime256v1 -noout -out ec.pem
+openssl pkcs8 -topk8 -nocrypt -in ec.pem -out ec-pkcs8.pem
+openssl base64 -A -in ec-pkcs8.pem -out ec-pkcs8.b64
+
+# public key, SPKI — this goes into the app's "Signature public key" field
+openssl ec -in ec.pem -pubout -out ec-pub.pem
+openssl base64 -A -in ec-pub.pem -out ec-pub.b64
+```
+
+Keep `ec.pem` and `ec-pkcs8.b64` out of git. The public key is not a secret.
+
+## 2. Deploy
+
+```bash
+cd examples/remote-activation-worker
+npm install
+
+npx wrangler login
+npm run kv:create          # paste the printed id into wrangler.toml
+
+npx wrangler secret put SIGNING_KEY < ec-pkcs8.b64
+npx wrangler deploy
+```
+
+Then open the deployed URL in a browser. A healthy worker answers:
+
+```json
+{
+  "ok": true,
+  "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE…",
+  "keyFingerprint": "3f9a1c02…",
+  "urlEncryption": "disabled",
+  "problems": []
+}
+```
+
+`publicKey` is the SPKI Base64 of your key — paste it straight into the app's
+**Signature public key** field. If `problems` is not empty, the worker will not
+verify anything and will say why.
+
+## 3. Add codes
+
+One KV entry per code. The key is `code:` followed by the uppercased code.
+
+```bash
+# unlimited activations
+npx wrangler kv:key put --binding=ACTIVATION_CODES "code:DEMO1234" \
+  '{"note":"demo"}'
+
+# expires at a fixed date (epoch millis)
+npx wrangler kv:key put --binding=ACTIVATION_CODES "code:YEAR2027" \
+  '{"expiresAt":1798761600000,"maxDevices":1,"devices":[]}'
+
+# locked to one package, delivering an encrypted target URL
+npx wrangler kv:key put --binding=ACTIVATION_CODES "code:VIP0001" \
+  '{"packageName":"com.example.app","url":"https://example.com/target","encryptUrl":true}'
+```
+
+`encryptUrl` requires an AES key on the worker:
+
+```bash
+openssl rand -base64 32 | tr -d '\n' | xargs -0 npx wrangler secret put AES_KEY
+```
+
+### Code record fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `expiresAt` | number \| null | Absolute expiry, epoch millis. Omit for never. |
+| `maxDevices` | number | Seats, enforced only when the app sends `deviceBound: true`. Default 1. |
+| `devices` | string[] | Device ids that have redeemed this code. Maintained by the worker. |
+| `packageName` | string \| null | If set, the code only works for that package. |
+| `url` | string \| null | Enables URL delivery. See the caveat below. |
+| `encryptUrl` | boolean | AES-256-GCM encrypt `url`. Requires `AES_KEY`. |
+| `message` | string | Returned to the client on success. |
+| `note` | string | Your own bookkeeping; never leaves the server. |
+
+## Two things to know before you go live
+
+**URL delivery is configured on both sides, and they must agree.** The request
+the app sends does not say whether it expects a delivered URL, so the worker
+cannot tell. The rule is therefore: a code with a `url` is for an app with
+**Deliver target URL** enabled, and a code without one is for an app with it
+disabled. Mismatched, the signature check fails on every activation, because the
+app and the server disagree about whether the URL is part of the signed payload.
+
+**Workers KV is eventually consistent and has no compare-and-swap.** Two devices
+redeeming the last seat of a device-bound code in the same instant can both
+succeed. For most apps this is an acceptable risk at this scale; if it is not for
+yours, move the record store to D1 or a Durable Object — the signing path is
+unchanged, only `get`/`put` differ.
+
+## Verifying your changes
+
+`test/protocol-check.mjs` drives the real worker with a mock KV and verifies each
+response the way the Android client does — same payload construction, same
+ECDSA P-256 check in P1363 form, same AES-GCM wire format.
+
+```bash
+npm run check
+```
+
+It is the fastest way to catch a change that would silently break every
+installed app.
+
+## Protocol details worth not breaking
+
+Both live in `RemoteActivationVerifier.kt` on the app side, and both are
+reproduced in `src/index.js`:
+
+1. The signature field is **`sig`**, not `signature`.
+2. The signed payload has a fixed key order — `ok`, `expiresAt`,
+   `remainingUses`, `nonce`, then `url` when URL delivery is on — with `null`
+   collapsed to `0` for `expiresAt` and `-1` for `remainingUses`.

--- a/examples/remote-activation-worker/package.json
+++ b/examples/remote-activation-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "webtoapp-activation-worker",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Reference remote-activation verification server for WebToApp (Cloudflare Worker)",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "check": "node test/protocol-check.mjs",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "kv:create": "wrangler kv:namespace create ACTIVATION_CODES"
+  },
+  "devDependencies": {
+    "wrangler": "^3.78.0"
+  }
+}

--- a/examples/remote-activation-worker/src/index.js
+++ b/examples/remote-activation-worker/src/index.js
@@ -1,0 +1,278 @@
+/**
+ * WebToApp remote activation — reference verification server (Cloudflare Worker).
+ *
+ * Speaks the contract documented in `.github/docs/remote-activation.md` and
+ * implemented client-side by `RemoteActivationVerifier.kt`. Two details in that
+ * contract are easy to get wrong and will fail every activation if you do:
+ *
+ *   1. The signature field is `sig`, not `signature`.
+ *   2. The signed payload is a JSON object whose keys are emitted in a fixed
+ *      order — ok, expiresAt, remainingUses, nonce, then url — with null
+ *      collapsed to 0 (expiresAt) and -1 (remainingUses). The client rebuilds
+ *      the exact same string and verifies it, so a different key order or a
+ *      different null fallback produces a signature mismatch.
+ *
+ * Storage is Workers KV. That is eventual-consistent and has no compare-and-
+ * swap, so two devices redeeming the last seat of a device-bound code at the
+ * same instant can both succeed. For anything where that matters, move the
+ * record store to D1 or a Durable Object; the signing path is unchanged.
+ */
+
+const JSON_HEADERS = { "content-type": "application/json; charset=utf-8" };
+const DEFAULT_CLOCK_SKEW_MS = 24 * 60 * 60 * 1000;
+
+export default {
+  async fetch(request, env) {
+    if (request.method === "GET") return handleStatus(env);
+    if (request.method === "POST") return handleVerify(request, env);
+    return json({ error: "method not allowed" }, 405);
+  },
+};
+
+/** GET / — config self-check. Never exposes the private key itself. */
+async function handleStatus(env) {
+  const problems = [];
+  if (!env.SIGNING_KEY) problems.push("SIGNING_KEY is not set");
+  if (!env.ACTIVATION_CODES) problems.push("ACTIVATION_CODES KV namespace is not bound");
+
+  let publicKey = null;
+  let fingerprint = null;
+  if (env.SIGNING_KEY) {
+    try {
+      const spki = await publicSpki(await importSigningKey(env.SIGNING_KEY));
+      // Hand back the public half so it can be pasted straight into the app's
+      // "Signature public key" field. A public key is not a secret.
+      publicKey = bytesToBase64(new Uint8Array(spki));
+      fingerprint = await fingerprintOf(spki);
+    } catch (error) {
+      problems.push(`SIGNING_KEY is not a usable PKCS#8 EC P-256 key (${error.message})`);
+    }
+  }
+
+  return json({
+    ok: problems.length === 0,
+    publicKey,
+    keyFingerprint: fingerprint,
+    urlEncryption: env.AES_KEY ? "enabled" : "disabled",
+    problems,
+  });
+}
+
+async function handleVerify(request, env) {
+  if (!env.SIGNING_KEY) return json({ error: "server misconfigured: SIGNING_KEY missing" }, 500);
+  if (!env.ACTIVATION_CODES) {
+    return json({ error: "server misconfigured: ACTIVATION_CODES not bound" }, 500);
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "invalid JSON body" }, 400);
+  }
+
+  const code = String(body.code ?? "").trim().toUpperCase();
+  const deviceId = String(body.deviceId ?? "");
+  const nonce = String(body.nonce ?? "");
+  const packageName = String(body.packageName ?? "");
+  const deviceBound = body.deviceBound === true;
+  const timestamp = Number(body.ts);
+
+  if (!code || !nonce) return json({ error: "code and nonce are required" }, 400);
+
+  const skew = Number(env.MAX_CLOCK_SKEW_MS ?? DEFAULT_CLOCK_SKEW_MS);
+  if (Number.isFinite(timestamp) && skew > 0) {
+    const drift = Math.abs(Date.now() - timestamp);
+    if (drift > skew) {
+      // Not an error the client recovers from: it caches nothing, so the user
+      // just sees the rejection message. Keeps stolen requests from replaying.
+      return signed(env, {
+        ok: false,
+        message: "request timestamp too far from server time",
+        nonce,
+      });
+    }
+  }
+
+  const record = await env.ACTIVATION_CODES.get(`code:${code}`, { type: "json" });
+  if (!record) {
+    return signed(env, { ok: false, message: "unknown code", nonce });
+  }
+
+  if (record.expiresAt && Date.now() > record.expiresAt) {
+    return signed(env, { ok: false, message: "code expired", nonce, expiresAt: record.expiresAt });
+  }
+
+  if (record.packageName && packageName && record.packageName !== packageName) {
+    return signed(env, { ok: false, message: "code not valid for this app", nonce });
+  }
+
+  let remainingUses = null;
+  if (deviceBound) {
+    const maxDevices = record.maxDevices ?? 1;
+    const devices = Array.isArray(record.devices) ? record.devices : [];
+    if (!devices.includes(deviceId) && devices.length >= maxDevices) {
+      return signed(env, {
+        ok: false,
+        message: "code already in use on another device",
+        nonce,
+        expiresAt: record.expiresAt ?? null,
+      });
+    }
+    if (!devices.includes(deviceId)) {
+      record.devices = [...devices, deviceId];
+      await env.ACTIVATION_CODES.put(`code:${code}`, JSON.stringify(record));
+    }
+    remainingUses = Math.max(0, maxDevices - record.devices.length);
+  }
+
+  // The request carries no flag telling us whether the app expects a delivered
+  // URL, so the code record is the source of truth: a record with `url` must be
+  // paired with an app that has "Deliver target URL" enabled, and a record
+  // without one with an app that has it disabled. See the README.
+  const includeUrl = typeof record.url === "string" && record.url.length > 0;
+  let url = null;
+  if (includeUrl) {
+    if (record.encryptUrl) {
+      if (!env.AES_KEY) {
+        return json({ error: "code requires URL encryption but AES_KEY is not set" }, 500);
+      }
+      url = await encryptUrl(record.url, env.AES_KEY);
+    } else {
+      url = record.url;
+    }
+  }
+
+  return signed(env, {
+    ok: true,
+    message: record.message ?? "",
+    nonce,
+    expiresAt: record.expiresAt ?? null,
+    remainingUses,
+    includeUrl,
+    url,
+  });
+}
+
+/**
+ * Builds the response and signs it. `includeUrl` decides whether the URL joins
+ * the signed payload, which must match the client's own deliverUrl setting.
+ */
+async function signed(env, options) {
+  const {
+    ok,
+    message = "",
+    nonce,
+    expiresAt = null,
+    remainingUses = null,
+    includeUrl = false,
+    url = null,
+  } = options;
+
+  const payload = canonicalSignedPayload({ ok, expiresAt, remainingUses, nonce, includeUrl, url });
+  const signature = await signPayload(env.SIGNING_KEY, payload);
+
+  const response = { ok, expiresAt, remainingUses, message, nonce, sig: signature };
+  if (includeUrl) response.url = url;
+  return json(response);
+}
+
+/**
+ * Byte-for-byte reproduction of `RemoteActivationVerifier.canonicalSignedPayload`.
+ * Built by hand rather than with JSON.stringify so the key order and the null
+ * fallbacks cannot drift from the client.
+ */
+function canonicalSignedPayload({ ok, expiresAt, remainingUses, nonce, includeUrl, url }) {
+  const fields = [
+    `"ok":${ok === true}`,
+    `"expiresAt":${expiresAt == null ? 0 : Math.trunc(expiresAt)}`,
+    `"remainingUses":${remainingUses == null ? -1 : Math.trunc(remainingUses)}`,
+    `"nonce":${JSON.stringify(nonce)}`,
+  ];
+  if (includeUrl) fields.push(`"url":${JSON.stringify(url ?? "")}`);
+  return `{${fields.join(",")}}`;
+}
+
+async function signPayload(privateKeyBase64, payload) {
+  const key = await importSigningKey(privateKeyBase64);
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    key,
+    new TextEncoder().encode(payload)
+  );
+  // WebCrypto emits P1363 (r || s), which is what Java's SHA256withECDSA expects.
+  return bytesToBase64(new Uint8Array(signature));
+}
+
+async function importSigningKey(privateKeyBase64) {
+  return crypto.subtle.importKey(
+    "pkcs8",
+    base64ToBytes(privateKeyBase64),
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign"]
+  );
+}
+
+/**
+ * SPKI encoding of the public half of a signing key.
+ *
+ * Goes through JWK rather than exporting "spki" from the private key directly:
+ * that form is rejected by some WebCrypto implementations (Node, notably).
+ */
+async function publicSpki(privateKey) {
+  const jwk = await crypto.subtle.exportKey("jwk", privateKey);
+  const publicKey = await crypto.subtle.importKey(
+    "jwk",
+    { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y },
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["verify"]
+  );
+  return crypto.subtle.exportKey("spki", publicKey);
+}
+
+async function fingerprintOf(spki) {
+  const digest = await crypto.subtle.digest("SHA-256", spki);
+  return [...new Uint8Array(digest).slice(0, 8)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Wire format: Base64(IV[12] || ciphertext || GCM tag[16]). */
+async function encryptUrl(plaintext, aesKeyBase64) {
+  const key = await crypto.subtle.importKey("raw", base64ToBytes(aesKeyBase64), "AES-GCM", false, [
+    "encrypt",
+  ]);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encrypted = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      key,
+      new TextEncoder().encode(plaintext)
+    )
+  );
+  // WebCrypto already appends the tag to the ciphertext.
+  const combined = new Uint8Array(iv.length + encrypted.length);
+  combined.set(iv, 0);
+  combined.set(encrypted, iv.length);
+  return bytesToBase64(combined);
+}
+
+function base64ToBytes(base64) {
+  const cleaned = String(base64).replace(/\s+/g, "");
+  const binary = atob(cleaned);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToBase64(bytes) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}

--- a/examples/remote-activation-worker/test/protocol-check.mjs
+++ b/examples/remote-activation-worker/test/protocol-check.mjs
@@ -1,0 +1,285 @@
+/**
+ * Protocol conformance check: drive the real Worker with a mock KV and verify
+ * the response the way the Android client does.
+ *
+ * The client path being reproduced is RemoteActivationVerifier.verifySignature:
+ *   - the signed payload is rebuilt from the response fields
+ *   - the signature is ECDSA / SHA-256 / P-256 in P1363 (r || s) form, which is
+ *     what Java's "SHA256withECDSA" consumes
+ *   - the nonce must match the one the request sent
+ *
+ * Run with: npm run check   (or: node test/protocol-check.mjs)
+ */
+
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { webcrypto } from "node:crypto";
+import worker from "../src/index.js";
+
+// Node 18 exposes WebCrypto globally, but be explicit in case it is stripped.
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+const tests = [];
+function test(name, fn) {
+  tests.push([name, fn]);
+}
+
+/** Minimal Workers KV stand-in. */
+function mockKv(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    async get(key, options) {
+      const value = store.get(key);
+      if (value === undefined) return null;
+      return options?.type === "json" ? JSON.parse(value) : value;
+    },
+    async put(key, value) {
+      store.set(key, value);
+    },
+  };
+}
+
+async function generateSigningKey() {
+  const pair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const pkcs8 = Buffer.from(await crypto.subtle.exportKey("pkcs8", pair.privateKey)).toString(
+    "base64"
+  );
+  const spki = Buffer.from(await crypto.subtle.exportKey("spki", pair.publicKey));
+  return { pkcs8, spki };
+}
+
+function publicKeyFromSpki(spki) {
+  return crypto.createPublicKey({ key: spki, format: "der", type: "spki" });
+}
+
+/**
+ * Rebuilds the payload exactly as RemoteActivationVerifier.canonicalSignedPayload
+ * does on the client, then verifies the signature from the response.
+ */
+function verifyLikeClient(publicKey, response, expectedNonce, includeUrl) {
+  assert.ok(response.sig, "response is missing the `sig` field");
+  assert.equal(response.nonce, expectedNonce, "nonce was not echoed back");
+
+  const fields = [
+    `"ok":${response.ok === true}`,
+    `"expiresAt":${response.expiresAt == null ? 0 : Math.trunc(response.expiresAt)}`,
+    `"remainingUses":${response.remainingUses == null ? -1 : Math.trunc(response.remainingUses)}`,
+    `"nonce":${JSON.stringify(response.nonce)}`,
+  ];
+  if (includeUrl) fields.push(`"url":${JSON.stringify(response.url ?? "")}`);
+
+  const payload = `{${fields.join(",")}}`;
+  const signature = Buffer.from(response.sig, "base64");
+  return crypto.verify(
+    "sha256",
+    Buffer.from(payload, "utf8"),
+    { key: publicKey, dsaEncoding: "ieee-p1363" },
+    signature
+  );
+}
+
+/** Mirrors RemoteActivationVerifier.decryptUrl: Base64(IV[12] || ct || tag[16]). */
+function decryptUrlLikeClient(encryptedBase64, aesKeyBase64) {
+  const combined = Buffer.from(encryptedBase64, "base64");
+  const iv = combined.subarray(0, 12);
+  const tag = combined.subarray(combined.length - 16);
+  const ciphertext = combined.subarray(12, combined.length - 16);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", Buffer.from(aesKeyBase64, "base64"), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}
+
+async function post(body, env) {
+  const response = await worker.fetch(
+    new Request("https://activation.example.com/verify", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env
+  );
+  return { status: response.status, body: await response.json() };
+}
+
+test("a valid code produces a signature the client accepts", async () => {
+  const { pkcs8, spki } = await generateSigningKey();
+  const expiresAt = Date.now() + 86_400_000;
+  const env = {
+    SIGNING_KEY: pkcs8,
+    ACTIVATION_CODES: mockKv({
+      "code:DEMO1234": JSON.stringify({ expiresAt, maxDevices: 1, devices: [] }),
+    }),
+  };
+
+  const { status, body } = await post(
+    { code: "demo1234", deviceId: "device-a", packageName: "com.example.app", nonce: "nonce-1", ts: Date.now() },
+    env
+  );
+
+  assert.equal(status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.expiresAt, expiresAt);
+  assert.ok(verifyLikeClient(publicKeyFromSpki(spki), body, "nonce-1", false));
+});
+
+test("unknown code is signed as a rejection rather than failing open", async () => {
+  const { pkcs8, spki } = await generateSigningKey();
+  const env = { SIGNING_KEY: pkcs8, ACTIVATION_CODES: mockKv() };
+
+  const { body } = await post({ code: "NOPE", deviceId: "d", nonce: "nonce-2", ts: Date.now() }, env);
+
+  assert.equal(body.ok, false);
+  assert.ok(verifyLikeClient(publicKeyFromSpki(spki), body, "nonce-2", false));
+});
+
+test("an expired code is rejected", async () => {
+  const { pkcs8, spki } = await generateSigningKey();
+  const env = {
+    SIGNING_KEY: pkcs8,
+    ACTIVATION_CODES: mockKv({
+      "code:OLD": JSON.stringify({ expiresAt: Date.now() - 1000 }),
+    }),
+  };
+
+  const { body } = await post({ code: "OLD", deviceId: "d", nonce: "nonce-3", ts: Date.now() }, env);
+
+  assert.equal(body.ok, false);
+  assert.match(body.message, /expired/);
+  assert.ok(verifyLikeClient(publicKeyFromSpki(spki), body, "nonce-3", false));
+});
+
+test("a device-bound code rejects a second device", async () => {
+  const { pkcs8, spki } = await generateSigningKey();
+  const env = {
+    SIGNING_KEY: pkcs8,
+    ACTIVATION_CODES: mockKv({
+      "code:ONESEAT": JSON.stringify({ maxDevices: 1, devices: ["device-a"] }),
+    }),
+  };
+
+  const first = await post({ code: "ONESEAT", deviceId: "device-a", nonce: "n-a", ts: Date.now(), deviceBound: true }, env);
+  assert.equal(first.body.ok, true, "the bound device may re-verify");
+  assert.equal(first.body.remainingUses, 0);
+  assert.ok(verifyLikeClient(publicKeyFromSpki(spki), first.body, "n-a", false));
+
+  const second = await post({ code: "ONESEAT", deviceId: "device-b", nonce: "n-b", ts: Date.now(), deviceBound: true }, env);
+  assert.equal(second.body.ok, false);
+  assert.match(second.body.message, /another device/);
+  assert.ok(verifyLikeClient(publicKeyFromSpki(spki), second.body, "n-b", false));
+});
+
+test("a delivered url is inside the signed payload", async () => {
+  const { pkcs8, spki } = await generateSigningKey();
+  const env = {
+    SIGNING_KEY: pkcs8,
+    ACTIVATION_CODES: mockKv({
+      "code:WITHURL": JSON.stringify({ url: "https://example.com/target" }),
+    }),
+  };
+
+  const { body } = await post({ code: "WITHURL", deviceId: "d", nonce: "nonce-4", ts: Date.now() }, env);
+
+  assert.equal(body.ok, true);
+  assert.equal(body.url, "https://example.com/target");
+  // Client has Deliver URL enabled, so its payload includes the url field.
+  assert.ok(verifyLikeClient(publicKeyFromSpki(spki), body, "nonce-4", true));
+  // And the legacy payload (without url) must NOT verify — proving the url is
+  // actually protected and not merely riding along unsigned.
+  assert.equal(verifyLikeClient(publicKeyFromSpki(spki), body, "nonce-4", false), false);
+});
+
+test("an encrypted url decrypts with the format the client expects", async () => {
+  const { pkcs8, spki } = await generateSigningKey();
+  const aesKey = crypto.randomBytes(32).toString("base64");
+  const env = {
+    SIGNING_KEY: pkcs8,
+    AES_KEY: aesKey,
+    ACTIVATION_CODES: mockKv({
+      "code:SECURE": JSON.stringify({ url: "https://example.com/secret", encryptUrl: true }),
+    }),
+  };
+
+  const { body } = await post({ code: "SECURE", deviceId: "d", nonce: "nonce-5", ts: Date.now() }, env);
+
+  assert.equal(body.ok, true);
+  assert.notEqual(body.url, "https://example.com/secret", "url must not be sent in the clear");
+  assert.ok(verifyLikeClient(publicKeyFromSpki(spki), body, "nonce-5", true));
+  assert.equal(decryptUrlLikeClient(body.url, aesKey), "https://example.com/secret");
+});
+
+test("a stale timestamp is rejected", async () => {
+  const { pkcs8, spki } = await generateSigningKey();
+  const env = {
+    SIGNING_KEY: pkcs8,
+    MAX_CLOCK_SKEW_MS: "60000",
+    ACTIVATION_CODES: mockKv({ "code:FRESH": JSON.stringify({}) }),
+  };
+
+  const stale = Date.now() - 3_600_000;
+  const { body } = await post({ code: "FRESH", deviceId: "d", nonce: "nonce-6", ts: stale }, env);
+
+  assert.equal(body.ok, false);
+  assert.match(body.message, /timestamp/);
+  assert.ok(verifyLikeClient(publicKeyFromSpki(spki), body, "nonce-6", false));
+});
+
+test("GET returns a usable public key and no secrets", async () => {
+  const { pkcs8, spki } = await generateSigningKey();
+  const response = await worker.fetch(new Request("https://activation.example.com/"), {
+    SIGNING_KEY: pkcs8,
+    ACTIVATION_CODES: mockKv(),
+  });
+  const body = await response.json();
+
+  assert.equal(body.ok, true);
+  assert.deepEqual(body.problems, []);
+  assert.match(body.keyFingerprint, /^[0-9a-f]{16}$/);
+  assert.equal(body.urlEncryption, "disabled");
+
+  // The point of the endpoint: the operator can copy this straight into the
+  // app's "Signature public key" field, so it must be the real counterpart.
+  const returned = crypto.createPublicKey({
+    key: Buffer.from(body.publicKey, "base64"),
+    format: "der",
+    type: "spki",
+  });
+  assert.equal(
+    returned.export({ type: "spki", format: "der" }).toString("base64"),
+    spki.toString("base64"),
+    "GET must return the public half of SIGNING_KEY"
+  );
+
+  assert.equal(JSON.stringify(body).includes(pkcs8), false, "private key must never be returned");
+});
+
+test("GET reports a missing KV binding instead of failing silently", async () => {
+  const { pkcs8 } = await generateSigningKey();
+  const response = await worker.fetch(new Request("https://activation.example.com/"), {
+    SIGNING_KEY: pkcs8,
+  });
+  const body = await response.json();
+
+  assert.equal(body.ok, false);
+  assert.ok(
+    body.problems.some((problem) => problem.includes("ACTIVATION_CODES")),
+    `expected a KV problem, got ${JSON.stringify(body.problems)}`
+  );
+});
+
+let failures = 0;
+for (const [name, fn] of tests) {
+  try {
+    await fn();
+    console.log(`  ok    ${name}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`  FAIL  ${name}\n        ${error.message}`);
+  }
+}
+
+console.log(`\n${tests.length - failures}/${tests.length} passed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/examples/remote-activation-worker/wrangler.toml
+++ b/examples/remote-activation-worker/wrangler.toml
@@ -1,0 +1,20 @@
+name = "webtoapp-activation"
+main = "src/index.js"
+compatibility_date = "2024-09-23"
+
+# Codes live in KV. Create the namespace with:
+#   npx wrangler kv:namespace create ACTIVATION_CODES
+# then paste the returned id into the binding below.
+[[kv_namespaces]]
+binding = "ACTIVATION_CODES"
+id = "REPLACE_WITH_YOUR_KV_NAMESPACE_ID"
+
+[vars]
+# How far the client clock may drift from server time before a request is
+# rejected. Defaults to 24h in code; tighten it if your users keep accurate time.
+MAX_CLOCK_SKEW_MS = "86400000"
+
+# Secrets — set with `npx wrangler secret put <NAME>`, never commit them.
+#
+# SIGNING_KEY       PKCS#8 EC P-256 private key, single-line Base64 (required)
+# AES_KEY           32-byte Base64 key, only when a code sets encryptUrl


### PR DESCRIPTION
Remote verification is the only real answer to the "local activation cannot survive a data wipe" half of #672 — and the thing that keeps people from using it is that they have to stand up a server first. This PR is aimed squarely at that: a reference worker you can deploy with one command.

No production code is touched.

## What's in `examples/remote-activation-worker/`

- Codes in Workers KV, revocable and rotatable without rebuilding an APK.
- Every response signed with EC P-256 / SHA-256, so a fake server or a MITM cannot forge `ok: true`.
- Nonce echo for replay protection, plus device binding for one-seat codes.
- Optional dynamic URL delivery, with or without AES-256-GCM encryption.
- `GET /` is a configuration self-check that reports missing bindings or an unusable key, and returns the SPKI public key so the operator can paste it straight into the app's **Signature public key** field — no openssl round-trip needed.
- A mismatch between the request clock and server time is rejected (configurable skew, default 24h).

## Contract details worth not breaking

Both are easy to get wrong and fail *every* activation silently, so they're called out in the code, the README and the test:

1. The signature field is **`sig`**, not `signature`.
2. The signed payload has a fixed key order — `ok`, `expiresAt`, `remainingUses`, `nonce`, then `url` when URL delivery is on — with `null` collapsed to `0` for `expiresAt` and `-1` for `remainingUses`.

## Verification

`test/protocol-check.mjs` drives the **real worker** with a mock KV — it imports `src/index.js`, so it cannot drift from the deployed code — and verifies each response the way `RemoteActivationVerifier` does: same payload construction, same ECDSA P-256 check in P1363 form, same AES-GCM wire format. 9 cases, `npm run check`.

The interesting one: with URL delivery enabled the legacy payload *without* `url` must **fail** verification. If it passed, the delivered URL would be riding along unprotected rather than covered by the signature.

## Documented constraints

Added to the server contract, because any implementation hits them:

- **The request carries no flag saying whether the app expects a delivered URL**, so the server cannot discover it. A code with a `url` must be paired with an app that has "Deliver target URL" enabled; mismatched, the two sides sign different payloads and every activation fails.
- **Workers KV has no compare-and-swap**, so two devices redeeming the last seat of a device-bound code in the same instant can both succeed. Fine at this scale, but the README says to move to D1 or a Durable Object if it isn't — only `get`/`put` change, the signing path is unaffected.

The existing Node.js reference server stays; this is the "I don't want to run a server" option next to it.