### PR TITLE
fix(shell): apply the configured auto-start boot delay in exported apps

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivityInit.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivityInit.kt
@@ -41,7 +41,7 @@ object ShellActivityInit {
                 autoStartManager.setBootStart(
                     appId = 0L,
                     enabled = autoStartConfig.bootStartEnabled,
-                    delayMs = com.webtoapp.core.autostart.AutoStartManager.DEFAULT_BOOT_DELAY_MS
+                    delayMs = autoStartConfig.bootDelay
                 )
 
                 if (autoStartConfig.scheduledStartEnabled) {
@@ -55,7 +55,11 @@ object ShellActivityInit {
                     autoStartManager.setScheduledStart(appId = 0L, enabled = false)
                 }
 
-                com.webtoapp.core.shell.ShellLogger.i("ShellActivity", "自启动配置已注册: 开机=${autoStartConfig.bootStartEnabled}, 定时=${autoStartConfig.scheduledStartEnabled}")
+                com.webtoapp.core.shell.ShellLogger.i(
+                    "ShellActivity",
+                    "自启动配置已注册: 开机=${autoStartConfig.bootStartEnabled}, delay=${autoStartConfig.bootDelay}ms, " +
+                        "定时=${autoStartConfig.scheduledStartEnabled}"
+                )
             } catch (e: Exception) {
                 com.webtoapp.core.shell.ShellLogger.e("ShellActivity", "自启动配置注册失败", e)
             }


### PR DESCRIPTION
## Summary

`ShellActivityInit.initAutoStart` hardcoded `AutoStartManager.DEFAULT_BOOT_DELAY_MS` (5000 ms) even though `autoStartConfig.bootDelay` travels through the shell config JSON and is parsed by `ShellModeManager`. The hardcoded value was persisted into shared prefs and read back by `BootReceiver`, so a user-configured 30 s boot delay silently became 5 s in every exported app — the export chain broke at its last step.

Fixes #739

## Change

- Pass the parsed `autoStartConfig.bootDelay` into `setBootStart` (`AutoStartManager` already clamps to `MIN/MAX_BOOT_DELAY_MS`, the same bounds the editor slider uses).
- `scheduledRepeat` has no runtime parameter (the scheduler always repeats); left out of scope and documented in the Issue.

## Test plan

- [x] `./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache` green.
- [ ] CI green on this PR.