### PR TITLE
fix(apk): embed the dark status-bar background image into generated APKs

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
@@ -131,6 +131,7 @@ class ApkBuildCache(private val context: Context) {
             galleryItems = galleryItems,
             errorPageMediaPath = errorPageMediaPath,
             statusBarImage = config.statusBarBackgroundImage,
+            statusBarImageDark = config.statusBarBackgroundImageDark,
             floatingIcon = config.floatingWindowMinimizedIconPath
         )
 
@@ -389,6 +390,7 @@ class ApkBuildCache(private val context: Context) {
         galleryItems: List<com.webtoapp.data.model.GalleryItem>,
         errorPageMediaPath: String?,
         statusBarImage: String?,
+        statusBarImageDark: String?,
         floatingIcon: String?
     ): String {
         val parts = mutableListOf<String>()
@@ -400,6 +402,7 @@ class ApkBuildCache(private val context: Context) {
         parts += "splash=${fileFingerprint(splashMediaPath)}"
         parts += "errorPage=${fileFingerprint(errorPageMediaPath)}"
         parts += "statusBar=${fileFingerprint(statusBarImage)}"
+        parts += "statusBarDark=${fileFingerprint(statusBarImageDark)}"
         parts += "floatingIcon=${fileFingerprint(floatingIcon)}"
         bgmPlaylistPaths.forEachIndexed { index, path ->
             parts += "bgm[$index]=${fileFingerprint(path)}"

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -1518,6 +1518,13 @@ class ApkBuilder(private val context: Context) {
                     addStatusBarBackgroundToAssets(zipOut, config.statusBarBackgroundImage!!)
                 }
 
+                // The config JSON promises assets/statusbar_background_dark.png whenever the
+                // dark variant is an image (ApkConfigJsonFactory). Without this embed the
+                // generated app fails to open the asset and silently falls back to a color.
+                if (config.statusBarBackgroundTypeDark == "IMAGE" && !config.statusBarBackgroundImageDark.isNullOrEmpty()) {
+                    addStatusBarBackgroundToAssets(zipOut, config.statusBarBackgroundImageDark!!, "assets/statusbar_background_dark.png")
+                }
+
                 if (config.floatingWindowEnabled && !config.floatingWindowMinimizedIconPath.isNullOrEmpty()) {
                     addFloatingWindowMinimizedIconToAssets(zipOut, config.floatingWindowMinimizedIconPath!!)
                 }
@@ -1870,9 +1877,10 @@ class ApkBuilder(private val context: Context) {
 
     private fun addStatusBarBackgroundToAssets(
         zipOut: ZipOutputStream,
-        imagePath: String
+        imagePath: String,
+        assetEntry: String = "assets/statusbar_background.png"
     ) {
-        AppLogger.d("ApkBuilder", "Preparing to embed status bar background: path=$imagePath")
+        AppLogger.d("ApkBuilder", "Preparing to embed status bar background: path=$imagePath, entry=$assetEntry")
 
         val imageFile = File(imagePath)
         if (!imageFile.exists()) {
@@ -1892,8 +1900,8 @@ class ApkBuilder(private val context: Context) {
                 return
             }
 
-            writeEntryDeflated(zipOut, "assets/statusbar_background.png", imageBytes)
-            AppLogger.d("ApkBuilder", "Status bar background embedded: assets/statusbar_background.png (${imageBytes.size} bytes)")
+            writeEntryDeflated(zipOut, assetEntry, imageBytes)
+            AppLogger.d("ApkBuilder", "Status bar background embedded: $assetEntry (${imageBytes.size} bytes)")
         } catch (e: Exception) {
             AppLogger.e("ApkBuilder", "Failed to embed status bar background: ${e.message}", e)
         }


### PR DESCRIPTION
## Summary

The config JSON promises `assets/statusbar_background_dark.png` whenever the dark status-bar variant is an image (the factory's unit test asserts exactly that), but `ApkBuilder` never embedded it — the writer hardcoded the light entry name. Generated apps therefore always failed the asset open and silently fell back to a flat color in dark mode. Also, the dark image file was absent from the incremental-build content fingerprint, so a swapped dark image could ship stale via REUSE_UNSIGNED.

Fixes #737

## Change

- `addStatusBarBackgroundToAssets` takes the target entry name; the dark variant is embedded as `assets/statusbar_background_dark.png`.
- `ApkBuildCache.contentFingerprint` now includes `statusBarDark`.

## Test plan

- [x] `./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache` green.
- [x] `ApkBuildCacheTest` 8/8 green.
- [ ] CI green on this PR.