### PR TITLE
fix(update): skip mirrors that answer with junk instead of failing outright

### DIFF
--- a/app/src/main/java/com/webtoapp/core/network/CnMirrorProbe.kt
+++ b/app/src/main/java/com/webtoapp/core/network/CnMirrorProbe.kt
@@ -159,7 +159,19 @@ object CnMirrorProbe {
                 if (resp.code !in 200..399) return -1
                 val body = resp.body ?: return -1
                 body.byteStream().use { input ->
-                    input.read(ByteArray(PROBE_RANGE_BYTES))
+                    var read = 0
+                    val buffer = ByteArray(PROBE_RANGE_BYTES)
+                    while (read < PROBE_RANGE_BYTES) {
+                        val n = input.read(buffer, read, PROBE_RANGE_BYTES - read)
+                        if (n == -1) break
+                        read += n
+                    }
+                    // A proxy that answers 200 with a short plain-text error
+                    // ("Suspent", "404 not found") hits EOF long before the
+                    // requested range. It measures as the fastest route and
+                    // then poisons every consumer of the ordering, so a
+                    // truncated body counts as dead, same as a timeout.
+                    if (read < PROBE_RANGE_BYTES) return -1
                 }
                 val elapsedMs = (System.nanoTime() - start) / 1_000_000
                 if (elapsedMs > PROBE_BUDGET_MS) -1 else elapsedMs

--- a/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
+++ b/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
@@ -221,7 +221,13 @@ object UpdateChecker {
         var lastError: Exception? = null
         for (endpoint in candidates) {
             try {
-                return httpGet(endpoint)
+                val body = httpGet(endpoint) ?: continue
+                // A proxy can answer 200 with a plain-text error ("Suspent",
+                // "404 not found") — not every mirror actually proxies
+                // api.github.com. Only a JSON object counts as a hit; anything
+                // else falls through to the next candidate.
+                if (body.trimStart().startsWith("{")) return body
+                AppLogger.w(TAG, "Release API returned non-JSON via $endpoint: ${body.take(80)}")
             } catch (e: Exception) {
                 AppLogger.w(TAG, "Release API failed via $endpoint: ${e.message}")
                 lastError = e
@@ -236,7 +242,10 @@ object UpdateChecker {
         var lastError: Exception? = null
         for (endpoint in candidates) {
             try {
-                return httpGet(endpoint)
+                // fetchAllReleasesJson expects an array response, not an object.
+                val body = httpGet(endpoint) ?: continue
+                if (body.trimStart().startsWith("[")) return body
+                AppLogger.w(TAG, "All-releases API returned non-JSON via $endpoint: ${body.take(80)}")
             } catch (e: Exception) {
                 AppLogger.w(TAG, "All-releases API failed via $endpoint: ${e.message}")
                 lastError = e


### PR DESCRIPTION
A user report (error report, scope: Update check) captured it exactly:

```
JSONException: Value Suspent of type java.lang.String cannot be converted to JSONObject
```

`"Suspent"` is not JSON — it is the plain-text error a rate-limited or suspended accelerator returns **with HTTP 200**. Not every mirror actually proxies `api.github.com`: probing five of them directly produced one correct JSON response, a 403 text page ("Invalid input."), a 404 text page ("404 not found") and two connection timeouts.

The user's own observation was the second half of the clue: the check fails on a cold start, and "seconds-succeeds" only after a runtime download has happened. That pointed at the mirror ordering, not the update logic itself.

## Three layers stacked into the crash

1. **The probe measured time-to-first-byte only.** A proxy answering 200 with an eight-byte error page is the fastest route on the wire and took the top spot — poisoning the ordering every consumer shares.
2. **`fetchLatestReleaseJson` did `return httpGet(endpoint)`.** `httpGet` returns null for non-2xx, so a null came straight back without trying the next candidate.
3. **JSON parsing sat outside the candidate loop**, so a 200-with-garbage body aborted the whole check instead of falling through to the next route.

Runtime downloads were immune: their content is validated (zip / sha256) and a bad mirror gets skipped automatically. Only the update check parsed outside the loop — and only it crashed. The "works after a runtime download" part is the intermittent nature of rate-limited proxies, which the fix no longer depends on.

## Fix, both layers

- **`CnMirrorProbe.measureLatency`** now reads the *full* requested range and treats a truncated body as dead, same as a timeout. The probe target is a multi-megabyte release asset, so a real route always has 1 KB to give; a short body means the proxy answered with an error page. Fast-but-empty no longer wins the ordering.
- **Both fetch loops in `UpdateChecker`** validate the body before accepting it: a JSON object for the latest release, an array for the full history (that one parses into `JSONArray`). A rejected body logs its first 80 bytes with the endpoint, so the offending proxy is identifiable from the log alone. `httpGet` returning null now `continue`s instead of returning.

Candidate lists still end with the plain URL, so the worst case remains "direct connection works" — exactly what it was before the mirror pool existed. The change only ever adds fallbacks.

## Testing

Compilation plus the full suite: **959 tests, 0 failures**. The behavioural change needs a live proxy to observe; the log line added for rejected bodies is what makes the next incident diagnosable without one.