### PR TITLE
fix(app): don't delete a borrowed html_projects dir when deleting a MULTI_WEB app

### DIFF
--- a/app/src/main/java/com/webtoapp/core/app/ProjectDirCleaner.kt
+++ b/app/src/main/java/com/webtoapp/core/app/ProjectDirCleaner.kt
@@ -100,7 +100,18 @@ object ProjectDirCleaner {
                 if (importedDir != null) {
                     deleteIfSandboxed(importedDir)
                 } else if (pid != null) {
-                    deleteIfSandboxed(File(appContext.filesDir, "html_projects/$pid"))
+                    // A MULTI_WEB app built purely from EXISTING sites borrows the source HTML
+                    // app's projectId (MainViewModel.saveMultiWebApp). That directory is still
+                    // owned by the source app — deleting it would wipe another live app's files.
+                    // Only delete when the multi-web app owns the id (no site points back at it).
+                    val borrowedFromSite = app.multiWebConfig?.sites?.any {
+                        it.type == "EXISTING" && it.sourceProjectId.isNotBlank() && it.sourceProjectId == pid
+                    } == true
+                    if (borrowedFromSite) {
+                        AppLogger.i(TAG, "Skip html_projects/$pid: MULTI_WEB app borrows the source app's project id")
+                    } else {
+                        deleteIfSandboxed(File(appContext.filesDir, "html_projects/$pid"))
+                    }
                 }
             }
             // WEB / IMAGE / VIDEO / GALLERY have no source project directory on disk.

--- a/app/src/test/java/com/webtoapp/core/app/ProjectDirCleanerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/app/ProjectDirCleanerTest.kt
@@ -1,0 +1,73 @@
+package com.webtoapp.core.app
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.HtmlConfig
+import com.webtoapp.data.model.MultiWebConfig
+import com.webtoapp.data.model.MultiWebSite
+import com.webtoapp.data.model.WebApp
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Regression coverage for issue #722: deleting a MULTI_WEB app that borrowed the
+ * source HTML app's projectId (build-only-from-EXISTING-sites flow) must not wipe
+ * the html_projects directory still owned by the source app.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class ProjectDirCleanerTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun multiWebApp(projectId: String, sites: List<MultiWebSite>) = WebApp(
+        id = 1L,
+        name = "multi",
+        url = "",
+        appType = AppType.MULTI_WEB,
+        htmlConfig = HtmlConfig(projectId = projectId),
+        multiWebConfig = MultiWebConfig(sites = sites, projectId = projectId)
+    )
+
+    @Test
+    fun `deleting borrowed-project multi-web app keeps the source project dir`() {
+        val projectDir = File(context.filesDir, "html_projects/src-project-1").apply { mkdirs() }
+        File(projectDir, "index.html").writeText("<html></html>")
+
+        val app = multiWebApp(
+            projectId = "src-project-1",
+            sites = listOf(
+                MultiWebSite(id = "s1", name = "site", type = "EXISTING", sourceProjectId = "src-project-1")
+            )
+        )
+
+        val deleted = ProjectDirCleaner.deleteForApp(context, app)
+
+        assertThat(deleted).isEmpty()
+        assertThat(projectDir.exists()).isTrue()
+        projectDir.deleteRecursively()
+    }
+
+    @Test
+    fun `deleting own-project multi-web app removes its project dir`() {
+        val projectDir = File(context.filesDir, "html_projects/own-project").apply { mkdirs() }
+        File(projectDir, "index.html").writeText("<html></html>")
+
+        val app = multiWebApp(
+            projectId = "own-project",
+            sites = listOf(
+                MultiWebSite(id = "s1", name = "site", type = "LOCAL", localFilePath = "site/index.html")
+            )
+        )
+
+        val deleted = ProjectDirCleaner.deleteForApp(context, app)
+
+        assertThat(deleted).isNotEmpty()
+        assertThat(projectDir.exists()).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

A Multi-Site app built purely from EXISTING sites borrows the source HTML app's `projectId` (`MainViewModel.saveMultiWebApp` / `updateMultiWebApp`). `ProjectDirCleaner.deleteForApp` assumed every MULTI_WEB app owns `html_projects/<projectId>`, so deleting such a Multi-Site app wiped the directory still owned by the live source HTML app: the source app's DB row survived but its files were gone, and it opened blank.

Fixes #722

## Change

- `ProjectDirCleaner`: for MULTI_WEB, skip the `html_projects/<projectId>` delete when any site's `sourceProjectId` equals the app's projectId (i.e. the directory is borrowed from a source app that is still alive).
- Added `ProjectDirCleanerTest` (Robolectric) covering the borrowed-dir survival and own-dir deletion paths.

## Test plan

- [x] `./gradlew :app:testStandardDebugUnitTest --tests "com.webtoapp.core.app.ProjectDirCleanerTest"` — 2/2 green.
- [ ] CI green on this PR.