### PR TITLE
chore: bump version to 2.5.5 (versionCode 61)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ rest.
 
 > **English** · [简体中文](#贡献-webtoapp中文)
 
-This guide targets **WebToApp 2.5.4** (`versionCode 60`).
+This guide targets **WebToApp 2.5.5** (`versionCode 61`).
 
 ---
 
@@ -219,7 +219,7 @@ logged and otherwise disregarded.
 非常感谢你愿意花时间。WebToApp 的迭代速度取决于"小而聚焦"的贡献——下面三条路
 里挑一条走，其他的先忽略。
 
-本指南对应 **WebToApp 2.5.4**（`versionCode 60`）。
+本指南对应 **WebToApp 2.5.5**（`versionCode 61`）。
 
 ### 你想做什么？
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
         minSdk = 23
 
         targetSdk = 35
-        versionCode = 60
-        versionName = "2.5.4"
+        versionCode = 61
+        versionName = "2.5.5"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/modules/README.md
+++ b/modules/README.md
@@ -201,7 +201,7 @@ entry mirrors the module manifest plus a `path` (folder name) and a
 
 `minAppVersion` lets you ship a module that needs APIs only present from a
 specific WebToApp `versionCode` onwards — older clients hide the entry.
-The current `versionCode` is **60** (`v2.5.4`); set this only if you
+The current `versionCode` is **61** (`v2.5.5`); set this only if you
 genuinely depend on a newer build.
 
 `iconUrl` is optional. Either a relative path (`"icon.png"`, `"icon.svg"`,

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 60
-        versionName = "2.5.4"
+        versionCode = 61
+        versionName = "2.5.5"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
## Summary

Version bump for the 2.5.5 release cycle: `app`/`shell` gradle `versionCode`/`versionName` (60 -> 61), plus the version references in `CONTRIBUTING.md` (EN + ZH) and `modules/README.md`.

Highlights of the cycle (PRs #646-#691):

- **Toolbar**: the inverted "hide toolbar" model is replaced by a positive **Toolbar** master toggle, with the seven item switches sitting flat in the card (#666, #664, #667, #670)
- **Page zoom**: moved out of the toolbar into Advanced Settings as a build-time per-app setting, superseding the reverted #660 approach (#662, #661, #660)
- **Find in page**: the IME now raises when the bar opens, and backspace is no longer swallowed (#658, #649, #665)
- **Network**: runtime downloads now probe every GitHub route and fetch from the fastest measured one; update checks and the module market go through the same mirror pool (#687, #691)
- **Fixes**: AI model generations falling through the capability fallback (#690), version bump on rebuild and absolute activation expiry (#686), GeckoView `content://` file picking (#657), BGM library persistence (#656), and the pre-API-30 keyboard resize path (#651)

Note: #654 is only half-addressed here — the initial-zoom-in-settings half ships in #662, but true browser-level page zoom (#660) was reverted, so that issue stays open.

## Test plan

- [x] Version references updated in `app/build.gradle.kts`, `shell/build.gradle.kts`, `CONTRIBUTING.md` (EN + ZH), `modules/README.md`
- [ ] CI (`Android CI Build / check`) green on this PR
- [ ] Signed `:app:assembleStandardRelease` APK built locally and attached to the `v2.5.5` release after merge