### PR TITLE
fix(adblock): keep the unanchored-rule index valid through every parse path

### DIFF
--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
@@ -1376,11 +1376,15 @@ class AdBlocker {
         }
 
         if (isException) {
+            val idx = networkExceptionFilters.size
             networkExceptionFilters.add(filter)
-            unanchoredFilterIndex.remove(networkExceptionFilters)
+            unanchoredFilterIndex[networkExceptionFilters] =
+                (unanchoredFilterIndex[networkExceptionFilters] ?: emptyList()) + idx
         } else {
+            val idx = networkBlockFilters.size
             networkBlockFilters.add(filter)
-            unanchoredFilterIndex.remove(networkBlockFilters)
+            unanchoredFilterIndex[networkBlockFilters] =
+                (unanchoredFilterIndex[networkBlockFilters] ?: emptyList()) + idx
         }
     }
 
@@ -1869,9 +1873,6 @@ class AdBlocker {
             t.startsWith("[Adblock") || t.startsWith("!") || t.startsWith("||") ||
                 t.startsWith("@@") || t.contains("##") || t.contains("#@#")
         }
-
-        unanchoredFilterIndex.remove(networkBlockFilters)
-        unanchoredFilterIndex.remove(networkExceptionFilters)
 
         val lines = content.lineSequence().iterator()
         while (lines.hasNext()) {


### PR DESCRIPTION
## Summary

`parseAndAddRule` invalidated the whole `unanchoredFilterIndex` entry on every unanchored rule and only `rebuildUnanchoredIndex()` restored it. `prepareRuntimeFilters` — the path every WebView launch uses — never called the rebuild, so every network rule without an `||domain` anchor (plain pattern rules like `/adframe.`, a large fraction of EasyList/uBlock lists) was silently skipped by the matcher. A single unanchored custom rule added after the compiled-state restore deleted the index again.

Fixes #733

## Change

- Unanchored index entries are appended incrementally as rules are added; the wholesale invalidations in `parseAndAddRule` / `parseFilterContent` are gone.
- Existing full rebuilds still overwrite the entry from scratch, preserving their behavior.
- Shared source change is authored under `app/`; the shell copy is regenerated by `syncShellRuntimeSources`.

## Test plan

- [x] `./gradlew :app:testStandardDebugUnitTest --tests "com.webtoapp.core.adblock.*"` — 18/18 green.
- [ ] CI green on this PR.