### PR TITLE
fix(webview): gate private-network fetch hijack on the bridge being enabled

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
@@ -1242,7 +1242,11 @@ if (NativeBridge.isFullscreen()) {
     @JavascriptInterface
     fun httpRequest(requestJson: String): String {
         if (!capabilities.privateNetwork && !corsBypass) {
-            return privateNetworkBridgeError("disabled", "Native private network capability disabled")
+            return privateNetworkBridgeError(
+                "disabled",
+                "Native private network capability disabled. " +
+                    "Enable the private network (or CORS bypass) capability for the native bridge in the WebToApp editor and rebuild."
+            )
         }
         return try {
             val request = org.json.JSONObject(requestJson)

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -3977,10 +3977,15 @@ class WebViewManager(
 
     private fun injectPrivateNetworkApiBridgeFallback(webView: WebView, pageUrl: String?) {
         if (!isLocalRuntimeUrl(pageUrl ?: webView.url)) return
+        // Only install the fetch/XHR hijack when a Java-side NativeBridge actually
+        // exists. Without this gate the hijack intercepts cross-origin fetches on
+        // local pages and rejects them with "bridge is unavailable" even though the
+        // user never enabled any bridge — the request should just use the WebView's
+        // normal (CORS-enforcing) behavior instead.
+        val cfg = currentConfig ?: return
+        if (!cfg.enableNativeBridge && !cfg.enablePrivateNetworkBridge && !cfg.enableCorsBypass) return
         try {
-
-            val cfg = currentConfig
-            val script = if (cfg != null) privateNetworkScriptWithScope(cfg) else PrivateNetworkApiBridgeScriptHolder.SCRIPT
+            val script = privateNetworkScriptWithScope(cfg)
             webView.evaluateJavascript(script, null)
         } catch (e: Exception) {
             AppLogger.w("WebViewManager", "Private network bridge fallback injection failed", e)
@@ -6340,7 +6345,12 @@ class WebViewManager(
 
                 function nativeHttpRequest(payload) {
                     if (!window.NativeBridge || typeof window.NativeBridge.httpRequest !== 'function') {
-                        return Promise.reject(new TypeError('Native private network bridge is unavailable'));
+                        // Defensive only since the wrapper is no longer injected without a
+                        // bridge; kept actionable in case interface removal races injection.
+                        return Promise.reject(new TypeError(
+                            'Native private network bridge is unavailable. ' +
+                            'Enable "Private network bridge" (or CORS bypass) for this app in the WebToApp editor and rebuild.'
+                        ));
                     }
                     return bodyToBase64(payload.body).then(function(bodyBase64) {
                         var raw = window.NativeBridge.httpRequest(JSON.stringify({


### PR DESCRIPTION
## Summary

Fixes #704. The fetch/XHR hijack script was injected into every local-runtime page (loopback / private-IP origin) regardless of configuration, while the Java-side `NativeBridge` interface only exists when `enableNativeBridge`, `enablePrivateNetworkBridge`, or `enableCorsBypass` is on. Local pages making cross-origin fetches were intercepted and rejected with the opaque `Native private network bridge is unavailable` TypeError even though the user never enabled any bridge.

## Fix

- `injectPrivateNetworkApiBridgeFallback` now skips injection when no bridge flag is configured (covers both call sites — the `onPageStarted` fallback and the minimized-local-runtime path), so unconfigured apps fall back to the WebView's normal CORS-enforcing fetch behavior.
- Both rejection messages are now actionable: the JS-side defensive check (kept for interface-removal races) and the Java-side `capability disabled` branch tell the user to enable "Private network bridge" (or CORS bypass) in the WebToApp editor and rebuild.

## Verification

- `:app:compileStandardDebugKotlin` — passes
- `:app:testStandardDebugUnitTest` (`core.webview.*`, `ui.shell.*` incl. the new `ShellWebViewConfigMappingTest`) — pass
- `checkConfigFieldDrift` — OK
- Shell template rebuilt; updated messages confirmed in the template DEX
- API 29 emulator smoke: host app and WebView preview launch normally with the fix
- GeckoView path already registered the extension only under the same flags (`GeckoViewEngine.kt:449`), so no change needed there