### PR TITLE
feat(icon): manual image upload with crop in the Icon Library

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -963,6 +963,15 @@ object Strings {
     val iconLibraryEmpty: String get() = StringsA.iconLibraryEmpty
     val iconLibraryEmptyHint: String get() = StringsA.iconLibraryEmptyHint
     val savedIcons: String get() = StringsA.savedIcons
+    val uploadToLibrary: String get() = StringsA.uploadToLibrary
+    val uploadToLibraryDesc: String get() = StringsA.uploadToLibraryDesc
+    val cropIcon: String get() = StringsA.cropIcon
+    val cropDragHint: String get() = StringsA.cropDragHint
+    val cropRatioSquare: String get() = StringsA.cropRatioSquare
+    val cropRatioFree: String get() = StringsA.cropRatioFree
+    val cropRatioCircle: String get() = StringsA.cropRatioCircle
+    val cropOriginalSize: String get() = StringsA.cropOriginalSize
+    val cropOutputSize: String get() = StringsA.cropOutputSize
     val deleteIcon: String get() = StringsA.deleteIcon
     val deleteIconConfirm: String get() = StringsA.deleteIconConfirm
     val saveFailed: String get() = StringsA.saveFailed
@@ -17125,6 +17134,123 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Сохраненные иконки"
         AppLanguage.JAPANESE -> "保存済みアイコン"
         AppLanguage.KOREAN -> "저장된 아이콘"
+    }
+
+    val uploadToLibrary: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "上传图片"
+        AppLanguage.ENGLISH -> "Upload Image"
+        AppLanguage.ARABIC -> "تحميل صورة"
+        AppLanguage.PORTUGUESE -> "Enviar Imagem"
+        AppLanguage.SPANISH -> "Subir Imagen"
+        AppLanguage.FRENCH -> "Téléverser une image"
+        AppLanguage.GERMAN -> "Bild hochladen"
+        AppLanguage.RUSSIAN -> "Загрузить изображение"
+        AppLanguage.JAPANESE -> "画像をアップロード"
+        AppLanguage.KOREAN -> "이미지 업로드"
+    }
+
+    val uploadToLibraryDesc: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "从相册选择图片，裁剪后存入图标库"
+        AppLanguage.ENGLISH -> "Pick an image from the gallery, crop it, and save it to the library"
+        AppLanguage.ARABIC -> "اختر صورة من المعرض، قصها، واحفظها في المكتبة"
+        AppLanguage.PORTUGUESE -> "Escolha uma imagem da galeria, recorte-a e salve-a na biblioteca"
+        AppLanguage.SPANISH -> "Elige una imagen de la galería, recórtala y guárdala en la biblioteca"
+        AppLanguage.FRENCH -> "Choisissez une image dans la galerie, recadrez-la et enregistrez-la dans la bibliothèque"
+        AppLanguage.GERMAN -> "Bild aus der Galerie wählen, zuschneiden und in der Bibliothek speichern"
+        AppLanguage.RUSSIAN -> "Выберите изображение из галереи, обрежьте его и сохраните в библиотеку"
+        AppLanguage.JAPANESE -> "ギャラリーから画像を選び、クロップしてライブラリに保存"
+        AppLanguage.KOREAN -> "갤러리에서 이미지를 선택하고 자른 뒤 라이브러리에 저장"
+    }
+
+    val cropIcon: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "裁剪图标"
+        AppLanguage.ENGLISH -> "Crop Icon"
+        AppLanguage.ARABIC -> "قص الأيقونة"
+        AppLanguage.PORTUGUESE -> "Recortar Ícone"
+        AppLanguage.SPANISH -> "Recortar Icono"
+        AppLanguage.FRENCH -> "Rogner l'icône"
+        AppLanguage.GERMAN -> "Symbol zuschneiden"
+        AppLanguage.RUSSIAN -> "Обрезать иконку"
+        AppLanguage.JAPANESE -> "アイコンをクロップ"
+        AppLanguage.KOREAN -> "아이콘 자르기"
+    }
+
+    val cropDragHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "拖动或双指缩放调整裁剪区域"
+        AppLanguage.ENGLISH -> "Drag or pinch to adjust the crop area"
+        AppLanguage.ARABIC -> "اسحب أو استخدم إصبعين لضبط منطقة القص"
+        AppLanguage.PORTUGUESE -> "Arraste ou pinça para ajustar a área de corte"
+        AppLanguage.SPANISH -> "Arrastra o pellizca para ajustar el área de recorte"
+        AppLanguage.FRENCH -> "Faites glisser ou pincez pour ajuster la zone de rognage"
+        AppLanguage.GERMAN -> "Ziehen oder auf-/zuziehen, um den Zuschnitt anzupassen"
+        AppLanguage.RUSSIAN -> "Перетащите или сожмите пальцами, чтобы настроить область обрезки"
+        AppLanguage.JAPANESE -> "ドラッグまたはピンチでクロップ範囲を調整"
+        AppLanguage.KOREAN -> "드래그하거나 두 손가락으로 확대/축소하여 영역 조정"
+    }
+
+    val cropRatioSquare: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "方形"
+        AppLanguage.ENGLISH -> "Square"
+        AppLanguage.ARABIC -> "مربع"
+        AppLanguage.PORTUGUESE -> "Quadrado"
+        AppLanguage.SPANISH -> "Cuadrado"
+        AppLanguage.FRENCH -> "Carré"
+        AppLanguage.GERMAN -> "Quadratisch"
+        AppLanguage.RUSSIAN -> "Квадрат"
+        AppLanguage.JAPANESE -> "正方形"
+        AppLanguage.KOREAN -> "정사각형"
+    }
+
+    val cropRatioFree: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "自由"
+        AppLanguage.ENGLISH -> "Free"
+        AppLanguage.ARABIC -> "حر"
+        AppLanguage.PORTUGUESE -> "Livre"
+        AppLanguage.SPANISH -> "Libre"
+        AppLanguage.FRENCH -> "Libre"
+        AppLanguage.GERMAN -> "Frei"
+        AppLanguage.RUSSIAN -> "Свободно"
+        AppLanguage.JAPANESE -> "自由"
+        AppLanguage.KOREAN -> "자유"
+    }
+
+    val cropRatioCircle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "圆形"
+        AppLanguage.ENGLISH -> "Circle"
+        AppLanguage.ARABIC -> "دائرة"
+        AppLanguage.PORTUGUESE -> "Círculo"
+        AppLanguage.SPANISH -> "Círculo"
+        AppLanguage.FRENCH -> "Cercle"
+        AppLanguage.GERMAN -> "Kreis"
+        AppLanguage.RUSSIAN -> "Круг"
+        AppLanguage.JAPANESE -> "円形"
+        AppLanguage.KOREAN -> "원형"
+    }
+
+    val cropOriginalSize: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "原图尺寸"
+        AppLanguage.ENGLISH -> "Original Size"
+        AppLanguage.ARABIC -> "الحجم الأصلي"
+        AppLanguage.PORTUGUESE -> "Tamanho Original"
+        AppLanguage.SPANISH -> "Tamaño Original"
+        AppLanguage.FRENCH -> "Taille d'origine"
+        AppLanguage.GERMAN -> "Originalgröße"
+        AppLanguage.RUSSIAN -> "Исходный размер"
+        AppLanguage.JAPANESE -> "元のサイズ"
+        AppLanguage.KOREAN -> "원본 크기"
+    }
+
+    val cropOutputSize: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "输出尺寸"
+        AppLanguage.ENGLISH -> "Output Size"
+        AppLanguage.ARABIC -> "حجم الإخراج"
+        AppLanguage.PORTUGUESE -> "Tamanho de Saída"
+        AppLanguage.SPANISH -> "Tamaño de Salida"
+        AppLanguage.FRENCH -> "Taille de sortie"
+        AppLanguage.GERMAN -> "Ausgabegröße"
+        AppLanguage.RUSSIAN -> "Размер вывода"
+        AppLanguage.JAPANESE -> "出力サイズ"
+        AppLanguage.KOREAN -> "출력 크기"
     }
 
     val deleteIcon: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/components/IconCropDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/IconCropDialog.kt
