### PR TITLE
fix(update): retry the update APK across the measured mirror pool

### DIFF
--- a/app/src/main/java/com/webtoapp/core/update/ApkUpdateInstaller.kt
+++ b/app/src/main/java/com/webtoapp/core/update/ApkUpdateInstaller.kt
@@ -52,9 +52,14 @@ object ApkUpdateInstaller {
     }
 
     /**
-     * Streams [url] into `update_apks/web-to-app-<version>.apk` via OkHttp, emitting progress
-     * roughly once per second. On completion the file is SHA-256 verified against [expectedSha256]
-     * (if provided); on mismatch the file is deleted and [UpdateDownloadState.Failed] is emitted.
+     * Streams the update APK into `update_apks/web-to-app-<version>.apk` via OkHttp, emitting
+     * progress roughly once per second.
+     *
+     * [url] is the raw GitHub asset URL; the measured mirror pool expands it into candidates and
+     * each is tried in turn — a mirror that stalls, errors mid-stream, or yields a file that
+     * fails the SHA-256 check falls through to the next one instead of failing the download.
+     * On completion the file is SHA-256 verified against [expectedSha256] (if provided); on
+     * final mismatch the file is deleted and [UpdateDownloadState.Failed] is emitted.
      *
      * The APK is **not** auto-installed; the caller decides when to launch the system installer
      * (see `ApkBuilder.installApk`). This keeps the user in control and matches Android's rule
@@ -72,30 +77,48 @@ object ApkUpdateInstaller {
         activeJob?.cancel()
         val appContext = context.applicationContext
         val job = scope.launch {
-            try {
-                onState(UpdateDownloadState.Downloading(0L, -1L, 0L))
-                val file = streamToFile(appContext, url, version, onState)
-                if (expectedSha256 != null) {
-                    onState(UpdateDownloadState.Verifying)
-                    val actual = sha256Of(file)
-                    if (actual == null || !actual.equals(expectedSha256, ignoreCase = true)) {
-                        AppLogger.e(
-                            TAG,
-                            "APK integrity check failed: expected=$expectedSha256 actual=$actual"
-                        )
-                        file.delete()
-                        onState(UpdateDownloadState.Failed("sha256-mismatch"))
-                        return@launch
+            // Fastest-first measured routes, plain GitHub URL last. If the URL
+            // was already mirrored upstream this still works: non-GitHub URLs
+            // expand to themselves, so behaviour degrades to the old single
+            // attempt instead of breaking.
+            val candidates = com.webtoapp.core.network.GitHubMirror.proxiedCn(url)
+            var lastError: Exception? = null
+            for (candidate in candidates) {
+                try {
+                    onState(UpdateDownloadState.Downloading(0L, -1L, 0L))
+                    val file = streamToFile(appContext, candidate, version, onState)
+                    if (expectedSha256 != null) {
+                        onState(UpdateDownloadState.Verifying)
+                        val actual = sha256Of(file)
+                        if (actual == null || !actual.equals(expectedSha256, ignoreCase = true)) {
+                            AppLogger.e(
+                                TAG,
+                                "APK integrity check failed via $candidate: " +
+                                    "expected=$expectedSha256 actual=$actual"
+                            )
+                            // A mismatch here means the route served something
+                            // other than the release asset; treat it like any
+                            // other broken mirror and try the next route.
+                            file.delete()
+                            lastError = IllegalStateException("sha256-mismatch")
+                            continue
+                        }
+                        AppLogger.i(TAG, "APK integrity verified (sha256 match)")
                     }
-                    AppLogger.i(TAG, "APK integrity verified (sha256 match)")
+                    onState(UpdateDownloadState.Done(file))
+                    return@launch
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    AppLogger.w(TAG, "Update download failed via $candidate: ${e.message}")
+                    lastError = e
                 }
-                onState(UpdateDownloadState.Done(file))
-            } catch (e: kotlinx.coroutines.CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                AppLogger.e(TAG, "Update download failed", e)
-                onState(UpdateDownloadState.Failed(e.message ?: e.javaClass.simpleName))
             }
+            onState(
+                UpdateDownloadState.Failed(
+                    lastError?.message ?: lastError?.javaClass?.simpleName ?: "all routes failed"
+                )
+            )
         }
         activeJob = job
         return job

--- a/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
+++ b/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
@@ -104,18 +104,6 @@ object UpdateChecker {
         data class Failed(val message: String, val throwable: Throwable? = null) : Result()
     }
 
-    /**
-     * Best current route for a GitHub URL. Release assets go through the
-     * measured mirror pool (same routing the runtime downloads use, so an
-     * update APK is not stuck on one hard-coded accelerator); anything else
-     * comes back untouched.
-     *
-     * Single URL rather than a list because the result is carried on [Result]
-     * and handed to the installer, which has no fallback logic of its own.
-     */
-    fun withMirror(url: String): String =
-        com.webtoapp.core.network.GitHubMirror.proxiedCn(url).firstOrNull() ?: url
-
     suspend fun check(currentVersionName: String): Result = withContext(Dispatchers.IO) {
         val current = Version.parse(currentVersionName)
             ?: return@withContext Result.Failed("Cannot parse current version: $currentVersionName")
@@ -143,7 +131,10 @@ object UpdateChecker {
 
             val info = ReleaseInfo(
                 version = latest.toString(),
-                downloadUrl = withMirror(rawUrl),
+                // Raw asset URL: ApkUpdateInstaller expands the measured mirror
+                // candidates itself and retries, so a single stale prefix can
+                // no longer sink the download.
+                downloadUrl = rawUrl,
                 sizeBytes = asset.optLong("size", 0L),
                 sha256 = asset.optString("digest").takeIf { it.isNotBlank() }
                     ?.substringAfter("sha256:", "")?.takeIf { it.isNotBlank() },
@@ -183,7 +174,7 @@ object UpdateChecker {
                         name = release.optString("name").trim(),
                         publishedAt = release.optString("published_at").trim(),
                         body = localizeReleaseBody(release.optString("body")),
-                        downloadUrl = rawUrl?.let { withMirror(it) },
+                        downloadUrl = rawUrl,
                         sizeBytes = asset?.optLong("size", 0L) ?: 0L,
                         sha256 = asset?.optString("digest").takeIf { !it.isNullOrBlank() }
                             ?.substringAfter("sha256:", "")?.takeIf { it.isNotBlank() }


### PR DESCRIPTION
Closes the last single point of failure in the update path. #694 made the update *check* survive broken mirrors; the download it offers afterwards did not.

## The gap

`withMirror` handed the installer one URL — the fastest measured route at check time — and `streamToFile` made exactly one attempt over it. A mirror that stalls mid-stream, or serves bytes that fail the SHA-256 check, failed the whole download with no fallback. The user sees "update available", taps download, and gets `Failed` because a proxy that answered a latency probe quickly cannot actually carry 100 MB.

## The change

Move the routing decision to where the retries are:

- `UpdateChecker` now carries the **raw** asset URL.
- `ApkUpdateInstaller.download` expands it through the measured mirror pool and walks the candidates fastest-first, plain GitHub URL last.
- **`sha256-mismatch` joins network errors as a fall-through condition.** A mismatch means the route served something that is not the release asset — exactly the failure mode #694 documented for JSON endpoints — so it retries like any other broken mirror instead of failing.
- Each failed attempt deletes its partial file before the next route starts, and progress resets to zero, so the bar never claims 80% of a broken attempt and then jumps.

`withMirror` is gone. It existed to pre-mirror a single URL for a callee that could not retry; that callee now does its own routing, and the UI contract is unchanged.

## Testing

Compilation plus the full suite: **959 tests, 0 failures**. As with #694, the retry behaviour needs live proxies to observe end-to-end; the per-route log lines (`Update download failed via <route>`) are what make the next incident diagnosable.