### PR TITLE
feat(network): route update checks and the module market through the mirror pool

### DIFF
--- a/app/src/main/java/com/webtoapp/core/market/ModuleMarketRepository.kt
+++ b/app/src/main/java/com/webtoapp/core/market/ModuleMarketRepository.kt
@@ -61,7 +61,6 @@ class ModuleMarketRepository private constructor(
             "https://cdn.jsdelivr.net/gh/$OWNER/$REPO@$BRANCH/$MODULES_DIR"
         )
 
-        private const val MIRROR_PREFIX = "https://v4.gh-proxy.org/"
     }
 
     private val gson: Gson = GsonBuilder().setLenient().create()
@@ -283,7 +282,8 @@ class ModuleMarketRepository private constructor(
         if (raw.startsWith("https://") || raw.startsWith("http://")) return raw
 
         val normalised = raw.removePrefix("./").removePrefix("/")
-        return "$MIRROR_PREFIX${SOURCES.first()}/${entry.path}/$normalised"
+        val direct = "${SOURCES.first()}/${entry.path}/$normalised"
+        return com.webtoapp.core.network.GitHubMirror.proxiedCnGitHubHost(direct).first()
     }
 
     val contributingUrl: String =
@@ -291,11 +291,12 @@ class ModuleMarketRepository private constructor(
 
     private fun fetchRaw(relativePath: String): String? {
         for (base in SOURCES) {
-            val mirroredUrl = "$MIRROR_PREFIX$base/$relativePath"
-            fetchOnce(mirroredUrl)?.let { return it }
-
             val directUrl = "$base/$relativePath"
-            fetchOnce(directUrl)?.let { return it }
+            // GitHub hosts get the measured mirror pool; jsDelivr is not a
+            // GitHub host and passes through as a single candidate.
+            for (candidate in com.webtoapp.core.network.GitHubMirror.proxiedCnGitHubHost(directUrl)) {
+                fetchOnce(candidate)?.let { return it }
+            }
         }
         return null
     }

--- a/app/src/main/java/com/webtoapp/core/network/GitHubMirror.kt
+++ b/app/src/main/java/com/webtoapp/core/network/GitHubMirror.kt
@@ -66,6 +66,34 @@ object GitHubMirror {
     }
 
     /**
+     * Same routing as [proxiedCn], but for the smaller GitHub-hosted JSON
+     * fetches that never touch a release asset: `api.github.com` for update
+     * checks and `raw.githubusercontent.com` for the module catalogue.
+     *
+     * Kept separate from [proxiedCn] on purpose. Release downloads are the
+     * paths that were measured and shipped; widening that function's host
+     * match would quietly change where they fetch from. Anything that is not
+     * a GitHub host (jsDelivr, for instance) comes back unchanged.
+     */
+    fun proxiedCnGitHubHost(url: String): List<String> {
+        if (!isGitHubHost(url)) return listOf(url)
+        val ordered = CnMirrorProbe.orderedChannels()
+        return (ordered.map { it.rewrite(url) } + url).distinct()
+    }
+
+    private fun isGitHubHost(url: String): Boolean {
+        val host = url
+            .substringAfter("https://", "")
+            .substringBefore("/")
+            .lowercase()
+        if (host.isEmpty()) return false
+        return host == "github.com" ||
+            host == "api.github.com" ||
+            host.endsWith(".github.com") ||
+            host.endsWith("githubusercontent.com")
+    }
+
+    /**
      * npm registry tarball URLs with the npmmirror CN variant first when
      * [cn] is set; anything not hosted on registry.npmjs.org passes through.
      */

--- a/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
+++ b/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
@@ -14,7 +14,6 @@ object UpdateChecker {
 
     private const val TAG = "UpdateChecker"
 
-    private const val MIRROR_PREFIX = "https://gh-proxy.org/"
     private const val OWNER = "shiaho777"
     private const val REPO = "web-to-app"
     private const val LATEST_RELEASE_API =
@@ -105,8 +104,17 @@ object UpdateChecker {
         data class Failed(val message: String, val throwable: Throwable? = null) : Result()
     }
 
+    /**
+     * Best current route for a GitHub URL. Release assets go through the
+     * measured mirror pool (same routing the runtime downloads use, so an
+     * update APK is not stuck on one hard-coded accelerator); anything else
+     * comes back untouched.
+     *
+     * Single URL rather than a list because the result is carried on [Result]
+     * and handed to the installer, which has no fallback logic of its own.
+     */
     fun withMirror(url: String): String =
-        if (url.startsWith(MIRROR_PREFIX)) url else MIRROR_PREFIX + url
+        com.webtoapp.core.network.GitHubMirror.proxiedCn(url).firstOrNull() ?: url
 
     suspend fun check(currentVersionName: String): Result = withContext(Dispatchers.IO) {
         val current = Version.parse(currentVersionName)
@@ -209,7 +217,7 @@ object UpdateChecker {
     }
 
     private fun fetchLatestReleaseJson(): String? {
-        val candidates = listOf(withMirror(LATEST_RELEASE_API), LATEST_RELEASE_API)
+        val candidates = com.webtoapp.core.network.GitHubMirror.proxiedCnGitHubHost(LATEST_RELEASE_API)
         var lastError: Exception? = null
         for (endpoint in candidates) {
             try {
@@ -224,7 +232,7 @@ object UpdateChecker {
     }
 
     private fun fetchAllReleasesJson(): String? {
-        val candidates = listOf(withMirror(ALL_RELEASES_API), ALL_RELEASES_API)
+        val candidates = com.webtoapp.core.network.GitHubMirror.proxiedCnGitHubHost(ALL_RELEASES_API)
         var lastError: Exception? = null
         for (endpoint in candidates) {
             try {

--- a/app/src/test/java/com/webtoapp/core/network/GitHubMirrorTest.kt
+++ b/app/src/test/java/com/webtoapp/core/network/GitHubMirrorTest.kt
@@ -52,6 +52,34 @@ class GitHubMirrorTest {
     }
 
     @Test
+    fun `api and raw hosts expand like release assets do`() {
+        listOf(
+            "https://api.github.com/repos/shiaho777/web-to-app/releases/latest",
+            "https://raw.githubusercontent.com/shiaho777/web-to-app/main/modules/registry.json",
+            "https://github.com/shiaho777/web-to-app/releases/download/v1/a.apk"
+        ).forEach { url ->
+            val urls = GitHubMirror.proxiedCnGitHubHost(url)
+            assertThat(urls).hasSize(GitHubMirror.CN_PROXIES.size + 1)
+            // The plain URL is always last so there is somewhere to fall back to.
+            assertThat(urls.last()).isEqualTo(url)
+        }
+    }
+
+    @Test
+    fun `cdn hosts are not treated as github hosts`() {
+        val url = "https://cdn.jsdelivr.net/gh/shiaho777/web-to-app@main/modules/registry.json"
+        assertThat(GitHubMirror.proxiedCnGitHubHost(url)).containsExactly(url)
+    }
+
+    @Test
+    fun `release downloads keep using the untouched proxiedCn path`() {
+        // Widen proxiedCn to api.github.com later and this fails: the release
+        // path was measured and shipped, so it should not drift on its own.
+        val api = "https://api.github.com/repos/shiaho777/web-to-app/releases/latest"
+        assertThat(GitHubMirror.proxiedCn(api)).containsExactly(api)
+    }
+
+    @Test
     fun `npmTarballUrls prefers npmmirror only in cn region`() {
         val url = "https://registry.npmjs.org/npm/-/npm-10.9.0.tgz"
         assertThat(GitHubMirror.npmTarballUrls(url, cn = true)).containsExactly(


### PR DESCRIPTION
Follow-up to #687.

That PR gave runtime downloads (PHP, Python, Node, Composer) a route pool ordered by measured latency. Two GitHub fetches were left out, and they happen to be the two a user actually notices when they fail:

- **Checking for an app update** — pointed at one hard-coded accelerator.
- **Loading the module market** — pointed at a different hard-coded accelerator.

Neither hits a release asset, which is why they were skipped. But "not a release asset" was never a good reason to leave them on a single point of failure.

## What changed

New `GitHubMirror.proxiedCnGitHubHost` applies the same measured routing to any GitHub host:

- `api.github.com` — release metadata for the update check
- `raw.githubusercontent.com` — module catalogue and icons
- everything else passes through untouched, so **jsDelivr behaves exactly as it does today**

**It is a separate entry point from `proxiedCn`, deliberately.** Runtime downloads are the path that was measured and shipped; if someone later widened `proxiedCn`'s host match, it would silently change where those downloads fetch from. A test now pins `proxiedCn` to release URLs only, so that cannot happen by accident.

Concretely:

- `UpdateChecker` tries every routed candidate for both release endpoints instead of "one mirror, then direct". Its download URLs now use the fastest measured route rather than a fixed prefix — that path is a release asset, so it belongs in the measured pool.
- `ModuleMarketRepository` routes catalogue and icon fetches the same way.

Both candidate lists still end with the plain URL, so this only ever **adds** fallbacks. Nothing that works today can stop working.

## Testing

Three new cases in `GitHubMirrorTest`:

- `api.github.com` and `raw.githubusercontent.com` expand to the full candidate list, plain URL last
- jsDelivr is not treated as a GitHub host and comes back untouched
- `proxiedCn` still ignores `api.github.com` — the guard described above

Full suite: **959 tests, 0 failures**.