### PR TITLE
feat(activation): device binding toggle for remote one-time codes

### DIFF
--- a/.github/docs/remote-activation.md
+++ b/.github/docs/remote-activation.md
@@ -50,14 +50,23 @@ Accept: application/json
 - `nonce` is fresh per request — you **must** echo it back unchanged (replay
   protection).
 - `ts` is the client clock in epoch milliseconds.
-- `deviceBound` is `true` when the entered code is a **device-bound** code. For
-  such codes your server should enforce per-device binding: record the first
-  `deviceId` that activates a given `code`, and reject the same `code` from any
-  different `deviceId` (return `{ "ok": false }`). This is the only way to
-  truly restrict a device-bound code to one device — the app itself has no
-  shared state between devices, so a purely local device-bound code can only
-  prevent re-activation on the same device after a local reset or hardware
-  change.
+- `deviceBound` is `true` when the app has the **Device binding (one-time codes)**
+  toggle enabled in the editor's remote-activation section (it is always `false`
+  for purely local verification — see below). For such codes your server should
+  enforce per-device binding: record the first `deviceId` that activates a given
+  `code`, and reject the same `code` from any different `deviceId` (return
+  `{ "ok": false }`). This is the only way to truly restrict a device-bound code
+  to one device — the app itself has no shared state between devices, so a purely
+  local device-bound code can only prevent re-activation on the same device
+  after a local reset or hardware change.
+
+  The reference worker in `examples/remote-activation-worker` implements this as
+  seats: `maxDevices` (default `1`) devices may claim a code; a code with
+  `maxDevices: 1` behaves as a **one-time / single-device code**. The claimed
+  device id survives uninstall + reinstall on the same device (it derives from
+  `ANDROID_ID`, stable per signing key), so a seat is only released when you edit
+  the KV record. To free a seat manually, remove the `deviceId` entry from
+  `record.devices` (or delete `code:<CODE>`).
 
 ## Response (your server → app)
 

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3770,7 +3770,8 @@ private fun WebApp.buildActivationBlock(): ActivationBlock = ActivationBlock(
     remoteOfflinePolicy = activationRemoteConfig?.offlinePolicy?.name ?: "ALLOW_CACHED",
     remoteDeliverUrl = activationRemoteConfig?.deliverUrl ?: false,
     remoteEncryptUrl = activationRemoteConfig?.encryptUrl ?: false,
-    remoteAesKey = activationRemoteConfig?.aesKeyBase64 ?: ""
+    remoteAesKey = activationRemoteConfig?.aesKeyBase64 ?: "",
+    remoteDeviceBound = activationRemoteConfig?.deviceBound ?: false
 )
 
 private fun WebApp.buildAdBlockBlock(): AdBlockBlock = AdBlockBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -67,6 +67,7 @@ data class ApkConfig(
     val activationRemoteDeliverUrl: Boolean get() = activation.remoteDeliverUrl
     val activationRemoteEncryptUrl: Boolean get() = activation.remoteEncryptUrl
     val activationRemoteAesKey: String get() = activation.remoteAesKey
+    val activationRemoteDeviceBound: Boolean get() = activation.remoteDeviceBound
 
     val adBlockEnabled: Boolean get() = adBlock.enabled
     val adBlockRules: List<String> get() = adBlock.rules
@@ -419,7 +420,8 @@ data class ActivationBlock(
     val remotePublicKey: String = "",    val remoteOfflinePolicy: String = "ALLOW_CACHED",
     val remoteDeliverUrl: Boolean = false,
     val remoteEncryptUrl: Boolean = false,
-    val remoteAesKey: String = ""
+    val remoteAesKey: String = "",
+    val remoteDeviceBound: Boolean = false
 )
 
 data class AdBlockBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -44,6 +44,7 @@ internal object ApkConfigJsonFactory {
         "activationRemoteDeliverUrl" to activation.remoteDeliverUrl,
         "activationRemoteEncryptUrl" to activation.remoteEncryptUrl,
         "activationRemoteAesKey" to activation.remoteAesKey,
+        "activationRemoteDeviceBound" to activation.remoteDeviceBound,
         "adBlockEnabled" to adBlock.enabled,
         "adBlockRules" to adBlock.rules,
         "adBlockSubscriptions" to adBlock.subscriptions,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -909,6 +909,8 @@ object Strings {
     val remoteActivationPrivacyNote: String get() = StringsA.remoteActivationPrivacyNote
     val remoteActivationDeliverUrlTitle: String get() = StringsA.remoteActivationDeliverUrlTitle
     val remoteActivationDeliverUrlHint: String get() = StringsA.remoteActivationDeliverUrlHint
+    val remoteActivationDeviceBoundTitle: String get() = StringsA.remoteActivationDeviceBoundTitle
+    val remoteActivationDeviceBoundHint: String get() = StringsA.remoteActivationDeviceBoundHint
     val remoteActivationEncryptUrlTitle: String get() = StringsA.remoteActivationEncryptUrlTitle
     val remoteActivationEncryptUrlHint: String get() = StringsA.remoteActivationEncryptUrlHint
     val remoteActivationAesKeyLabel: String get() = StringsA.remoteActivationAesKeyLabel
@@ -16424,6 +16426,31 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Если включено, целевой URL доставляется сервером проверки после успешной активации вместо упаковки (URL можно оставить пустым). Сервер должен включать подписанное поле url в ответ."
         AppLanguage.JAPANESE -> "有効にすると、ターゲットURLはパッケージ化される代わりに、アクティベーション成功後に検証サーバーから配信されます（URLは空欄可）。サーバーは応答に署名付きのurlフィールドを含める必要があります。"
         AppLanguage.KOREAN -> "활성화 시, 대상 URL이 패키징되는 대신 활성화 성공 후 검증 서버에서 전달됩니다(URL은 비워둘 수 있음). 서버는 응답에 서명된 url 필드를 포함해야 합니다."
+    }
+
+    val remoteActivationDeviceBoundTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "设备绑定（一码一次）"
+        AppLanguage.ENGLISH -> "Device binding (one-time codes)"
+        AppLanguage.ARABIC -> "ربط الجهاز (رموز لمرة واحدة)"
+        AppLanguage.PORTUGUESE -> "Vínculo de dispositivo (códigos únicos)"
+        AppLanguage.SPANISH -> "Vinculación de dispositivo (códigos de un solo uso)"
+        AppLanguage.FRENCH -> "Liaison d'appareil (codes à usage unique)"
+        AppLanguage.GERMAN -> "Gerätebindung (Einmalcodes)"
+        AppLanguage.RUSSIAN -> "Привязка к устройству (одноразовые коды)"
+        AppLanguage.JAPANESE -> "デバイスバインディング（使い切りコード）"
+        AppLanguage.KOREAN -> "기기 바인딩(일회용 코드)"
+    }
+    val remoteActivationDeviceBoundHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "需要远程验证。开启后，激活请求携带设备标识，由服务器执行绑定：每个码默认限 1 台设备（首个激活的设备占座），其他设备激活将被拒绝。卸载重装不换设备不受影响；清除数据/换机后需服务器释放座位。本地（离线）验证无法实现此能力。"
+        AppLanguage.ENGLISH -> "Requires remote verification. The activation request carries a device identifier and the server enforces binding: each code is limited to 1 device by default (the first device to activate claims the seat); other devices are rejected. Reinstalling on the same device is unaffected; after clearing data or switching devices the server must release the seat. Not possible with local (offline) verification."
+        AppLanguage.ARABIC -> "يتطلب التحقق عن بُعد. يحمل طلب التفعيل معرّف الجهاز ويقوم الخادم بالربط: كل رمز محدود بجهاز واحد افتراضياً (أول جهاز يفعّل يحجز المقعد)؛ تُرفض الأجهزة الأخرى. إعادة التثبيت على نفس الجهاز لا تتأثر؛ بعد مسح البيانات أو تغيير الجهاز يجب أن يفرغ الخادم المقعد. غير ممكن مع التحقق المحلي (دون اتصال)."
+        AppLanguage.PORTUGUESE -> "Requer verificação remota. A solicitação de ativação carrega um identificador de dispositivo e o servidor impõe o vínculo: cada código é limitado a 1 dispositivo por padrão (o primeiro dispositivo a ativar reivindica a vaga); outros dispositivos são rejeitados. Reinstalar no mesmo dispositivo não é afetado; após limpar dados ou trocar de dispositivo o servidor precisa liberar a vaga. Não é possível com verificação local (offline)."
+        AppLanguage.SPANISH -> "Requiere verificación remota. La solicitud de activación lleva un identificador de dispositivo y el servidor aplica la vinculación: cada código está limitado a 1 dispositivo por defecto (el primer dispositivo que activa reclama el cupo); otros dispositivos son rechazados. Reinstalar en el mismo dispositivo no se ve afectado; tras borrar datos o cambiar de dispositivo el servidor debe liberar el cupo. No es posible con verificación local (sin conexión)."
+        AppLanguage.FRENCH -> "Nécessite la vérification distante. La requête d'activation transporte un identifiant d'appareil et le serveur applique la liaison : chaque code est limité à 1 appareil par défaut (le premier appareil qui active réserve la place) ; les autres appareils sont refusés. Réinstaller sur le même appareil n'a aucun effet ; après effacement des données ou changement d'appareil, le serveur doit libérer la place. Impossible avec la vérification locale (hors ligne)."
+        AppLanguage.GERMAN -> "Erfordert Remote-Verifizierung. Die Aktivierungsanfrage überträgt eine Gerätekennung, der Server erzwingt die Bindung: Jeder Code ist standardmäßig auf 1 Gerät begrenzt (das erste Gerät, das aktiviert, belegt den Platz); andere Geräte werden abgelehnt. Neuinstallation auf demselben Gerät bleibt unberührt; nach Datenlöschung oder Gerätewechsel muss der Server den Platz freigeben. Mit lokaler (Offline-)Verifizierung nicht möglich."
+        AppLanguage.RUSSIAN -> "Требуется удалённая проверка. Запрос активации несёт идентификатор устройства, сервер выполняет привязку: каждый код по умолчанию ограничен 1 устройством (первое активировавшее устройство занимает место); другие устройства отклоняются. Переустановка на том же устройстве не влияет; после очистки данных или смены устройства сервер должен освободить место. При локальной (офлайн) проверке невозможно."
+        AppLanguage.JAPANESE -> "リモート検証が必要です。アクティベーション要求にデバイス識別子を含め、サーバー側でバインディングを強制します：各コードは既定で1台のデバイスに制限され（最初にアクティベートしたデバイスが席を確保）、他のデバイスは拒否されます。同じデバイスへの再インストールは影響しません。データ消去や機種変更後はサーバーで席を解放する必要があります。ローカル（オフライン）検証では実現できません。"
+        AppLanguage.KOREAN -> "원격 검증이 필요합니다. 활성화 요청에 기기 식별자를 담아 서버가 바인딩을 강제합니다: 각 코드는 기본적으로 1대의 기기로 제한되며(최초 활성화한 기기가 자리를 차지), 다른 기기는 거부됩니다. 같은 기기에 재설치해도 영향이 없으며, 데이터 삭제나 기기 변경 후에는 서버에서 자리를 해제해야 합니다. 로컬(오프라인) 검증으로는 불가능합니다."
     }
 
     val remoteActivationEncryptUrlTitle: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -190,6 +190,9 @@ data class ShellConfig(
     @SerializedName("activationRemoteAesKey")
     val activationRemoteAesKey: String = "",
 
+    @SerializedName("activationRemoteDeviceBound")
+    val activationRemoteDeviceBound: Boolean = false,
+
     @SerializedName("adBlockEnabled")
     val adBlockEnabled: Boolean = false,
 

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -1396,7 +1396,12 @@ data class RemoteActivationConfig(
     val offlinePolicy: RemoteActivationOfflinePolicy = RemoteActivationOfflinePolicy.ALLOW_CACHED,
     val deliverUrl: Boolean = false,
     val encryptUrl: Boolean = false,
-    val aesKeyBase64: String = ""
+    val aesKeyBase64: String = "",
+    // When true, the verification request carries deviceBound=true so the server can
+    // enforce per-device seats (maxDevices, default 1 = one-time / single-device code).
+    // Requires a remote verifier; purely local activation cannot bind devices because
+    // there is no shared state between devices.
+    val deviceBound: Boolean = false
 )
 
 data class AutoStartConfig(

--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -515,6 +515,13 @@ private fun RemoteActivationSection(
             onCheckedChange = { onRemoteConfigChange(remoteConfig.copy(deliverUrl = it)) }
         )
 
+        WtaToggleRow(
+            title = Strings.remoteActivationDeviceBoundTitle,
+            subtitle = Strings.remoteActivationDeviceBoundHint,
+            checked = remoteConfig.deviceBound,
+            onCheckedChange = { onRemoteConfigChange(remoteConfig.copy(deviceBound = it)) }
+        )
+
         AnimatedVisibility(
             visible = remoteConfig.deliverUrl,
             enter = CardExpandTransition,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -46,7 +46,8 @@ fun ShellActivationDialog(
                         offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
                         deliverUrl = config.activationRemoteDeliverUrl,
                         encryptUrl = config.activationRemoteEncryptUrl,
-                        aesKeyBase64 = config.activationRemoteAesKey
+                        aesKeyBase64 = config.activationRemoteAesKey,
+                        deviceBound = config.activationRemoteDeviceBound
                     )
                 )
             } else {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -188,7 +188,8 @@ fun ShellScreen(
                                 offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
                                 deliverUrl = config.activationRemoteDeliverUrl,
                                 encryptUrl = config.activationRemoteEncryptUrl,
-                                aesKeyBase64 = config.activationRemoteAesKey
+                                aesKeyBase64 = config.activationRemoteAesKey,
+                                deviceBound = config.activationRemoteDeviceBound
                             )
                         )
                 } else {

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -138,7 +138,8 @@ fun SplashLauncherScreen(
                     offlinePolicy = remoteConfig.offlinePolicy,
                     deliverUrl = remoteConfig.deliverUrl,
                     encryptUrl = remoteConfig.encryptUrl,
-                    aesKeyBase64 = remoteConfig.aesKeyBase64
+                    aesKeyBase64 = remoteConfig.aesKeyBase64,
+                    deviceBound = remoteConfig.deviceBound
                 )
                 if (activationRequireEveryTime) {
                     val result = activation.reverifyRemoteWithCachedCode(activationAppId, remoteRequest)
@@ -283,7 +284,8 @@ fun SplashLauncherScreen(
                             offlinePolicy = remoteConfig.offlinePolicy,
                             deliverUrl = remoteConfig.deliverUrl,
                             encryptUrl = remoteConfig.encryptUrl,
-                            aesKeyBase64 = remoteConfig.aesKeyBase64
+                            aesKeyBase64 = remoteConfig.aesKeyBase64,
+                            deviceBound = remoteConfig.deviceBound
                         )
                     )
                 } else {

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -1398,7 +1398,8 @@ fun WebViewScreen(
                                         offlinePolicy = remote.offlinePolicy,
                                         deliverUrl = remote.deliverUrl,
                                         encryptUrl = remote.encryptUrl,
-                                        aesKeyBase64 = remote.aesKeyBase64
+                                        aesKeyBase64 = remote.aesKeyBase64,
+                                        deviceBound = remote.deviceBound
                                     )
                                 )
                         } else {
@@ -3554,7 +3555,8 @@ fun WebViewScreen(
                             offlinePolicy = remote.offlinePolicy,
                             deliverUrl = remote.deliverUrl,
                             encryptUrl = remote.encryptUrl,
-                            aesKeyBase64 = remote.aesKeyBase64
+                            aesKeyBase64 = remote.aesKeyBase64,
+                            deviceBound = remote.deviceBound
                         )
                     )
                     if (result is com.webtoapp.core.activation.ActivationResult.Success && remote.deliverUrl) {

--- a/app/src/test/java/com/webtoapp/core/activation/RemoteDeviceBoundRoundTripTest.kt
+++ b/app/src/test/java/com/webtoapp/core/activation/RemoteDeviceBoundRoundTripTest.kt
@@ -1,0 +1,77 @@
+package com.webtoapp.core.activation
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.apkbuilder.ApkConfigJsonFactory
+import com.webtoapp.core.apkbuilder.toApkConfig
+import com.webtoapp.core.shell.ShellConfig
+import com.webtoapp.data.model.RemoteActivationConfig
+import com.webtoapp.data.model.RemoteActivationOfflinePolicy
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.util.GsonProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression coverage for the device-bound remote activation round trip (#704-era gap):
+ * PR #570 removed the local DEVICE_BOUND code type and, with it, the only call site that
+ * forwarded `deviceBound` into remote requests — the server's seat enforcement
+ * (`maxDevices`, default 1 = one-time code) could never trigger because the client
+ * always sent `deviceBound: false`.
+ *
+ * The editor toggle now flows through model → ApkConfig → JSON → shell config, and
+ * every runtime call site forwards it via `buildRemoteRequest(deviceBound = …)`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RemoteDeviceBoundRoundTripTest {
+
+    private fun shellJsonOf(remote: RemoteActivationConfig): String {
+        val app = WebApp(name = "t", url = "https://t.example.com", activationRemoteConfig = remote)
+        val apk = app.toApkConfig("com.example.test")
+        return ApkConfigJsonFactory.toShellConfigJson(apk)
+    }
+
+    @Test
+    fun `deviceBound survives the export round trip when enabled`() {
+        val json = shellJsonOf(
+            RemoteActivationConfig(
+                enabled = true,
+                verifyUrl = "https://example.com/verify",
+                publicKeyBase64 = "PUBKEY",
+                deviceBound = true
+            )
+        )
+        val shell = GsonProvider.gson.fromJson(json, ShellConfig::class.java)!!
+        assertThat(shell.activationRemoteEnabled).isTrue()
+        assertThat(shell.activationRemoteDeviceBound).isTrue()
+    }
+
+    @Test
+    fun `deviceBound stays false by default and when disabled`() {
+        val json = shellJsonOf(RemoteActivationConfig(enabled = true, verifyUrl = "https://x"))
+        val shell = GsonProvider.gson.fromJson(json, ShellConfig::class.java)!!
+        assertThat(shell.activationRemoteDeviceBound).isFalse()
+    }
+
+    @Test
+    fun `buildRemoteRequest forwards the deviceBound flag`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val activation = ActivationManager(context)
+        val request = activation.buildRemoteRequest(
+            verifyUrl = "https://example.com/verify",
+            publicKeyBase64 = "PUBKEY",
+            offlinePolicy = RemoteActivationOfflinePolicy.ALLOW_CACHED,
+            deviceBound = true
+        )
+        assertThat(request.deviceBound).isTrue()
+
+        val requestOff = activation.buildRemoteRequest(
+            verifyUrl = "https://example.com/verify",
+            publicKeyBase64 = "PUBKEY",
+            offlinePolicy = RemoteActivationOfflinePolicy.ALLOW_CACHED
+        )
+        assertThat(requestOff.deviceBound).isFalse()
+    }
+}

--- a/docs/guide/app-actions/edit-common-config/activation.md
+++ b/docs/guide/app-actions/edit-common-config/activation.md
@@ -11,8 +11,11 @@ Gate the generated app behind activation codes, so it runs only after a valid co
 - **Require every time** — ask for the code on every launch, not just the first (`activationRequireEveryTime`).
 - **Dialog config** — customize the activation dialog (title, subtitle, input label, button text).
 - **Remote activation** — verify against your own HTTPS endpoint signed with EC P-256, with an offline policy (`activationRemoteConfig`).
+- **Device binding (one-time codes)** — remote-verification only (`activationRemoteConfig.deviceBound`). The verification request carries a device identifier and the server enforces per-code seats: each code is limited to 1 device by default (first device to activate claims the seat), so a code behaves as a one-time / single-device code. Other devices are rejected with the server's message. The claimed seat survives uninstall + reinstall on the same device. Requires a verification server that enforces binding — the [reference worker](https://github.com/shiaho777/web-to-app/blob/main/examples/remote-activation-worker/README.md) does this out of the box via `maxDevices`.
 
 ## Notes
 
 - Local verification checks codes on-device; remote verification calls your server. See the [remote activation reference](https://github.com/shiaho777/web-to-app/blob/main/.github/docs/remote-activation.md).
+- Device binding is impossible with local verification: the app has no shared state between devices, so any "one-time" claim on a purely local code cannot be enforced. Use remote verification with **Device binding** enabled for one-time codes.
+- The **usage limit** on a local usage-limited code counts app launches on the device after activation — it is not a per-code redemption limit and resets if app data is cleared.
 - The app list shows an activation chip on gated apps.

--- a/docs/zh/guide/app-actions/edit-common-config/activation.md
+++ b/docs/zh/guide/app-actions/edit-common-config/activation.md
@@ -11,8 +11,11 @@
 - **每次验证** —— 每次启动都要求输入码,而非仅首次(`activationRequireEveryTime`)。
 - **对话框配置** —— 自定义激活对话框(标题、副标题、输入框标签、按钮文本)。
 - **远程激活** —— 对你自己经 EC P-256 签名的 HTTPS 端点校验,带离线策略(`activationRemoteConfig`)。
+- **设备绑定(一码一次)** —— 仅远程验证可用(`activationRemoteConfig.deviceBound`)。激活请求携带设备标识,由服务器执行每码占座:每个码默认限 1 台设备(首台激活的设备占座),即一次性/单设备码;其他设备激活会被拒绝并显示服务器消息。同一设备卸载重装不丢失占座。需要能执行绑定的验证服务器——[参考 Worker](https://github.com/shiaho777/web-to-app/blob/main/examples/remote-activation-worker/README.md) 通过 `maxDevices` 开箱即用。
 
 ## 说明
 
 - 本地校验在设备上检查码;远程校验调用你的服务器。见[远程激活参考](https://github.com/shiaho777/web-to-app/blob/main/.github/docs/remote-activation.md)。
+- 本地校验无法实现设备绑定:应用在设备间没有任何共享状态,纯本地的"一码一次"无法强制执行。一次性码请使用远程验证并开启 **设备绑定**。
+- 本地"次数限制"码的次数指激活后本机的应用启动次数,不是该码可被兑换的次数;清除应用数据后会重置。
 - 应用列表会在设门的应用上显示激活标签。


### PR DESCRIPTION
## Summary

Fixes #708. Restores the ability to run one-time / single-device activation codes with remote verification, lost as a side effect of PR #570: the server-side seat enforcement (`maxDevices` in the reference worker) only triggers when the request carries `deviceBound: true`, and after #570 no client path could ever send that flag. Now an explicit editor toggle flows through the whole chain and every remote call site forwards it.

## Changes

- **Model** — `RemoteActivationConfig.deviceBound` (default `false`).
- **Export chain** — `ActivationBlock.remoteDeviceBound` (ApkConfig) → `buildActivationBlock` → `"activationRemoteDeviceBound"` in `ApkConfigJsonFactory` → `@SerializedName` field in `ShellModeManager` (shell config).
- **Runtime** — all six `buildRemoteRequest` call sites now forward the flag: `ShellScreen` (startup check), `ShellDialogs` (activation dialog), `WebViewActivity` ×2 (startup + dialog), `SplashLauncherActivity` ×2 (startup + dialog).
- **Editor UI** — "Device binding (one-time codes)" toggle in the remote-activation section, after the deliver-URL block. The hint explains the enforcement model (server-side seats, `maxDevices` default 1 = first device wins), that reinstalling on the same device keeps the seat, and that local verification cannot do this. Strings cover all 10 languages.
- **Docs** — activation guide (EN + ZH) documents the toggle, clarifies that a local usage-limit counts launches (not redemptions) and resets on data clear, and points one-time-code users to remote verification. `.github/docs/remote-activation.md` now ties `deviceBound` to the editor toggle, describes the reference worker's seat behavior and how to release a seat.

## Design notes

- The flag is transport-only: servers that ignore it behave exactly as before, so this is backward compatible with any deployed verifier.
- Device identity derives from `ANDROID_ID` (stable per signing key), so a claimed seat survives uninstall + reinstall on the same device; factory reset / new device yields a new id and needs the seat released server-side (documented).
- Local one-time codes remain impossible by design — the UI copy and docs say so explicitly instead of implying otherwise (the #570 rationale still stands).

## Test plan

- [x] New `RemoteDeviceBoundRoundTripTest`: flag survives model → ApkConfig → shell JSON round trip (on and off) and `buildRemoteRequest` forwards it
- [x] Full `:app:testStandardDebugUnitTest` — passes
- [x] `checkConfigFieldDrift` — OK (payload 438→439, shell 469→470, shared 431→432)
- [x] Shell template rebuilt; `activationRemoteDeviceBound` confirmed present in the template DEX