### PR TITLE
fix(shell): re-assert immersive flags on the classic pre-30 window path

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
@@ -247,6 +247,30 @@ object WindowHelper {
                     activity.window.navigationBarColor = activity.window.statusBarColor
                 }
                 applyKeyboardMode(activity, keyboardAdjustMode, tag, decorFitsSystemWindows)
+                if (classicKeyboardResize && enabled) {
+                    // Classic (below API 30, RESIZE) windows have no insets controller: hiding
+                    // a bar sets the legacy SYSTEM_UI_FLAG_* bits, and the system clears the
+                    // fullscreen flag again whenever the hidden bar finishes animating away
+                    // (no ViewCompat.requestApplyInsets pass re-asserts it there). Without
+                    // this re-assert the window background shows through as a white strip
+                    // where the status bar was (2.5.5 fullscreen regression on Android 10).
+                    activity.window.decorView.postDelayed({
+                        try {
+                            val target = activity.window.decorView.systemUiVisibility
+                            val want = View.SYSTEM_UI_FLAG_LOW_PROFILE or
+                                View.SYSTEM_UI_FLAG_FULLSCREEN or
+                                View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                            if ((target and (View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)) !=
+                                (View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
+                            ) {
+                                activity.window.decorView.systemUiVisibility = target or want
+                            }
+                        } catch (e: Exception) {
+                            AppLogger.w(tag, "re-assert immersive flags failed", e)
+                        }
+                    }, 350)
+                }
             }
         } catch (e: Exception) {
             AppLogger.w(tag, "applyImmersiveFullscreen failed", e)


### PR DESCRIPTION
## Summary

Fixes the 2.5.5 fullscreen regression on Android 10 (#696): with fullscreen enabled, the status bar reappeared after being hidden, leaving a white strip at the top of the window.

## Root cause

#650 dropped edge-to-edge below API 30 with the default RESIZE keyboard mode so the keyboard resizes the window again (#613). On that classic (non-edge-to-edge) path, hiding the status bar relies on the legacy `SYSTEM_UI_FLAG_FULLSCREEN` bit, which the system clears once the bar's hide animation finishes. With the decor fitting system windows there is no insets dispatch pass to re-assert the flags, so fullscreen apps ended up with the status bar back and the window background showing through as a white strip.

## Fix

In `WindowHelper.applyImmersiveFullscreen`, on the classic path (below API 30, RESIZE mode) when fullscreen is enabled, a guarded `postDelayed` (350ms) check re-asserts `SYSTEM_UI_FLAG_FULLSCREEN | HIDE_NAVIGATION | IMMERSIVE_STICKY` if the system cleared them. Failures are logged, never thrown. The keyboard-resize behavior from #613 is untouched — verified by the existing `WindowHelperKeyboardModePreApi30Test` / `WindowHelperKeyboardModeApi30Test`.

## Verification

- `:app:compileStandardDebugKotlin` — passes
- `WindowHelperKeyboardModePreApi30Test` (sdk 29) and `WindowHelperKeyboardModeApi30Test` (sdk 30) — pass, confirming no keyboard-fix regression
- API 29 emulator, end-to-end: built the host app, opened a WebView preview with fullscreen enabled — window reports `vsysui=HIDE_NAVIGATION FULLSCREEN IMMERSIVE_STICKY` with `sim={adjust=resize}` (classic path active), and the top 200 rows of a screenshot are uniform background (white strip gone)
- `WindowHelper.kt` is shell-synced (`**/ui/shared/**`); template rebuilt via `:shell:assembleRelease :app:syncShellTemplateApk` and the fix confirmed present in the template DEX

Fixes #696