### PR TITLE
fix(runtime): keep toolbar flags through shell mapping and surface router 5xx details

### DIFF
--- a/app/src/main/assets/php_router_server.php
+++ b/app/src/main/assets/php_router_server.php
@@ -526,6 +526,13 @@ function executePHP($client, string $filePath, array $request, string $docRoot, 
                 $output = '<h1>500 Internal Server Error</h1><pre>' . htmlspecialchars($message) . '</pre>';
             }
         }
+        // Surface the router's own diagnostic (fatal message / trace) to the WebView
+        // layer: local error pages read this header to show the cause instead of a
+        // bare "HTTP 500" that hides whether the failure is a fatal, a thrown
+        // exception, or PHP output. Keep it bounded — response bodies can be large.
+        if ($code >= 500 && $output !== '' && strlen($output) <= 65536) {
+            $headerList[] = 'X-Wta-Router-Error: ' . base64_encode($output);
+        }
         if (function_exists('header_remove')) header_remove();
 
         fwrite(STDERR, "[RouterServer] Shutdown response uri=$uri code=$code bytes=" . strlen($output) . " " . describeHeaders($headerList) . "\n");
@@ -556,6 +563,9 @@ function executePHP($client, string $filePath, array $request, string $docRoot, 
             . htmlspecialchars($e->getTraceAsString()) . "</pre>";
     }
 
