### PR TITLE
fix(site): keep the hero download pill on its own row without overlapping

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 .vitepress/dist/
+.vitepress/.temp/
 .vitepress/cache/
 *.log

--- a/docs/.vitepress/theme/CustomLayout.vue
+++ b/docs/.vitepress/theme/CustomLayout.vue
@@ -10,7 +10,8 @@ const { frontmatter } = useData()
 <template>
   <Layout>
     <template #home-hero-actions-after>
-      <LatestRelease v-if="frontmatter.layout === 'home' && frontmatter.hero" />
+      <!-- leading space: soft wrap point between .actions and the download pill -->
+      {{ ' ' }}<LatestRelease v-if="frontmatter.layout === 'home' && frontmatter.hero" />
     </template>
   </Layout>
 </template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -274,27 +274,26 @@
 }
 
 /*
- * On homepages the LatestRelease slot sits right after the hero actions
- * container; tuck it into the same row (button then version caption),
- * inheriting the actions row's wrap + centering. The -6px margin cancels
- * .actions' own -6px gutter so the two rows line up seamlessly.
+ * On homepages the LatestRelease slot follows the hero actions container in
+ * the same inline formatting context. Because the shrink-to-fit .main column
+ * is narrower than buttons + pill together, the pill usually wraps to its
+ * own row right below the actions (it stays inline when they do fit);
+ * margin-top minus .actions' -6px bottom margin leaves a small gutter there.
+ * The pill must be inline-flex, not inline: an inline box's line box is
+ * sized by font metrics, so the 40px button bleeds above it into the actions
+ * row — that was the overlap bug. Baseline alignment keeps the pill's text
+ * on the buttons' text baseline when they share a row. Row alignment
+ * (centered below 960px, left above) follows .container's text-align,
+ * matching how VitePress aligns the actions row itself.
  */
+.VPHero .actions {
+  display: inline-flex;
+}
+
 .VPHero .wta-release {
   display: inline-flex;
-  margin: -6px;
-  margin-top: -6px;
-  padding-top: 0;
-  align-self: center;
-}
-
-.VPHero.has-image .wta-release {
-  justify-content: center;
-}
-
-@media (min-width: 960px) {
-  .VPHero.has-image .wta-release {
-    justify-content: flex-start;
-  }
+  vertical-align: baseline;
+  margin-top: 12px;
 }
 
 .wta-release-btn {


### PR DESCRIPTION
## Summary

Follow-up to #685 (part of the #654/#676-#685 docs-site series). The `LatestRelease` download pill still fought the hero actions row:

- `.actions` was left as a block-level flex container, so the pill always wrapped to its own line — but as an *inline* box its line box is sized by font metrics, so the 40px pill bled upwards into the actions row. `.actions` becomes `inline-flex` and the pill becomes `inline-flex` with `vertical-align: baseline`: they share one row when they fit, and the overlap is gone when they don't.
- Drops the `-6px` margin hack that cancelled `.actions`' own gutter; a straight `12px` margin-top supplies the gutter on the wrapped row.
- Row alignment (centered below 960px, left above) now follows `.container`'s `text-align` — the same mechanism VitePress uses for the actions row — instead of duplicating the breakpoint.
- Adds a leading space in the template so the pill has a soft wrap point after the actions instead of being glued to the last button.

Also ignores `.vitepress/.temp/`: VitePress recreates it on every build and it was showing up untracked next to the already-ignored `dist/` and `cache/`.

## Test plan

- [x] `npx vitepress build` completes — bundles built, all 181 pages rendered, no warnings from this change
- [x] Built CSS contains the new rules: `.VPHero .actions{display:inline-flex}` and `.VPHero .wta-release{display:inline-flex;vertical-align:baseline;margin-top:12px}`
- [x] Built `index.html` renders the `wta-release` / `wta-release-btn` pill
- [ ] CI (`docs-deploy`) green on this PR
- [ ] Visual check of the hero at narrow and wide widths after deploy

Note: the local build was verified with `--outDir /tmp/...` because cleaning the existing `dist/` and `.temp/` dirs exceeds a bulk-delete guard in my sandbox — that is environmental only and does not affect the output.