### PR TITLE
fix(editor): refuse binary and oversized files in the HTML code editor

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -4106,6 +4106,8 @@ object Strings {
     val codeEditorReplaceHint: String get() = StringsE.codeEditorReplaceHint
     val codeEditorMatchCase: String get() = StringsE.codeEditorMatchCase
     val codeEditorNoMatches: String get() = StringsE.codeEditorNoMatches
+    val codeEditorBinaryFile: String get() = StringsE.codeEditorBinaryFile
+    val codeEditorFileTooLarge: String get() = StringsE.codeEditorFileTooLarge
     val orWriteDirectly: String get() = StringsE.orWriteDirectly
     val deviceDisguiseTitle: String get() = StringsE.deviceDisguiseTitle
     val deviceDisguiseHint: String get() = StringsE.deviceDisguiseHint
@@ -56247,6 +56249,30 @@ object StringsE {
         AppLanguage.RUSSIAN -> "Совпадений нет"
         AppLanguage.JAPANESE -> "一致なし"
         AppLanguage.KOREAN -> "결과 없음"
+    }
+    val codeEditorBinaryFile: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "此文件是二进制文件（图片、字体等），不支持文本编辑"
+        AppLanguage.ENGLISH -> "This file is binary (image, font, etc.) and cannot be edited as text"
+        AppLanguage.ARABIC -> "هذا ملف ثنائي (صورة أو خط وما إلى ذلك) ولا يمكن تحريره كنص"
+        AppLanguage.PORTUGUESE -> "Este arquivo é binário (imagem, fonte etc.) e não pode ser editado como texto"
+        AppLanguage.SPANISH -> "Este archivo es binario (imagen, fuente, etc.) y no se puede editar como texto"
+        AppLanguage.FRENCH -> "Ce fichier est binaire (image, police, etc.) et ne peut pas être modifié comme texte"
+        AppLanguage.GERMAN -> "Diese Datei ist binär (Bild, Schriftart usw.) und kann nicht als Text bearbeitet werden"
+        AppLanguage.RUSSIAN -> "Этот файл бинарный (изображение, шрифт и т.п.) и не может быть изменён как текст"
+        AppLanguage.JAPANESE -> "このファイルはバイナリ（画像・フォントなど）のため、テキスト編集できません"
+        AppLanguage.KOREAN -> "이 파일은 바이너리(이미지, 글꼴 등)이므로 텍스트로 편집할 수 없습니다"
+    }
+    val codeEditorFileTooLarge: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "文件过大（超过 1 MB），不支持在应用内编辑"
+        AppLanguage.ENGLISH -> "File is too large (over 1 MB) to edit in-app"
+        AppLanguage.ARABIC -> "الملف كبير جدًا (أكثر من 1 ميغابايت) ولا يمكن تحريره داخل التطبيق"
+        AppLanguage.PORTUGUESE -> "O arquivo é grande demais (mais de 1 MB) para editar no app"
+        AppLanguage.SPANISH -> "El archivo es demasiado grande (más de 1 MB) para editarse en la app"
+        AppLanguage.FRENCH -> "Le fichier est trop volumineux (plus de 1 Mo) pour être modifié dans l'appli"
+        AppLanguage.GERMAN -> "Die Datei ist zu groß (über 1 MB), um sie in der App zu bearbeiten"
+        AppLanguage.RUSSIAN -> "Файл слишком большой (более 1 МБ) для редактирования в приложении"
+        AppLanguage.JAPANESE -> "ファイルが大きすぎる（1 MB 超）ため、アプリ内では編集できません"
+        AppLanguage.KOREAN -> "파일이 너무 커서(1 MB 초과) 앱에서 편집할 수 없습니다"
     }
     val orWriteDirectly: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "或直接编写"

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateHtmlAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateHtmlAppScreen.kt
@@ -1,6 +1,7 @@
 package com.webtoapp.ui.screens
 
 import android.net.Uri
+import android.widget.Toast
 import com.webtoapp.ui.design.WtaSwitch
 import com.webtoapp.ui.components.PremiumOutlinedButton
 import android.provider.DocumentsContract
