### PR TITLE
fix(ai): stop letting new model generations fall through the fallback

### DIFF
--- a/app/src/main/java/com/webtoapp/core/ai/AiApiClient.kt
+++ b/app/src/main/java/com/webtoapp/core/ai/AiApiClient.kt
@@ -51,18 +51,15 @@ class AiApiClient(private val context: Context) {
 
             val modelsEndpoint = apiKey.getEffectiveModelsEndpoint()
             val fullUrl = buildApiUrl(baseUrl, modelsEndpoint)
-            val displayUrl = when (apiKey.provider) {
-                AiProvider.GOOGLE -> "$fullUrl?key=***"
-                else -> fullUrl
-            }
-
-            AppLogger.i("AiApiClient", "Testing API connection: provider=${apiKey.provider.name}, url=$displayUrl")
+            // The key travels in a header now, so the URL is safe to log as-is.
+            AppLogger.i("AiApiClient", "Testing API connection: provider=${apiKey.provider.name}, url=$fullUrl")
 
             val request = when (apiKey.provider) {
                 AiProvider.GOOGLE -> {
 
                     Request.Builder()
-                        .url("$fullUrl?key=${apiKey.apiKey.trim()}")
+                        .url(fullUrl)
+                        .header("x-goog-api-key", apiKey.apiKey.trim())
                         .get()
                         .build()
                 }
@@ -137,7 +134,8 @@ class AiApiClient(private val context: Context) {
             val request = when (apiKey.provider) {
                 AiProvider.GOOGLE -> {
                     Request.Builder()
-                        .url("$fullUrl?key=${apiKey.apiKey.trim()}")
+                        .url(fullUrl)
+                        .header("x-goog-api-key", apiKey.apiKey.trim())
                         .get()
                         .build()
                 }
@@ -385,15 +383,19 @@ class AiApiClient(private val context: Context) {
             return listOf(ModelCapability.IMAGE_GENERATION)
         }
 
+        // Matched on the family prefix rather than individual generations, so a
+        // new major version does not silently lose capabilities. Listing
+        // "claude-3"/"claude-4" used to drop Claude 5 back to text-only.
         if (id.contains("vision") || id.contains("gpt-4o") || id.contains("gpt-5") ||
-            id.contains("gemini") || id.contains("claude-3") || id.contains("claude-4") ||
+            id.contains("gemini") || id.contains("claude-") ||
             id.contains("pixtral") || id.contains("mistral-large") ||
             id.contains("llava") || id.contains("bakllava") ||
             id.contains("qwen-vl") || id.contains("qwen2-vl") || id.contains("qwen2.5-vl") ||
-            id.contains("glm-4v") || id.contains("step-1v") || id.contains("step-2v") ||
+            id.contains("glm-4v") || id.contains("glm-5") || id.contains("step-1v") || id.contains("step-2v") ||
             id.contains("yi-vision") || id.contains("internvl") ||
             id.contains("moonshot-v") || id.contains("kimi-v") ||
-            id.contains("hunyuan-vision") || id.contains("grok-2-vision") || id.contains("grok-3") ||
+            id.contains("hunyuan-vision") || id.contains("grok-2") ||
+            id.contains("grok-3") || id.contains("grok-4") ||
             id.contains("audio") || id.contains("whisper") || id.contains("realtime")) {
             return listOf(ModelCapability.MULTIMODAL)
         }
@@ -423,7 +425,9 @@ class AiApiClient(private val context: Context) {
             id.contains("gpt-3.5") -> 16000
             id.contains("o1") || id.contains("o3") || id.contains("o4") -> 200000
 
-            id.contains("claude-3") || id.contains("claude-4") -> 200000
+            // Family-prefixed so a new generation inherits the floor instead of
+            // falling through to the 8192 default and truncating every prompt.
+            id.contains("claude-") -> 200000
 
             id.contains("gemini-1.5") || id.contains("gemini-2") || id.contains("gemini-3") -> 1000000
             id.contains("gemini") -> 32000
@@ -439,7 +443,9 @@ class AiApiClient(private val context: Context) {
             id.contains("jamba-1.5") -> 256000
             id.contains("jamba") -> 256000
 
-            id.contains("grok-3") || id.contains("grok-2") -> 131072
+            // Grok 4 ships a longer window than this; 128k is a deliberate floor
+            // because the registry is the authoritative source when it is reachable.
+            id.contains("grok-4") || id.contains("grok-3") || id.contains("grok-2") -> 131072
             id.contains("grok") -> 8192
 
             id.contains("deepseek") -> 64000
@@ -447,6 +453,10 @@ class AiApiClient(private val context: Context) {
             id.contains("qwen-long") || id.contains("qwen-turbo") -> 1000000
             id.contains("qwen2.5") || id.contains("qwen3") -> 131072
             id.contains("qwen") -> 32000
+            // Zhipu is absent from the models.dev catalogue, so GLM models always
+            // land on these fallbacks — getting GLM-5 wrong truncated a 200k
+            // window down to 8192.
+            id.contains("glm-5") -> 200000
             id.contains("glm-4") -> 128000
             id.contains("glm") -> 8192
             id.contains("doubao") -> 32000
@@ -615,7 +625,8 @@ class AiApiClient(private val context: Context) {
         }
 
         val request = Request.Builder()
-            .url("$baseUrl/v1beta/models/$modelId:generateContent?key=$apiKey")
+            .url("$baseUrl/v1beta/models/$modelId:generateContent")
+            .header("x-goog-api-key", apiKey)
             .post(gson.toJson(body).toRequestBody("application/json".toMediaType()))
             .build()
 
@@ -785,7 +796,8 @@ class AiApiClient(private val context: Context) {
         }
 
         val request = Request.Builder()
-            .url("$baseUrl/v1beta/models/$modelId:generateContent?key=$apiKey")
+            .url("$baseUrl/v1beta/models/$modelId:generateContent")
+            .header("x-goog-api-key", apiKey)
             .post(gson.toJson(body).toRequestBody("application/json".toMediaType()))
             .build()
 
@@ -1322,7 +1334,8 @@ val json = gson.fromJson(body, JsonObject::class.java)
         }
 
         return Request.Builder()
-            .url("$baseUrl/v1beta/models/$modelId:streamGenerateContent?alt=sse&key=$apiKey")
+            .url("$baseUrl/v1beta/models/$modelId:streamGenerateContent?alt=sse")
+            .header("x-goog-api-key", apiKey)
             .header("Content-Type", "application/json")
             .post(gson.toJson(body).toRequestBody("application/json".toMediaType()))
             .build()
@@ -1600,7 +1613,8 @@ val json = gson.fromJson(body, JsonObject::class.java)
         }
 
         val request = Request.Builder()
-            .url("$baseUrl/v1beta/models/$modelId:generateContent?key=$apiKey")
+            .url("$baseUrl/v1beta/models/$modelId:generateContent")
+            .header("x-goog-api-key", apiKey)
             .post(gson.toJson(body).toRequestBody("application/json".toMediaType()))
             .build()
 
@@ -2299,7 +2313,8 @@ val json = gson.fromJson(body, JsonObject::class.java)
         }
 
         val request = Request.Builder()
-            .url("$baseUrl/v1beta/models/$modelId:generateContent?key=$apiKey")
+            .url("$baseUrl/v1beta/models/$modelId:generateContent")
+            .header("x-goog-api-key", apiKey)
             .post(gson.toJson(body).toRequestBody("application/json".toMediaType()))
             .build()
 


### PR DESCRIPTION
While checking whether the AI provider endpoints in AI Settings had gone stale, the endpoints turned out to be mostly fine — but the model fallbacks behind them were not.

## The bug

`inferCapabilities` and `inferContextLength` matched on individual generation numbers, so each new generation quietly degraded: it fell through to the `else -> 8192` default and was treated as text-only.

| Model | Configured | Before | After |
| --- | --- | --- | --- |
| `claude-sonnet-5`, `claude-opus-4-8` | 200k | 8192, text-only | 200k, multimodal |
| `glm-5.x` | 200k | 8192 | 200k |
| `grok-4.6`, `grok-4.20` | 128k+ | 8192 | 131072 |

The GLM case is the worst of the three: **Zhipu is absent from the models.dev catalogue**, so GLM models never get a registry hit and always resolve through these fallbacks. A 200k context window was being clipped to 8192 every time.

Fix is to match on the family prefix rather than the generation, so the next generation inherits the floor instead of needing another entry. `grok-4` stays at 131072 deliberately — that is a floor, not a claim about its real window, and the registry remains authoritative whenever it is reachable.

## Also: Gemini key moves to a header

The API key was travelling in the `?key=` query parameter. Google treats that as legacy and recommends the `x-goog-api-key` header instead. Beyond matching current guidance, it keeps the key out of the URL — and therefore out of request logs and anything else that records URLs. The URL-scrubbing branch that existed purely to hide the key from our own logs is now unnecessary and is deleted.

7 call sites: connection test, model list, 4× generateContent, and streamGenerateContent (whose URL keeps `?alt=sse`, just without the key).

## What this deliberately does not do

The audit covered all 15 providers. Notable results:

- **Anthropic** `anthropic-version: 2023-06-01` is still current. New capabilities arrive via opt-in `anthropic-beta` headers, not version bumps — so it is correct as written.
- **Zhipu** `/api/paas/v4/chat/completions` is still valid. It has since added Responses (`/api/v1`) and Anthropic-protocol (`/api/anthropic`) endpoints plus an international site; those would be additions, not fixes.
- **OpenAI** already covers both Chat Completions and Responses.
- **Gemini `generateContent` is now Legacy** — Google made the Interactions API the default recommendation in June 2026. That migration is a breaking rewrite (request becomes `model`+`input`, responses become `id`/`status`/`steps[]`, and the streaming event shape changes entirely), and Interactions does not yet cover everything generateContent does. It is left out of this PR on purpose: it is a decision, not a bug fix.

## Testing

No behaviour is observable from a unit test without network mocking, so this is verified by compilation plus the full suite: **956 tests, 0 failures**. The three `Unchecked cast` warnings in `AiApiClient` are pre-existing.