### PR TITLE
fix(agent): don't send image content arrays on role:tool messages (OpenAI schema)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
@@ -162,7 +162,7 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
     private fun buildMsg(msg: LlmMessage) = JsonObject().apply {
         addProperty("role", when(msg.role){LlmMessage.Role.SYSTEM->"system";LlmMessage.Role.USER->"user";LlmMessage.Role.ASSISTANT->"assistant";LlmMessage.Role.TOOL->"tool"})
         if (msg.toolCalls.isNotEmpty()) { add("tool_calls", JsonArray().apply { msg.toolCalls.forEach { tc -> add(JsonObject().apply { addProperty("id",tc.id);addProperty("type","function");add("function",JsonObject().apply{addProperty("name",tc.name);addProperty("arguments",tc.argumentsJson)}) }) } }); if(msg.content.isNotEmpty()) addProperty("content",msg.content) }
-        else if (msg.images.isNotEmpty()) {
+        else if (msg.images.isNotEmpty() && msg.role != LlmMessage.Role.TOOL) {
             add("content", JsonArray().apply {
                 if (msg.content.isNotEmpty()) add(JsonObject().apply { addProperty("type", "text"); addProperty("text", msg.content) })
                 msg.images.forEach { img ->
@@ -176,6 +176,17 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
             })
         }
         else addProperty("content", msg.content)
+
+        if (msg.role == LlmMessage.Role.TOOL) {
+            // The OpenAI Chat Completions schema only allows string content on role:"tool"
+            // messages — image content parts are valid solely on user messages. Tool
+            // results that carry images (ViewImage / GenerateImage / image-file reads) must
+            // degrade to a text reference here, otherwise strict endpoints reject the whole
+            // request with 400 and the engine retries the same invalid payload 5 times.
+            if (msg.images.isNotEmpty() && msg.content.isEmpty()) {
+                addProperty("content", "[${msg.images.size} image(s) returned by tool; not displayable in this message role]")
+            }
+        }
 
         if (msg.role == LlmMessage.Role.ASSISTANT) {
             // GLM thinking mode requires reasoning_content on every assistant message


### PR DESCRIPTION
## Summary

`OpenAiCompatProvider.buildMsg` serialized any message carrying images as a `content` array — including `role:"tool"` messages. The OpenAI Chat Completions schema only permits string content on tool messages (image parts are valid solely on `user`), so a vision run whose tool returned an image made the following request 400 — and `classifyHttpError` marked that 400 recoverable, resending the identical payload 5 times before failing the turn.

Fixes #750

## Change

- Tool-role messages never emit array content: images degrade to a short text placeholder when the tool result has no text.
- User/assistant multimodal arrays are unchanged; `AnthropicProvider` already wraps images in the `tool_result` content array correctly.

## Test plan

- [x] `./gradlew :app:testStandardDebugUnitTest --tests "com.webtoapp.core.agent.llm.*"` green; compile green.
- [ ] CI green on this PR.