@@ -420,7 +421,7 @@ fun CreateHtmlAppScreen(
     if (showCodeEditorDialog) {
         CodeEditorDialog(
             fileType = codeEditorType,
-            initialContent = codeEditorContent,
+            initialContent = codeEditorContent.takeIf { it.length <= MAX_CODE_EDITOR_FILE_BYTES / 4 } ?: "",
             onSave = { content ->
 
                 val fileName = codeEditorFileName ?: when (codeEditorType) {
@@ -720,8 +721,10 @@ fun CreateHtmlAppScreen(
                                 onSelect = { filePickerLauncher.launch("*/*") },
                                 onClear = { manualFiles = manualFiles.toMutableList().also { it.removeAt(index) } },
                                 onEdit = {
+                                    val editFile = File(file.path)
+                                    if (!isFileEditableInCodeEditor(context, editFile)) return@HtmlFileSlot
                                     codeEditorType = file.type.takeIf { it == HtmlFileType.HTML || it == HtmlFileType.CSS || it == HtmlFileType.JS } ?: HtmlFileType.OTHER
-                                    codeEditorContent = try { File(file.path).readText() } catch (e: Exception) { "" }
+                                    codeEditorContent = try { editFile.readText() } catch (e: Exception) { "" }
 
                                     codeEditorFileName = file.name
                                     showCodeEditorDialog = true
@@ -778,6 +781,7 @@ fun CreateHtmlAppScreen(
                                 onClick = {
                                     codeEditorType = HtmlFileType.HTML
                                     val existingHtml = manualFiles.firstOrNull { it.type == HtmlFileType.HTML || it.name.endsWith(".html", ignoreCase = true) }
+                                    if (existingHtml != null && !isFileEditableInCodeEditor(context, File(existingHtml.path))) return@PremiumOutlinedButton
                                     codeEditorContent = if (existingHtml != null) {
                                         try { File(existingHtml.path).readText() } catch (e: Exception) { "" }
                                     } else "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n    <meta charset=\"UTF-8\">\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n    <title>My App</title>\n</head>\n<body>\n    <h1>Hello World</h1>\n</body>\n</html>"
@@ -795,6 +799,7 @@ fun CreateHtmlAppScreen(
                                 onClick = {
                                     codeEditorType = HtmlFileType.CSS
                                     val existingCss = manualFiles.firstOrNull { it.type == HtmlFileType.CSS }
+                                    if (existingCss != null && !isFileEditableInCodeEditor(context, File(existingCss.path))) return@PremiumOutlinedButton
                                     codeEditorContent = if (existingCss != null) {
                                         try { File(existingCss.path).readText() } catch (e: Exception) { "" }
                                     } else "/* Styles */\nbody {\n    margin: 0;\n    padding: 0;\n    font-family: sans-serif;\n}\n"
@@ -812,6 +817,7 @@ fun CreateHtmlAppScreen(
                                 onClick = {
                                     codeEditorType = HtmlFileType.JS
                                     val existingJs = manualFiles.firstOrNull { it.type == HtmlFileType.JS }
+                                    if (existingJs != null && !isFileEditableInCodeEditor(context, File(existingJs.path))) return@PremiumOutlinedButton
                                     codeEditorContent = if (existingJs != null) {
                                         try { File(existingJs.path).readText() } catch (e: Exception) { "" }
                                     } else "// JavaScript\ndocument.addEventListener('DOMContentLoaded', () => {\n    console.log('App loaded');\n});\n"
@@ -1549,6 +1555,40 @@ private fun getFileType(fileName: String): HtmlFileType {
         "ttf", "otf", "woff", "woff2", "eot" -> HtmlFileType.FONT
         else -> HtmlFileType.OTHER
     }
+}
+
+private const val MAX_CODE_EDITOR_FILE_BYTES = 1L shl 20
+
+/**
+ * Guards the in-app code editor. Binary files (images, fonts, …) and oversized text
+ * files would render the whole content into one composable tree and freeze / OOM the
+ * app, so they are refused with a toast before the editor opens.
+ */
+private fun isFileEditableInCodeEditor(context: android.content.Context, file: File?): Boolean {
+    if (file == null) return true
+    if (file.length() > MAX_CODE_EDITOR_FILE_BYTES) {
+        Toast.makeText(context, Strings.codeEditorFileTooLarge, Toast.LENGTH_SHORT).show()
+        return false
+    }
+    val sample = try {
+        file.inputStream().use { input ->
+            val buffer = ByteArray(4096)
+            val read = input.read(buffer)
+            if (read > 0) buffer.copyOf(read) else ByteArray(0)
+        }
+    } catch (e: Exception) {
+        Toast.makeText(context, Strings.codeEditorBinaryFile, Toast.LENGTH_SHORT).show()
+        return false
+    }
+    val isBinary = sample.any { b ->
+        val v = b.toInt() and 0xFF
+        v < 32 && v != '\n'.code && v != '\r'.code && v != '\t'.code
+    }
+    if (isBinary) {
+        Toast.makeText(context, Strings.codeEditorBinaryFile, Toast.LENGTH_SHORT).show()
+        return false
+    }
+    return true
 }
 
 @OptIn(ExperimentalLayoutApi::class)


### PR DESCRIPTION
Fixes #714

## Problem

On the **Create HTML App** screen, tapping the pencil (edit) button next to an **image** resource froze the app for seconds and then crashed it.

## Root cause

`onEdit` in `CreateHtmlAppScreen.kt` read **any** file as text (`File(file.path).readText()`) and handed it to `WtaCodeEditorDialog`, which renders a gutter with **one `Text` composable per line** (`for (i in 1..lineCount)`) plus a `BasicTextField` holding the whole string. A binary blob decodes into millions of lines: the frame freezes, memory spikes (even with `largeHeap`), and the process is killed. FONT and binary OTHER files, plus oversized text files, hit the same wall.

## Fix

1. New `isFileEditableInCodeEditor()` guard in `CreateHtmlAppScreen.kt`:
   - refuses files **> 1 MB** with a localized toast;
   - sniffs the first 4 KB for binary control bytes (same heuristic class as `ExtensionSourceBrowser`) and refuses binary files with a localized toast.
2. Wired into **all four** editor entry points in the screen: the per-file `onEdit` slot and the HTML / CSS / JS "write code" buttons when an existing file is present.
3. Defense-in-depth: the editor `initialContent` is truncated if it somehow exceeds the budget.
4. Two new i18n strings `codeEditorBinaryFile` / `codeEditorFileTooLarge` with all 10 language branches (no `else ->`), satisfying `StringsKtTranslationParityTest`.

## Verification

- `./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex` — pass
- `StringsKtTranslationParityTest` + `AppStringsResourceConsistencyTest` — pass
- `./gradlew :app:checkConfigFieldDrift` — pass