### PR TITLE
feat(editor): enable safe experience features by default for new apps

### DIFF
--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -344,16 +344,21 @@ data class WebViewConfig(
     val enableCrossOriginIsolation: Boolean = false,
     val hideUrlPreview: Boolean = false,
 
-    val decodeBase64DeepLinks: Boolean = false,
+    // Features below default to ON: each one is opt-in-free, fails soft, and does not
+    // affect the normal run of the overwhelming majority of pages. Users can still turn
+    // any of them off per app in the editor's advanced settings. Only affects newly
+    // created apps — saved configs keep their stored values (Room converter preserves
+    // existing JSON fields).
+    val decodeBase64DeepLinks: Boolean = true,
     val decodeBase64Mode: Base64DeepLinkMode = Base64DeepLinkMode.GESTURE_ONLY,
-    val javaScriptCanOpenWindows: Boolean = false,
+    val javaScriptCanOpenWindows: Boolean = true,
     val jsOpenWindowsPolicy: JsOpenWindowsPolicy = JsOpenWindowsPolicy.ALLOW,
 
     val mediaAutoplayEnabled: Boolean = false,
     val mediaAutoplayScope: MediaAutoplayScope = MediaAutoplayScope.VIDEO_ONLY,
-    val enableImageRepair: Boolean = false,
-    val enableScrollMemory: Boolean = false,
-    val enableBackStatePreservation: Boolean = false,
+    val enableImageRepair: Boolean = true,
+    val enableScrollMemory: Boolean = true,
+    val enableBackStatePreservation: Boolean = true,
 
     val enableKernelDisguise: Boolean = false,
     val kernelDisguiseLevel: KernelDisguiseLevel = KernelDisguiseLevel.STANDARD,
@@ -362,7 +367,7 @@ data class WebViewConfig(
     val cloudflareCompatMode: CloudflareCompatMode = CloudflareCompatMode.AUTO_DETECT,
     val allowMixedContent: Boolean = false,
     val mixedContentMode: MixedContentMode = MixedContentMode.COMPATIBILITY,
-    val enablePrivateNetworkBridge: Boolean = false,
+    val enablePrivateNetworkBridge: Boolean = true,
     val privateNetworkScope: PrivateNetworkScope = PrivateNetworkScope.LOCAL_ONLY,
     val enableCorsBypass: Boolean = true,
 
@@ -371,14 +376,20 @@ data class WebViewConfig(
     val databaseEnabled: Boolean = true,
     val enableCookiePersistence: Boolean = true,
 
-    val enableClipboardPolyfill: Boolean = false,
+    val enableClipboardPolyfill: Boolean = true,
+    // Notification polyfill stays default-OFF: enabling it makes every exported app
+    // request POST_NOTIFICATIONS on first launch (RuntimePermissionSync), a visible
+    // permission prompt most pages never earn.
     val enableNotificationPolyfill: Boolean = false,
-    val enableOrientationPolyfill: Boolean = false,
-    val enableCompatPolyfills: Boolean = false,
+    val enableOrientationPolyfill: Boolean = true,
+    val enableCompatPolyfills: Boolean = true,
 
     val enableNativeBridge: Boolean = false,
     val nativeBridgeCapabilities: NativeBridgeCapabilities = NativeBridgeCapabilities(),
 
+    // Geolocation stays default-OFF: enabling it makes every exported app declare and
+    // request location permission (RuntimePermissionSync), a heavy default with
+    // antivirus-reputation cost.
     val geolocationEnabled: Boolean = false,
     val geolocationAccuracy: GeolocationAccuracy = GeolocationAccuracy.FINE,
     val geolocationPolicy: GeolocationPolicy = GeolocationPolicy.ALWAYS_ASK,
@@ -388,9 +399,9 @@ data class WebViewConfig(
 
     val enablePrintBridge: Boolean = true,
 
-    val enableMediaSession: Boolean = false,
+    val enableMediaSession: Boolean = true,
 
-    val primeUserActivation: Boolean = false,
+    val primeUserActivation: Boolean = true,
     val primeUserActivationMode: PrimeUserActivationMode = PrimeUserActivationMode.SYNTHETIC_TAP,
     val primeUserActivationTiming: PrimeUserActivationTiming = PrimeUserActivationTiming.ON_PAGE_FINISHED,
 

--- a/app/src/test/java/com/webtoapp/data/model/WebViewConfigDefaultsContractTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/WebViewConfigDefaultsContractTest.kt
@@ -1,0 +1,152 @@
+package com.webtoapp.data.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Contract test pinning the default value of every WebViewConfig feature toggle.
+ *
+ * Rationale: features whose behavior is opt-in-free, fails soft, and does not affect
+ * the normal run of the overwhelming majority of pages should default to ON, so users
+ * get the full experience without hunting through advanced settings. Features with a
+ * real downside (kernel disguise can trigger anti-bot rejections, third-party cookies
+ * weaken privacy, mixed content weakens transport security, failover needs a user
+ * supplied URL list, popup blocking suppresses wanted popups) stay OFF.
+ *
+ * If you flip a flag here, that is a product decision: update this test with the
+ * reasoning in the PR description, not silently.
+ */
+class WebViewConfigDefaultsContractTest {
+
+    // Features that must stay default-OFF: they carry a real trade-off, need user
+    // input to be meaningful, or exist to restrict behavior.
+    private val defaultOff = setOf(
+        "popupBlockerEnabled",           // suppressing popups can hide wanted windows
+        "popupBlockerToggleEnabled",
+        "mediaAutoplayEnabled",          // audible autoplay is intrusive by default
+        "enableKernelDisguise",          // anti-bot systems may reject disguised kernels
+        "allowMixedContent",             // weakens HTTPS transport security
+        "acceptThirdPartyCookies",        // privacy trade-off
+        "enableNativeBridge",            // exposes window.NativeBridge to pages
+        "enableCrossOriginIsolation",    // changes COOP/COEP headers
+        "hideUrlPreview",                // hides information
+        "failoverEnabled",               // meaningless without a user-supplied URL list
+        "followSystemDarkMode",
+        "longPressMenuEnabled",
+        "landscapeMode",
+        "clearBrowsingDataOnLaunch",
+        "autoRefreshEnabled",
+        "keepScreenOn",
+        "showFloatingBackButton",
+        "hostsMappingEnabled",
+        "tlsFingerprintEnabled",
+        "enableNotificationPolyfill",    // implies POST_NOTIFICATIONS on every export
+        "geolocationEnabled"             // implies location permission on every export
+    )
+
+    // Features that must stay default-ON: safe enable-by-default experience.
+    private val defaultOn = setOf(
+        "javaScriptEnabled",
+        "domStorageEnabled",
+        "databaseEnabled",
+        "enableCookiePersistence",
+        "enablePaymentSchemes",
+        "enableShareBridge",
+        "enableZoomPolyfill",
+        "enableCloudflareCompat",
+        "enableCorsBypass",
+        "enableBlobDownloadInterception",
+        "enablePrintBridge",
+        // Enable-by-default batch (experience parity without user setup):
+        "decodeBase64DeepLinks",
+        "javaScriptCanOpenWindows",
+        "enableImageRepair",
+        "enableScrollMemory",
+        "enableBackStatePreservation",
+        "enablePrivateNetworkBridge",
+        "enableClipboardPolyfill",
+        // Notification polyfill and geolocation stay default-OFF on purpose: enabling
+        // either makes every exported app declare/request runtime permissions
+        // (POST_NOTIFICATIONS / location) on first launch — a cost most pages never
+        // earn. See RuntimePermissionSync.
+        "enableOrientationPolyfill",
+        "enableCompatPolyfills",
+        "enableMediaSession",
+        "primeUserActivation"
+    )
+
+    @Test
+    fun `enable-by-default feature batch keeps its ON defaults`() {
+        val config = WebViewConfig()
+        val fields = WebViewConfig::class.java.declaredFields.associateBy { it.name }
+
+        val actualOn = defaultOn.mapNotNull { name ->
+            fields[name]?.let { field ->
+                field.isAccessible = true
+                name to (field.get(config) as? Boolean)
+            }
+        }
+        val missing = defaultOn - actualOn.map { it.first }.toSet()
+        assertThat(missing).isEmpty()
+
+        val notOn = actualOn.filter { it.second != true }.map { it.first }
+        assertThat(notOn).isEmpty()
+    }
+
+    @Test
+    fun `trade-off features keep their OFF defaults`() {
+        val config = WebViewConfig()
+        val fields = WebViewConfig::class.java.declaredFields.associateBy { it.name }
+
+        val actualOff = defaultOff.mapNotNull { name ->
+            fields[name]?.let { field ->
+                field.isAccessible = true
+                name to (field.get(config) as? Boolean)
+            }
+        }
+        val missing = defaultOff - actualOff.map { it.first }.toSet()
+        assertThat(missing).isEmpty()
+
+        val notOff = actualOff.filter { it.second != false }.map { it.first }
+        assertThat(notOff).isEmpty()
+    }
+
+    @Test
+    fun `geolocation stays default-off and keeps ask-first policy when enabled`() {
+        val config = WebViewConfig()
+        // Default OFF: enabling geolocation makes every exported app declare/request
+        // location permission (RuntimePermissionSync) — too heavy a default.
+        assertThat(config.geolocationEnabled).isFalse()
+        // Safety boundary: when a user does enable it, requests must still be ask-first.
+        assertThat(config.geolocationPolicy).isEqualTo(GeolocationPolicy.ALWAYS_ASK)
+    }
+
+    @Test
+    fun `private network bridge default stays scoped to local networks`() {
+        val config = WebViewConfig()
+        assertThat(config.enablePrivateNetworkBridge).isTrue()
+        assertThat(config.privateNetworkScope).isEqualTo(PrivateNetworkScope.LOCAL_ONLY)
+    }
+
+    @Test
+    fun `base64 deep link default stays gesture-gated`() {
+        val config = WebViewConfig()
+        assertThat(config.decodeBase64DeepLinks).isTrue()
+        assertThat(config.decodeBase64Mode).isEqualTo(Base64DeepLinkMode.GESTURE_ONLY)
+    }
+
+    @Test
+    fun `js open windows default stays on the allow policy`() {
+        val config = WebViewConfig()
+        assertThat(config.javaScriptCanOpenWindows).isTrue()
+        assertThat(config.jsOpenWindowsPolicy).isEqualTo(JsOpenWindowsPolicy.ALLOW)
+    }
+
+    @Test
+    fun `prime user activation default stays on the safe timing`() {
+        val config = WebViewConfig()
+        assertThat(config.primeUserActivation).isTrue()
+        assertThat(config.primeUserActivationMode).isEqualTo(PrimeUserActivationMode.SYNTHETIC_TAP)
+        assertThat(config.primeUserActivationTiming).isEqualTo(PrimeUserActivationTiming.ON_PAGE_FINISHED)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #706. New apps now get the full out-of-box experience: features that are opt-in-free, fail soft, and do not affect the normal run of the overwhelming majority of pages default to ON. Users no longer lose supported capabilities because an advanced-settings switch was never found — or misread the gap as a bug (cf. #704).

## Defaults flipped to ON (11)

`decodeBase64DeepLinks` (GESTURE_ONLY kept), `javaScriptCanOpenWindows` (ALLOW kept), `enableImageRepair`, `enableScrollMemory`, `enableBackStatePreservation`, `enablePrivateNetworkBridge` (LOCAL_ONLY kept), `enableClipboardPolyfill`, `enableOrientationPolyfill`, `enableCompatPolyfills`, `enableMediaSession`, `primeUserActivation` (ON_PAGE_FINISHED kept).

## Deliberately NOT flipped

- **Notification polyfill / geolocation**: enabling either makes every exported app declare/request runtime permissions (POST_NOTIFICATIONS / location) on first launch via `RuntimePermissionSync` — the full-suite run surfaced this (`ExportSecurityRegressionTest` / `RuntimePermissionSyncTest`), and it is a real product cost, not a test artifact. Both stay OFF.
- **Mixed content / third-party cookies**: security and privacy trade-offs.
- **Kernel disguise**: known anti-bot backlash.
- **Popup blocker / media autoplay**: intrusive or hides wanted popups.
- **Failover**: needs a user-supplied URL list to mean anything.

## Guardrail

New `WebViewConfigDefaultsContractTest` pins every ON/OFF default plus the safety sub-modes (LOCAL_ONLY, GESTURE_ONLY, ALWAYS_ASK, ALLOW, ON_PAGE_FINISHED). Flipping a flag later requires updating the test — an explicit product decision, not a silent accident.

## Compatibility

Only newly created apps are affected. Saved apps round-trip their stored `WebViewConfig` JSON through the Room converter (`fromJsonOrDefault` preserves existing fields), so existing apps keep their current behavior.

## Verification

- `:app:testStandardDebugUnitTest` — full suite (968 tests) passes
- `checkConfigFieldDrift` — OK
- Shell template rebuilt (`:shell:assembleRelease :app:syncShellTemplateApk`)
- API 29 emulator, UI-verified on a fresh app's editor: image repair, scroll memory, back-state preservation, clipboard/orientation/compat polyfills, base64 deep links, JS open windows, Cloudflare compat all render ON; notification polyfill, media autoplay, kernel disguise render OFF