### PR TITLE
fix(agent): allow plan-file writes when plan mode is entered mid-turn

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -326,7 +326,7 @@ class AgentEngine(
         if (decision == PermissionDecision.Deny) {
 
             val mode = permissionChecker.mode
-            val planFile = input.toolContext.activePlanFile
+            val planFile = input.toolContext.effectivePlanFile()
             val hint = when {
                 mode == com.webtoapp.core.agent.permission.PermissionMode.Plan && planFile != null ->
                     " — in plan mode, only Write/Edit to $planFile is allowed. " +

--- a/app/src/main/java/com/webtoapp/core/agent/permission/PermissionChecker.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/permission/PermissionChecker.kt
@@ -67,7 +67,7 @@ class PermissionChecker(
         if (tool.name in planWriteTools) {
             val path = args.get("path")?.asString ?: args.get("file_path")?.asString
             val resolved = path?.let { ctx.resolveSafePath(it) }
-            if (resolved != null && resolved == ctx.activePlanFile) return PermissionDecision.Allow
+            if (resolved != null && resolved == ctx.effectivePlanFile()) return PermissionDecision.Allow
             return PermissionDecision.Deny
         }
         return PermissionDecision.Deny

--- a/app/src/main/java/com/webtoapp/core/agent/tool/ToolContext.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/ToolContext.kt
@@ -32,6 +32,23 @@ data class ToolContext(
     val progress: suspend (String) -> Unit = NO_OP_PROGRESS
 ) {
 
+    // Plan mode entered mid-turn publishes the generated plan file path here so
+    // PermissionChecker.checkPlan (which compares against activePlanFile) can allow
+    // writes to it for the rest of the turn. Kept outside the data-class constructor
+    // because the constructor value is a per-turn snapshot that is always null in
+    // the mid-turn flow.
+    @Volatile
+    var livePlanFile: String? = null
+        private set
+
+    /** Publishes the active plan file path (plan mode entered mid-turn). */
+    fun setActivePlanFile(path: String?) {
+        livePlanFile = path
+    }
+
+    /** The path plan-mode writes must go to: live publication wins over the snapshot. */
+    fun effectivePlanFile(): String? = livePlanFile ?: activePlanFile
+
     fun resolveSafePath(rawPath: String?): String? {
         if (rawPath.isNullOrBlank()) return null
         val cleaned = rawPath.trim().trimStart('/').trim('\\')

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/PlanTools.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/PlanTools.kt
@@ -25,10 +25,16 @@ class EnterPlanModeTool(private val planManager: PlanManager) : Tool {
 
     override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
         return when (val r = planManager.enter()) {
-            is PlanManager.EnterResult.Entered ->
+            is PlanManager.EnterResult.Entered -> {
+                // Publish the path so PermissionChecker.checkPlan (which compares against
+                // ctx.activePlanFile) allows writes to the plan file for THIS turn.
+                ctx.setActivePlanFile(r.planPath)
                 ToolResult.ok("Entered plan mode. Plan file: ${r.planPath}\nWrite the plan there with Write/Edit, then call ExitPlanMode.")
-            is PlanManager.EnterResult.AlreadyActive ->
+            }
+            is PlanManager.EnterResult.AlreadyActive -> {
+                ctx.setActivePlanFile(r.planPath)
                 ToolResult.ok("Already in plan mode. Plan file: ${r.planPath}")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

`ToolContext.activePlanFile` was a turn-start snapshot — always `null` when the model called `EnterPlanMode` mid-turn. `PermissionChecker.checkPlan` then denied every `Write`/`Edit` to the plan file the tool itself instructed the model to write, and `ExitPlanMode` could only report `NoPlanWritten`: the plan round-trip was impossible for the mid-turn flow.

Fixes #743

## Change

- `EnterPlanModeTool.execute` publishes the generated plan path via `ctx.setActivePlanFile(...)` onto a mutable `livePlanFile` field.
- `ToolContext.effectivePlanFile()` = live publication ?: constructor snapshot; `checkPlan` and the engine's deny-hint now resolve through it.
- The pre-turn UI path (slash command) is unchanged — it still seeds the constructor snapshot.

## Test plan

- [x] `./gradlew :app:testStandardDebugUnitTest --tests "com.webtoapp.core.agent.*"` green; compile green.
- [ ] CI green on this PR.