@@ -1,0 +1,522 @@
+package com.webtoapp.ui.components
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CropFree
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ClipOp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.webtoapp.core.i18n.Strings
+import com.webtoapp.core.logging.AppLogger
+import com.webtoapp.util.IconLibraryStorage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * WeChat-avatar-style icon cropper: the user drags / pinch-zooms the picked
+ * image under a fixed crop window. The visible image (never the raw gesture
+ * math) is what gets exported, so all crop math happens in preview
+ * coordinates and maps back through one uniform scale at save time.
+ */
+enum class IconCropMode(val aspectRatio: Float?) {
+    SQUARE(1f),
+    FREE(null),
+    CIRCLE(1f)
+}
+
+private const val CROP_MAX_DIMENSION = 2048
+private const val CROP_OUTPUT_SIZE = 512
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IconCropDialog(
+    imageUri: Uri,
+    onCropComplete: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var originalBitmap by remember { mutableStateOf<Bitmap?>(null) }
+    var isLoading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var isCropping by remember { mutableStateOf(false) }
+    var cropMode by remember { mutableStateOf(IconCropMode.SQUARE) }
+    var previewSize by remember { mutableStateOf(IntSize.Zero) }
+
+    // Image transform in preview coordinates: uniform scale around the box
+    // center plus a pan offset from that centered position.
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    var offsetY by remember { mutableFloatStateOf(0f) }
+
+    LaunchedEffect(imageUri) {
+        isLoading = true
+        errorMessage = null
+        withContext(Dispatchers.IO) {
+            try {
+                val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                context.contentResolver.openInputStream(imageUri)?.use { stream ->
+                    BitmapFactory.decodeStream(stream, null, bounds)
+                }
+                val decodeOptions = BitmapFactory.Options().apply {
+                    inSampleSize = calculateInSampleSize(bounds, CROP_MAX_DIMENSION, CROP_MAX_DIMENSION)
+                }
+                val bitmap = context.contentResolver.openInputStream(imageUri)?.use { stream ->
+                    BitmapFactory.decodeStream(stream, null, decodeOptions)
+                }
+                if (bitmap != null) {
+                    originalBitmap = bitmap
+                } else {
+                    errorMessage = Strings.cannotParseImage
+                }
+            } catch (e: Exception) {
+                errorMessage = Strings.loadImageFailed.format(e.message)
+            }
+        }
+        isLoading = false
+    }
+
+    val cropRect = remember(previewSize, cropMode) {
+        val w = previewSize.width.toFloat()
+        val h = previewSize.height.toFloat()
+        if (w <= 0f || h <= 0f) {
+            Rect.Zero
+        } else {
+            when (cropMode.aspectRatio) {
+                null -> Rect(Offset.Zero, Size(w, h))
+                else -> if (w <= h) {
+                    Rect(Offset(0f, (h - w) / 2f), Size(w, w))
+                } else {
+                    Rect(Offset((w - h) / 2f, 0f), Size(h, h))
+                }
+            }
+        }
+    }
+
+    // Minimum scale keeps the image covering the crop window (no gaps);
+    // maximum is a generous zoom-in cap.
+    val minScale = remember(originalBitmap, cropRect) {
+        val bitmap = originalBitmap
+        if (bitmap == null || cropRect == Rect.Zero || bitmap.width == 0 || bitmap.height == 0) {
+            1f
+        } else {
+            max(
+                cropRect.width / bitmap.width,
+                cropRect.height / bitmap.height
+            )
+        }
+    }
+    val maxScale = remember(minScale) { (minScale * 8f).coerceAtLeast(1f) }
+
+    LaunchedEffect(originalBitmap, cropMode, minScale) {
+        if (originalBitmap != null && cropRect != Rect.Zero) {
+            scale = minScale
+            offsetX = 0f
+            offsetY = 0f
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = { if (!isCropping) onDismiss() },
+        title = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        Icons.Default.CropFree,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+                Text(Strings.cropIcon)
+            }
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = Strings.cropDragHint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    val modes = IconCropMode.entries
+                    modes.forEachIndexed { index, mode ->
+                        SegmentedButton(
+                            selected = cropMode == mode,
+                            onClick = { cropMode = mode },
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = modes.size)
+                        ) {
+                            Text(
+                                text = when (mode) {
+                                    IconCropMode.SQUARE -> Strings.cropRatioSquare
+                                    IconCropMode.FREE -> Strings.cropRatioFree
+                                    IconCropMode.CIRCLE -> Strings.cropRatioCircle
+                                },
+                                style = MaterialTheme.typography.labelMedium
+                            )
+                        }
+                    }
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(320.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .onSizeChanged { previewSize = it },
+                    contentAlignment = Alignment.Center
+                ) {
+                    when {
+                        isLoading -> {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                CircularProgressIndicator()
+                                Text(
+                                    text = Strings.loadingImage,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                        errorMessage != null -> {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Info,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.error
+                                )
+                                Text(
+                                    text = errorMessage!!,
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                        }
+                        originalBitmap != null && cropRect != Rect.Zero -> {
+                            val bitmap = originalBitmap!!
+                            val drawnWidth = bitmap.width * scale
+                            val drawnHeight = bitmap.height * scale
+
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .pointerInput(cropRect, minScale, maxScale) {
+                                        detectTransformGestures { _, pan, zoom, _ ->
+                                            scale = (scale * zoom).coerceIn(minScale, maxScale)
+
+                                            // Keep the image covering the crop
+                                            // window; if it is smaller than the
+                                            // window on an axis, center that axis.
+                                            val halfW = bitmap.width * scale / 2f
+                                            val halfH = bitmap.height * scale / 2f
+                                            val centerX = cropRect.center.x
+                                            val centerY = cropRect.center.y
+
+                                            val minOffsetX = cropRect.right - drawnWidth - centerX + halfW
+                                            val maxOffsetX = cropRect.left - centerX + halfW
+                                            offsetX = if (minOffsetX > maxOffsetX) {
+                                                0f
+                                            } else {
+                                                (offsetX + pan.x).coerceIn(minOffsetX, maxOffsetX)
+                                            }
+
+                                            val minOffsetY = cropRect.bottom - drawnHeight - centerY + halfH
+                                            val maxOffsetY = cropRect.top - centerY + halfH
+                                            offsetY = if (minOffsetY > maxOffsetY) {
+                                                0f
+                                            } else {
+                                                (offsetY + pan.y).coerceIn(minOffsetY, maxOffsetY)
+                                            }
+                                        }
+                                    }
+                            ) {
+                                val density = LocalDensity.current
+                                Image(
+                                    bitmap = bitmap.asImageBitmap(),
+                                    contentDescription = Strings.originalImage,
+                                    contentScale = ContentScale.FillBounds,
+                                    modifier = Modifier
+                                        .align(Alignment.Center)
+                                        .offset {
+                                            IntOffset(
+                                                (offsetX - drawnWidth / 2f).roundToInt(),
+                                                (offsetY - drawnHeight / 2f).roundToInt()
+                                            )
+                                        }
+                                        .size(
+                                            width = with(density) { drawnWidth.toDp() },
+                                            height = with(density) { drawnHeight.toDp() }
+                                        )
+                                )
+
+                                Canvas(modifier = Modifier.fillMaxSize()) {
+                                    val dim = Color.Black.copy(alpha = 0.55f)
+                                    when (cropMode) {
+                                        IconCropMode.CIRCLE -> {
+                                            val circle = Path().apply { addOval(cropRect) }
+                                            clipPath(circle, ClipOp.Difference) {
+                                                drawRect(dim)
+                                            }
+                                            drawOval(
+                                                color = Color.White,
+                                                topLeft = cropRect.topLeft,
+                                                size = cropRect.size,
+                                                style = Stroke(width = 2.dp.toPx())
+                                            )
+                                        }
+                                        IconCropMode.SQUARE -> {
+                                            clipRect(
+                                                cropRect.left, cropRect.top,
+                                                cropRect.right, cropRect.bottom,
+                                                ClipOp.Difference
+                                            ) {
+                                                drawRect(dim)
+                                            }
+                                            drawRect(
+                                                color = Color.White,
+                                                topLeft = cropRect.topLeft,
+                                                size = cropRect.size,
+                                                style = Stroke(width = 2.dp.toPx())
+                                            )
+                                        }
+                                        IconCropMode.FREE -> {
+                                            drawRect(dim)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (originalBitmap != null && cropRect != Rect.Zero) {
+                    val outputLabel = remember(cropRect, scale) {
+                        val srcWidth = cropRect.width / scale
+                        val srcHeight = cropRect.height / scale
+                        if (srcWidth >= srcHeight) {
+                            val outH = max(1, (srcHeight / srcWidth * CROP_OUTPUT_SIZE).roundToInt())
+                            "${CROP_OUTPUT_SIZE} × $outH px"
+                        } else {
+                            val outW = max(1, (srcWidth / srcHeight * CROP_OUTPUT_SIZE).roundToInt())
+                            "$outW × ${CROP_OUTPUT_SIZE} px"
+                        }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column {
+                            Text(
+                                text = Strings.cropOriginalSize,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = "${originalBitmap!!.width} × ${originalBitmap!!.height} px",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                        Column(horizontalAlignment = Alignment.End) {
+                            Text(
+                                text = Strings.cropOutputSize,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = outputLabel,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                }
+
+                if (isCropping) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val bitmap = originalBitmap ?: return@TextButton
+                    if (cropRect == Rect.Zero) return@TextButton
+                    isCropping = true
+                    scope.launch {
+                        val cropped = cropBitmap(
+                            bitmap = bitmap,
+                            cropRect = cropRect,
+                            scale = scale,
+                            offsetX = offsetX,
+                            offsetY = offsetY
+                        )
+                        val item = cropped?.let {
+                            IconLibraryStorage.saveFromBitmap(context, it, Strings.cropIcon)
+                        }
+                        cropped?.recycle()
+                        isCropping = false
+                        if (item != null) {
+                            onCropComplete(item.path)
+                        } else {
+                            errorMessage = Strings.saveFailed
+                        }
+                    }
+                },
+                enabled = originalBitmap != null && !isCropping
+            ) {
+                Text(Strings.confirmCrop)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isCropping) {
+                Text(Strings.btnCancel)
+            }
+        }
+    )
+}
+
+/**
+ * Maps the visible crop window from preview coordinates back to bitmap
+ * coordinates and extracts exactly the region the user saw. The image is
+ * drawn centered on the preview box, shifted by (offsetX, offsetY) and scaled
+ * by `scale`, so bitmap (0,0) sits at preview center + offset - half drawn
+ * size. The result is scaled so its longest side becomes CROP_OUTPUT_SIZE.
+ */
+private suspend fun cropBitmap(
+    bitmap: Bitmap,
+    cropRect: Rect,
+    scale: Float,
+    offsetX: Float,
+    offsetY: Float
+): Bitmap? = withContext(Dispatchers.IO) {
+    try {
+        val drawnWidth = bitmap.width * scale
+        val drawnHeight = bitmap.height * scale
+        val imageLeft = cropRect.center.x + offsetX - drawnWidth / 2f
+        val imageTop = cropRect.center.y + offsetY - drawnHeight / 2f
+
+        val srcLeft = ((cropRect.left - imageLeft) / scale).roundToInt().coerceIn(0, bitmap.width - 1)
+        val srcTop = ((cropRect.top - imageTop) / scale).roundToInt().coerceIn(0, bitmap.height - 1)
+        val srcRight = ((cropRect.right - imageLeft) / scale).roundToInt().coerceIn(srcLeft + 1, bitmap.width)
+        val srcBottom = ((cropRect.bottom - imageTop) / scale).roundToInt().coerceIn(srcTop + 1, bitmap.height)
+
+        val srcWidth = srcRight - srcLeft
+        val srcHeight = srcBottom - srcTop
+        if (srcWidth <= 0 || srcHeight <= 0) return@withContext null
+
+        val cropped = Bitmap.createBitmap(bitmap, srcLeft, srcTop, srcWidth, srcHeight)
+        val output = if (srcWidth >= srcHeight) {
+            val outHeight = max(1, (srcHeight.toFloat() / srcWidth * CROP_OUTPUT_SIZE).roundToInt())
+            Bitmap.createScaledBitmap(cropped, CROP_OUTPUT_SIZE, outHeight, true)
+        } else {
+            val outWidth = max(1, (srcWidth.toFloat() / srcHeight * CROP_OUTPUT_SIZE).roundToInt())
+            Bitmap.createScaledBitmap(cropped, outWidth, CROP_OUTPUT_SIZE, true)
+        }
+        if (output !== cropped) {
+            cropped.recycle()
+        }
+        AppLogger.i("IconCropDialog", "Icon cropped: ${output.width}x${output.height}")
+        output
+    } catch (e: Exception) {
+        AppLogger.e("IconCropDialog", "Crop failed", e)
+        null
+    }
+}
+
+private fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
+    val (height, width) = options.outHeight to options.outWidth
+    var inSampleSize = 1
+    if (height > reqHeight || width > reqWidth) {
+        val halfHeight = height / 2
+        val halfWidth = width / 2
+        while ((halfHeight / inSampleSize) >= reqHeight && (halfWidth / inSampleSize) >= reqWidth) {
+            inSampleSize *= 2
+        }
+    }
+    return inSampleSize
+}

--- a/app/src/main/java/com/webtoapp/ui/components/IconLibraryDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/IconLibraryDialog.kt
@@ -1,5 +1,9 @@
 package com.webtoapp.ui.components
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -37,8 +41,18 @@ fun IconLibraryDialog(
     val scope = rememberCoroutineScope()
     val icons by IconLibraryStorage.iconsFlow.collectAsState(initial = emptyList())
 
+    var pendingCropUri by remember { mutableStateOf<Uri?>(null) }
+
     LaunchedEffect(Unit) {
         IconLibraryStorage.initialize(context)
+    }
+
+    val cropImageLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        if (uri != null) {
+            pendingCropUri = uri
+        }
     }
 
     Dialog(onDismissRequest = onDismiss) {
@@ -87,6 +101,48 @@ fun IconLibraryDialog(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                OutlinedCard(
+                    onClick = {
+                        cropImageLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Outlined.AddPhotoAlternate,
+                            null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(32.dp)
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
+                            Text(
+                                Strings.uploadToLibrary,
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Text(
+                                Strings.uploadToLibraryDesc,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Icon(
+                            Icons.Default.ChevronRight,
+                            null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
 
                 Spacer(modifier = Modifier.height(16.dp))
 
@@ -201,6 +257,18 @@ fun IconLibraryDialog(
                 }
             }
         }
+    }
+
+    pendingCropUri?.let { uri ->
+        IconCropDialog(
+            imageUri = uri,
+            onDismiss = { pendingCropUri = null },
+            onCropComplete = { path ->
+                pendingCropUri = null
+                onSelectIcon(path)
+                onDismiss()
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/webtoapp/util/IconLibraryStorage.kt
+++ b/app/src/main/java/com/webtoapp/util/IconLibraryStorage.kt
@@ -114,6 +114,34 @@ object IconLibraryStorage {
         }
     }
 
+    suspend fun saveFromBitmap(
+        context: Context,
+        bitmap: Bitmap,
+        name: String = Strings.icon
+    ): IconLibraryItem? = withContext(Dispatchers.IO) {
+        try {
+            val id = "lib_${UUID.randomUUID().toString().take(8)}"
+            val file = File(getLibraryDir(context), "$id.png")
+
+            FileOutputStream(file).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+
+            val item = IconLibraryItem(
+                id = id,
+                path = file.absolutePath,
+                name = name,
+                isAiGenerated = false
+            )
+
+            _iconsFlow.value = listOf(item) + _iconsFlow.value
+            item
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "Operation failed", e)
+            null
+        }
+    }
+
     suspend fun delete(context: Context, item: IconLibraryItem) = withContext(Dispatchers.IO) {
         try {
             File(item.path).delete()

--- a/docs/guide/app-actions/edit-common-config/fullscreen.md
+++ b/docs/guide/app-actions/edit-common-config/fullscreen.md
@@ -19,5 +19,5 @@ Whether the in-app toolbar shows during fullscreen is governed by the [Browser T
 ## Notes
 
 - When the status bar is visible, the splash countdown/skip chip sits below it so it is never covered.
-- Fullscreen **video** orientation (landscape/sensor for fullscreen video playback, `fullscreenVideoOrientation`) is configured under [Special Settings](/guide/app-actions/edit-common-config/special-settings).
+- Fullscreen **video** orientation (landscape/sensor for fullscreen video playback, `fullscreenVideoOrientation`) is configured under [Special Settings](/guide/app-actions/edit-common-config/special-settings). The same card also has **hide status bar in video fullscreen** (`hideStatusBarInVideoFullscreen`, on by default), which force-hides the status bar while a web video is in HTML5 fullscreen even when "show status bar in fullscreen" is on.
 - Keyboard-avoidance behavior below Android 11 uses the classic window-resize path; see [Special Settings](/guide/app-actions/edit-common-config/special-settings) for the keyboard adjust mode.

--- a/docs/guide/app-actions/edit-common-config/special-settings.md
+++ b/docs/guide/app-actions/edit-common-config/special-settings.md
@@ -34,6 +34,7 @@ Compatibility polyfills, bridges, and other specialized toggles. This card colle
 
 - **Cross-origin isolation** — `enableCrossOriginIsolation`.
 - **Anti-capture** — block screen capture (`antiCapture`).
+- **Hide status bar in video fullscreen** — force-hide the status bar while a web video plays in HTML5 fullscreen, restoring it on exit (`hideStatusBarInVideoFullscreen`, on by default). Overrides the [Fullscreen Mode](/guide/app-actions/edit-common-config/fullscreen) "show status bar in fullscreen" option while the video holds the screen.
 - **File access from file URLs** — `allowFileAccessFromFileURLs`, `allowUniversalAccessFromFileURLs`.
 - **Error page** — custom error page config (`errorPageConfig`).
 - **Performance optimization** — `performanceOptimization`.

--- a/docs/guide/app-types/index.md
+++ b/docs/guide/app-types/index.md
@@ -24,7 +24,7 @@ Tap [Create](/guide/main-screen/create-app) on My Apps to open the app-type pick
 Every type follows the same shape:
 
 1. **Type-specific form** — e.g. Web asks for a URL; Node.js asks for the project and start command; Gallery asks for media and layout. Runtime types link to the [Linux Environment](/guide/more-features/linux-environment) for toolchain setup.
-2. **Basic info** — name and icon.
+2. **Basic info** — name and icon. The icon can be fetched from the website's favicon, picked from the **Icon Library** (AI-generated or your own uploaded images — uploads go through a crop step with square / free / circle modes, WeChat-avatar style), or selected directly from the gallery.
 3. **Save** — the app is created and appears on [My Apps](/guide/main-screen/my-apps).
 
 After creation, use the app's ⋮ menu: [Edit Core Config](/guide/app-actions/edit-core-config) returns to the type-specific form; [Edit Common Config](/guide/app-actions/edit-common-config/) opens the shared options.

--- a/docs/zh/guide/app-actions/edit-common-config/fullscreen.md
+++ b/docs/zh/guide/app-actions/edit-common-config/fullscreen.md
@@ -19,5 +19,5 @@
 ## 说明
 
 - 当状态栏可见时,启动倒计时/跳过胶囊会落在其下方,绝不被遮挡。
-- 全屏**视频**方向(全屏视频播放的横屏/传感器方向,`fullscreenVideoOrientation`)在[特殊设置](/zh/guide/app-actions/edit-common-config/special-settings)中配置。
+- 全屏**视频**方向(全屏视频播放的横屏/传感器方向,`fullscreenVideoOrientation`)在[特殊设置](/zh/guide/app-actions/edit-common-config/special-settings)中配置。同一卡片还有"视频全屏时隐藏状态栏"(`hideStatusBarInVideoFullscreen`,默认开启):网页视频进入 HTML5 全屏时,即使"全屏显示状态栏"开启也会强制隐藏状态栏。
 - Android 10 及以下的键盘避让走经典窗口缩放路径;键盘调整模式见[特殊设置](/zh/guide/app-actions/edit-common-config/special-settings)。

--- a/docs/zh/guide/app-actions/edit-common-config/special-settings.md
+++ b/docs/zh/guide/app-actions/edit-common-config/special-settings.md
@@ -34,6 +34,7 @@
 
 - **跨源隔离** —— `enableCrossOriginIsolation`。
 - **防截屏** —— 阻止屏幕截取(`antiCapture`)。
+- **视频全屏时隐藏状态栏** —— 网页视频进入 HTML5 全屏播放时强制隐藏状态栏,退出全屏后恢复(`hideStatusBarInVideoFullscreen`,默认开启)。视频全屏期间优先于[全屏模式](/zh/guide/app-actions/edit-common-config/fullscreen)中的"全屏显示状态栏"选项。
 - **文件 URL 的文件访问** —— `allowFileAccessFromFileURLs`、`allowUniversalAccessFromFileURLs`。
 - **错误页** —— 自定义错误页配置(`errorPageConfig`)。
 - **性能优化** —— `performanceOptimization`。

--- a/docs/zh/guide/app-types/index.md
+++ b/docs/zh/guide/app-types/index.md
@@ -24,7 +24,7 @@
 每种类型都遵循相同的形态:
 
 1. **类型专属表单** —— 例如网页要求填 URL;Node.js 要求填项目和启动命令;画廊要求填媒体和布局。运行时类型会链接到 [Linux 环境](/zh/guide/more-features/linux-environment)做工具链安装。
-2. **基本信息** —— 名称和图标。
+2. **基本信息** —— 名称和图标。图标可以来自网站 favicon 抓取、**图标库**(AI 生成的图标,或你自己上传的图片——上传需经过裁剪步骤,支持方形/自由/圆形三种模式,类似微信头像设置),也可以直接从相册选择。
 3. **保存** —— 应用被创建并出现在[我的应用](/zh/guide/main-screen/my-apps)上。
 
 创建后,使用应用的 ⋮ 菜单:[编辑核心配置](/zh/guide/app-actions/edit-core-config)回到类型专属表单;[编辑通用配置](/zh/guide/app-actions/edit-common-config/)打开共享选项。


### PR DESCRIPTION
## Summary

Adds a manual **Upload Image** path to the Icon Library with a WeChat-avatar-style crop step, closing #718.

### What's included

- **`IconCropDialog` (new)** — drag + pinch-zoom the picked image under a fixed crop window; crop modes **square (1:1) / free / circle preview** via segmented buttons; live original & output size labels; confirm exports exactly the visible region, normalized so the longest side is 512px PNG. Circle mode previews round but exports square (launchers mask icons themselves; square stays the most compatible asset).
- **Icon Library** — new **Upload Image** card above the AI generator: photo picker → crop → save to library → auto-select. User images become first-class, reusable library items.
- **`IconLibraryStorage.saveFromBitmap`** — persists cropped bitmaps with the same `lib_*` naming as other entries.
- **i18n** — 9 new strings across all 10 languages (`when(lang)` without `else`, no `R.string`).
- **Docs** — document the icon sources in the creation flow (EN+ZH) and carry over the `hideStatusBarInVideoFullscreen` docs for the fullscreen / special-settings config pages (EN+ZH, from the #711 follow-up).

### Design notes

- All crop math happens in preview coordinates and maps back through one uniform scale at save time; the exported bitmap is exactly what the user saw.
- Scale bounds keep the image covering the crop window (no gaps); pan is clamped accordingly.
- Upload sits above the AI generator since it's the lower-friction path.

Closes #718