### PR TITLE
fix(shell): stop fabricating a 24dp status-bar band when insets report 0

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/components/StatusBarBackground.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/StatusBarBackground.kt
@@ -28,14 +28,19 @@ fun StatusBarBackground(
     val context = LocalContext.current
     val density = LocalDensity.current
 
+    // Never guess a status-bar height when the insets report 0: on the classic pre-API-30
+    // path the value is 0 because the decor fits system windows, and a fabricated 24dp band
+    // shows up as a blank strip over the content (issue #683). The callers skip rendering on
+    // that path; the fallback below only covers transient first-frame inset dispatch.
     val topInsetPx = WindowInsets.statusBars.getTop(density)
     val systemStatusBarHeight = if (topInsetPx > 0) {
         with(density) { topInsetPx.toDp() }
     } else {
-        24.dp
+        0.dp
     }
 
     val actualHeight = if (heightDp >= 0) heightDp.dp else systemStatusBarHeight
+    if (actualHeight <= 0.dp) return
 
     val imageBitmap = remember(backgroundImagePath) {
         if (backgroundType == "IMAGE" && !backgroundImagePath.isNullOrEmpty()) {
@@ -115,14 +120,19 @@ fun StatusBarOverlay(
     val context = LocalContext.current
     val density = LocalDensity.current
 
+    // Never guess a status-bar height when the insets report 0: on the classic pre-API-30
+    // path the value is 0 because the decor fits system windows, and a fabricated 24dp band
+    // shows up as a blank strip over the content (issue #683). The callers skip rendering on
+    // that path; the fallback below only covers transient first-frame inset dispatch.
     val topInsetPx = WindowInsets.statusBars.getTop(density)
     val systemStatusBarHeight = if (topInsetPx > 0) {
         with(density) { topInsetPx.toDp() }
     } else {
-        24.dp
+        0.dp
     }
 
     val actualHeight = if (heightDp >= 0) heightDp.dp else systemStatusBarHeight
+    if (actualHeight <= 0.dp) return
 
     val imageBitmap = remember(backgroundImagePath) {
         if (backgroundType == "IMAGE" && !backgroundImagePath.isNullOrEmpty()) {

--- a/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
@@ -288,6 +288,18 @@ object WindowHelper {
         return window.attributes.softInputMode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE != 0
     }
 
+    /**
+     * Runtime truth for "this window does not draw behind the status bar and
+     * [androidx.compose.foundation.layout.WindowInsets.statusBars] cannot be used to size a
+     * status-bar band": on the classic pre-API-30 resize path the decor fits system windows,
+     * the insets value is 0 whether or not a bar is actually shown, and nothing renders behind
+     * the bar area. Compose callers must not fall back to a made-up 24dp band there (issue
+     * #683: fullscreen + "show status bar" left a blank strip because the content padding and
+     * the overlay each guessed an independent height).
+     */
+    fun isClassicSystemBarsWindow(activity: Activity): Boolean =
+        isClassicKeyboardResizeWindow(activity.window)
+
     private fun applyKeyboardMode(
         activity: Activity,
         keyboardAdjustMode: KeyboardAdjustMode?,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -166,11 +166,23 @@ fun BoxScope.ShellScaffoldLayout(
 
         val density = LocalDensity.current
 
-        val topInsetPx = WindowInsets.statusBars.getTop(density)
-        val systemStatusBarHeightDp = if (topInsetPx > 0) {
-            with(density) { topInsetPx.toDp() }
+        // On the classic pre-API-30 resize path the decor fits system windows: the status-bar
+        // inset is 0 whether or not a bar is drawn, and nothing renders behind the bar area
+        // (issue #683). Never pad the content by a guessed status-bar band there — only the
+        // user's explicit statusBarHeightDp override may reserve space.
+        val classicSystemBars = LocalContext.current.let { ctx ->
+            (ctx as? android.app.Activity)?.let { com.webtoapp.ui.shared.WindowHelper.isClassicSystemBarsWindow(it) } ?: false
+        }
+
+        val systemStatusBarHeightDp = if (classicSystemBars) {
+            0.dp
         } else {
-            24.dp
+            val topInsetPx = WindowInsets.statusBars.getTop(density)
+            if (topInsetPx > 0) {
+                with(density) { topInsetPx.toDp() }
+            } else {
+                0.dp
+            }
         }
 
         val actualStatusBarPadding = if (statusBarHeightDp >= 0) statusBarHeightDp.dp else systemStatusBarHeightDp

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -578,10 +578,15 @@ fun ShellScreen(
     val effectiveBgColor = resolveStatusBarOverlayColor(isDarkTheme)
     val effectiveBgImage = if (isDarkTheme) statusBarBackgroundImageDark else statusBarBackgroundImage
     val effectiveBgAlpha = if (isDarkTheme) statusBarBackgroundAlphaDark else statusBarBackgroundAlpha
-    val showOverlay = (hideToolbar && config.webViewConfig.showStatusBarInFullscreen) ||
+    // On the classic pre-API-30 resize path nothing draws behind the status bar and the bar
+    // itself is chrome-owned, so a Compose overlay would only paint a floating band over the
+    // web content (issue #683). Reserve space is already handled by the content padding; the
+    // window-level bar color comes from WindowHelper.
+    val classicSystemBars = com.webtoapp.ui.shared.WindowHelper.isClassicSystemBarsWindow(activity)
+    val showOverlay = !classicSystemBars && ((hideToolbar && config.webViewConfig.showStatusBarInFullscreen) ||
             (!hideToolbar && (effectiveBgType != "COLOR" ||
                 effectiveColorMode == com.webtoapp.data.model.StatusBarColorMode.CUSTOM.name ||
-                effectiveColorMode == com.webtoapp.data.model.StatusBarColorMode.PAGE_TOP.name))
+                effectiveColorMode == com.webtoapp.data.model.StatusBarColorMode.PAGE_TOP.name)))
     if (showOverlay) {
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2945,11 +2945,21 @@ fun WebViewScreen(
 
         val density = LocalDensity.current
 
-        val topInsetPx = WindowInsets.statusBars.getTop(density)
-        val systemStatusBarHeightDp = if (topInsetPx > 0) {
-            with(density) { topInsetPx.toDp() }
+        // On the classic pre-API-30 resize path the decor fits system windows: the status-bar
+        // inset is 0 whether or not a bar is drawn, and nothing renders behind the bar area
+        // (issue #683). Never pad the content by a guessed status-bar band there — only the
+        // user's explicit statusBarHeightDp override may reserve space.
+        val classicSystemBars = com.webtoapp.ui.shared.WindowHelper.isClassicSystemBarsWindow(activity)
+
+        val systemStatusBarHeightDp = if (classicSystemBars) {
+            0.dp
         } else {
-            24.dp
+            val topInsetPx = WindowInsets.statusBars.getTop(density)
+            if (topInsetPx > 0) {
+                with(density) { topInsetPx.toDp() }
+            } else {
+                0.dp
+            }
         }
 
         val actualStatusBarPadding = if (statusBarHeightDp >= 0) statusBarHeightDp.dp else systemStatusBarHeightDp
@@ -3517,7 +3527,12 @@ fun WebViewScreen(
         }
     }
 
-    if (hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true) {
+    // On the classic pre-API-30 resize path nothing draws behind the status bar and the bar
+    // itself is chrome-owned, so a Compose overlay would only paint a floating band over the
+    // web content (issue #683); the window-level bar color comes from WindowHelper instead.
+    if (!com.webtoapp.ui.shared.WindowHelper.isClassicSystemBarsWindow(activity) &&
+        hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true
+    ) {
         val overlayIsDark = com.webtoapp.ui.theme.LocalIsDarkTheme.current
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,

--- a/app/src/test/java/com/webtoapp/ui/shared/WindowHelperKeyboardModeTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/shared/WindowHelperKeyboardModeTest.kt
@@ -103,6 +103,22 @@ class WindowHelperKeyboardModePreApi30Test {
         assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING).isNotEqualTo(0)
         assertThat(isEdgeToEdge(activity)).isTrue()
     }
+
+    @Test
+    fun `classic system bars window reports true below API 30 in resize mode`() {
+        val activity = Robolectric.setupActivity(Activity::class.java)
+
+        WindowHelper.applyImmersiveFullscreen(
+            activity,
+            enabled = false,
+            keyboardAdjustMode = KeyboardAdjustMode.RESIZE
+        )
+
+        // Issue #683: Compose callers key their status-bar padding / overlay decisions off
+        // this flag, because WindowInsets.statusBars reports 0 on this path whether or not a
+        // bar is drawn — a fabricated 24dp fallback band is what left the blank strip.
+        assertThat(WindowHelper.isClassicSystemBarsWindow(activity)).isTrue()
+    }
 }
 
 @RunWith(RobolectricTestRunner::class)
@@ -122,5 +138,18 @@ class WindowHelperKeyboardModeApi30Test {
         val mode = activity.window.attributes.softInputMode
         assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING).isNotEqualTo(0)
         assertThat(isEdgeToEdge(activity)).isTrue()
+    }
+
+    @Test
+    fun `classic system bars window reports false on API 30 and above`() {
+        val activity = Robolectric.setupActivity(Activity::class.java)
+
+        WindowHelper.applyImmersiveFullscreen(
+            activity,
+            enabled = false,
+            keyboardAdjustMode = KeyboardAdjustMode.RESIZE
+        )
+
+        assertThat(WindowHelper.isClassicSystemBarsWindow(activity)).isFalse()
     }
 }


### PR DESCRIPTION
## Summary
Fixes the blank status-bar strip in fullscreen mode (issue #683, the "状态栏太高 / 会留下一段空白" part).

On the classic pre-API-30 resize path (Android 10 and below with `SOFT_INPUT_ADJUST_RESIZE`), the window's decor fits system windows, so:
- `WindowInsets.statusBars` reports **0** whether or not a status bar is actually drawn, and
- nothing renders behind the status-bar area.

Four call sites treated "insets == 0" as "fall back to a fabricated 24dp band" (content padding in `ShellScaffoldLayout` / `WebViewActivity`, and the overlay height in `StatusBarBackground` / `StatusBarOverlay`). The Compose `StatusBarOverlay` also rendered on the classic path, painting a floating band over the web content. Combined, this left a blank strip at the top of fullscreen WebView content.

### Changes
- `WindowHelper.isClassicSystemBarsWindow(activity)` — single source of truth for "this window does not draw behind the status bar and Compose insets cannot size a status-bar band" (reuses the existing `isClassicKeyboardResizeWindow` check: SDK < 30 && ADJUST_RESIZE).
- `ShellScaffoldLayout` / `WebViewActivity` — on the classic path, status-bar padding is 0dp (only the user's explicit `statusBarHeightDp` override may reserve space); the non-classic `insets == 0` fallback becomes 0dp instead of 24dp.
- `ShellScreen` / `WebViewActivity` — skip the Compose `StatusBarOverlay` on the classic path; the window-level bar color still comes from `WindowHelper`.
- `StatusBarBackground` / `StatusBarOverlay` — 0dp fallback with an early return, kept only as a transient first-frame inset-dispatch guard.
- `WindowHelperKeyboardModeTest` — Robolectric regression tests for the new API (true on API 29, false on API 30).

Fixes #683

## Test plan
- [x] `WindowHelperKeyboardModeTest` (PreApi30 + Api30 variants) passes
- [x] `./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex` compiles clean
- [ ] Follow-up (not in this PR): shell template rebuild `:shell:assembleRelease :app:syncShellTemplateApk` is required before a release, since `ShellScreen` / `ShellScaffoldLayout` are shell-synced