+    // Thrown-exception path: response goes through the normal-path sender below,
+    // which also stamps X-Wta-Router-Error on 5xx (see the shutdown handler).
+
     // 自动保存 session 数据（模拟 PHP 原生 session 行为）
     if (function_exists('session_write_close') && ($GLOBALS['__session_started'] ?? false)) {
         session_write_close();
@@ -570,6 +580,10 @@ function executePHP($client, string $filePath, array $request, string $docRoot, 
         }
         $code       = http_response_code() ?: 200;
         $headerList = headers_list();
+        // Same 5xx diagnostic stamping as the shutdown handler (see there).
+        if ($code >= 500 && $output !== '' && strlen($output) <= 65536) {
+            $headerList[] = 'X-Wta-Router-Error: ' . base64_encode($output);
+        }
         if (function_exists('header_remove')) header_remove();
 
         fwrite(STDERR, "[RouterServer] Response uri=$uri code=$code bytes=" . strlen($output) . " " . describeHeaders($headerList) . "\n");

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -3,6 +3,7 @@ package com.webtoapp.core.webview
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Dialog
+import android.util.Base64
 import com.webtoapp.core.logging.AppLogger
 import android.content.Context
 import android.content.Intent
@@ -2588,6 +2589,20 @@ class WebViewManager(
                     }
 
                     val manager = errorPageManager
+                    // Local router runtimes (PHP/WordPress) stamp their own diagnostic page
+                    // (fatal message / stack trace) into X-Wta-Router-Error on 5xx. Showing the
+                    // body beats replacing it with a generic "HTTP 500" page that hides whether
+                    // the failure is a fatal, an exception, or app-level PHP output.
+                    val routerErrorBody = if (statusCode in 500..599) {
+                        extractRouterErrorBody(errorResponse)
+                    } else null
+                    if (routerErrorBody != null && view != null && failedUrl != null) {
+                        lastFailedUrl = failedUrl
+                        view.loadDataWithBaseURL(failedUrl, routerErrorBody, "text/html", "UTF-8", failedUrl)
+                        AppLogger.d("WebViewManager", "Router 5xx diagnostic body shown for: $failedUrl, code=$statusCode")
+                        callbacks.onError(statusCode, description)
+                        return
+                    }
                     if (!isCloudflareResponse && manager != null && view != null && failedUrl != null && failedUrl != "about:blank") {
                         val errorHtml = manager.generateErrorPage(statusCode, description, failedUrl)
                         if (errorHtml != null) {
@@ -3095,6 +3110,23 @@ class WebViewManager(
 
         return com.webtoapp.core.perf.NativePerfEngine.extractHost(target)?.lowercase()
             ?: runCatching { Uri.parse(target).host?.lowercase() }.getOrNull()
+    }
+
+    /**
+     * Reads and base64-decodes the X-Wta-Router-Error diagnostic header that the local
+     * PHP router stamps onto 5xx responses. Returns null when the header is absent
+     * (non-router origins) or unreadable.
+     */
+    private fun extractRouterErrorBody(errorResponse: WebResourceResponse?): String? {
+        val headers = runCatching { errorResponse?.responseHeaders }.getOrNull() ?: return null
+        val encoded = headers.entries
+            .firstOrNull { it.key.equals("X-Wta-Router-Error", ignoreCase = true) }
+            ?.value
+            ?.takeIf { it.isNotBlank() }
+            ?: return null
+        return runCatching {
+            String(Base64.decode(encoded, Base64.DEFAULT), Charsets.UTF_8)
+        }.getOrNull()?.takeIf { it.isNotBlank() }
     }
 
     private fun isMitmSslError(error: android.net.http.SslError?): Boolean {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -44,6 +44,8 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         toolbarShowBack = config.webViewConfig.toolbarShowBack,
         toolbarShowForward = config.webViewConfig.toolbarShowForward,
         toolbarShowRefresh = config.webViewConfig.toolbarShowRefresh,
+        toolbarShowConsole = config.webViewConfig.toolbarShowConsole,
+        toolbarShowFind = config.webViewConfig.toolbarShowFind,
         showStatusBarInFullscreen = config.webViewConfig.showStatusBarInFullscreen,
         showNavigationBarInFullscreen = config.webViewConfig.showNavigationBarInFullscreen,
         showToolbarInFullscreen = config.webViewConfig.showToolbarInFullscreen,

--- a/app/src/test/java/com/webtoapp/ui/shell/ShellWebViewConfigMappingTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/shell/ShellWebViewConfigMappingTest.kt
@@ -1,0 +1,71 @@
+package com.webtoapp.ui.shell
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.apkbuilder.ApkConfigJsonFactory
+import com.webtoapp.core.apkbuilder.toApkConfig
+import com.webtoapp.core.shell.ShellConfig
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.model.WebViewConfig
+import com.webtoapp.util.GsonProvider
+import org.junit.Test
+
+/**
+ * Regression coverage for the toolbar flags that were silently dropped between the
+ * shell config and the runtime WebViewConfig in `buildWebViewConfig`
+ * (user report: "hide toolbar can't disappear" — exported APKs fell back to the
+ * data-class defaults `true` for toolbarShowConsole / toolbarShowFind, so the toolbar
+ * never vanished even with every button switched off).
+ *
+ * `WebViewConfigBooleanCoverageTest` covers the export → shell JSON layers; this test
+ * covers the third hop (shell config → runtime WebViewConfig) that has no drift gate.
+ */
+class ShellWebViewConfigMappingTest {
+
+    private fun runtimeConfigOf(app: WebApp): WebViewConfig {
+        val apk = app.toApkConfig("com.example.test")
+        val json = ApkConfigJsonFactory.toShellConfigJson(apk)
+        val shell = GsonProvider.gson.fromJson(json, ShellConfig::class.java)!!
+        return buildWebViewConfig(shell)
+    }
+
+    @Test
+    fun `disabled toolbar flags survive shell config to runtime WebViewConfig`() {
+        val app = WebApp(
+            name = "t",
+            url = "https://t.example.com",
+            webViewConfig = WebViewConfig(
+                browserToolbarEnabled = true,
+                toolbarShowTitle = false,
+                toolbarShowUrl = false,
+                toolbarShowBack = false,
+                toolbarShowForward = false,
+                toolbarShowRefresh = false,
+                toolbarShowConsole = false,
+                toolbarShowFind = false
+            )
+        )
+
+        val runtime = runtimeConfigOf(app)
+
+        assertThat(runtime.toolbarShowTitle).isFalse()
+        assertThat(runtime.toolbarShowUrl).isFalse()
+        assertThat(runtime.toolbarShowBack).isFalse()
+        assertThat(runtime.toolbarShowForward).isFalse()
+        assertThat(runtime.toolbarShowRefresh).isFalse()
+        assertThat(runtime.toolbarShowConsole).isFalse()
+        assertThat(runtime.toolbarShowFind).isFalse()
+    }
+
+    @Test
+    fun `enabled toolbar flags stay enabled through the mapping`() {
+        val runtime = runtimeConfigOf(WebApp(name = "t", url = "https://t.example.com"))
+
+        assertThat(runtime.toolbarShowTitle).isTrue()
+        assertThat(runtime.toolbarShowUrl).isTrue()
+        assertThat(runtime.toolbarShowBack).isTrue()
+        assertThat(runtime.toolbarShowForward).isTrue()
+        assertThat(runtime.toolbarShowRefresh).isTrue()
+        assertThat(runtime.toolbarShowConsole).isTrue()
+        assertThat(runtime.toolbarShowFind).isTrue()
+    }
+}

--- a/shell/src/main/assets/php_router_server.php
+++ b/shell/src/main/assets/php_router_server.php
@@ -526,6 +526,13 @@ function executePHP($client, string $filePath, array $request, string $docRoot, 
                 $output = '<h1>500 Internal Server Error</h1><pre>' . htmlspecialchars($message) . '</pre>';
             }
         }
+        // Surface the router's own diagnostic (fatal message / trace) to the WebView
+        // layer: local error pages read this header to show the cause instead of a
+        // bare "HTTP 500" that hides whether the failure is a fatal, a thrown
+        // exception, or PHP output. Keep it bounded — response bodies can be large.
+        if ($code >= 500 && $output !== '' && strlen($output) <= 65536) {
+            $headerList[] = 'X-Wta-Router-Error: ' . base64_encode($output);
+        }
         if (function_exists('header_remove')) header_remove();
 
         fwrite(STDERR, "[RouterServer] Shutdown response uri=$uri code=$code bytes=" . strlen($output) . " " . describeHeaders($headerList) . "\n");
@@ -556,6 +563,9 @@ function executePHP($client, string $filePath, array $request, string $docRoot, 
             . htmlspecialchars($e->getTraceAsString()) . "</pre>";
     }
 
+    // Thrown-exception path: response goes through the normal-path sender below,
+    // which also stamps X-Wta-Router-Error on 5xx (see the shutdown handler).
+
     // 自动保存 session 数据（模拟 PHP 原生 session 行为）
     if (function_exists('session_write_close') && ($GLOBALS['__session_started'] ?? false)) {
         session_write_close();
@@ -570,6 +580,10 @@ function executePHP($client, string $filePath, array $request, string $docRoot, 
         }
         $code       = http_response_code() ?: 200;
         $headerList = headers_list();
+        // Same 5xx diagnostic stamping as the shutdown handler (see there).
+        if ($code >= 500 && $output !== '' && strlen($output) <= 65536) {
+            $headerList[] = 'X-Wta-Router-Error: ' . base64_encode($output);
+        }
         if (function_exists('header_remove')) header_remove();
 
         fwrite(STDERR, "[RouterServer] Response uri=$uri code=$code bytes=" . strlen($output) . " " . describeHeaders($headerList) . "\n");


### PR DESCRIPTION
## Summary

Two fixes from user reports on exported APKs:

1. **Toolbar can't disappear (#699)** — after switching off every toolbar button in the editor, exported apps still showed the toolbar with console/find buttons the user had disabled. `buildWebViewConfig` (shell config → runtime `WebViewConfig`) dropped `toolbarShowConsole` / `toolbarShowFind`, so the runtime fell back to the data-class default `true` and `hasAnyToolbarItem` always held. Host preview was unaffected because it reads the real `WebViewConfig` directly — the classic "preview works, export broken" pattern. The missing layer is uncovered by `checkConfigFieldDrift` (which only compares JSON factory ↔ shell), so a mapping regression test is added covering all seven toolbar flags through export → shell JSON → runtime `WebViewConfig`.

2. **wp-admin bare Error 500 (#700)** — the local PHP router renders its own diagnostic page on 5xx (fatal message with file:line / exception trace), but the WebView layer replaced it with the generic built-in error page, hiding the actual cause. The router now stamps the diagnostic body into an `X-Wta-Router-Error` header (base64, capped at 64 KiB) on 5xx responses, and `WebViewManager` shows that body instead of the generic page when present. Also verified by probing the bundled pmmp PHP 8.4 binary: all core extensions WordPress needs are statically compiled in (session is polyfilled by the router; intl/sodium by WordPress), so a "load more extensions" change would not have addressed the report.

## Verification

- `:app:compileStandardDebugKotlin` — passes
- New `ShellWebViewConfigMappingTest` (both disabled and enabled flag paths) — passes
- `WebViewConfigBooleanCoverageTest`, `WindowHelperKeyboardMode*` suites — pass
- `checkConfigFieldDrift` — OK
- Shell template rebuilt (`:shell:assembleRelease :app:syncShellTemplateApk`); both fixes confirmed present in the template DEX / assets
- API 29 emulator smoke: host app launches, WebView preview opens with the expected window flags (`sim={adjust=resize}`, fullscreen flags intact)

Fixes #699, fixes #700