### PR TITLE
fix(webview): keep TLS-MITM tunnels alive and align ALPN between both ends

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/TlsMitmBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/TlsMitmBridge.kt
@@ -197,17 +197,32 @@ object TlsMitmBridge {
             safeClose(client); return
         }
 
+        // Handshake with the WebView FIRST and remember which ALPN protocol it picked,
+        // so the upstream connection can be restricted to the same protocol. The bridge
+        // relays raw bytes — if the two sides negotiated independently, a WebView on h2
+        // facing an http/1.1-only origin would stream HTTP/2 frames into an HTTP/1.1
+        // server and every request to that host would fail.
+        val mitmSocket = try {
+            performTlsHandshake(client, host)
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "MITM TLS handshake failed for $host: ${e.message}")
+            sendStatus(clientOut, 502, "Bad Gateway")
+            safeClose(client); return
+        }
+        val clientProtocol = try { mitmSocket.applicationProtocol } catch (_: Exception) { null }
+
         val upstreamSocket = try {
             TlsUpstreamConnector.connect(
                 host = host,
                 port = port,
                 template = config.template,
                 customCipherSuites = config.customCipherSuites,
-                upstreamSocks = config.upstreamSocks
+                upstreamSocks = config.upstreamSocks,
+                restrictAlpnTo = clientProtocol
             ).sslSocket
         } catch (e: Exception) {
             AppLogger.w(TAG, "Upstream TLS connect failed for $host:$port: ${e.message}")
-            sendStatus(clientOut, 502, "Bad Gateway")
+            safeClose(mitmSocket)
             safeClose(client); return
         }
 
@@ -220,13 +235,13 @@ object TlsMitmBridge {
             safeClose(client); return
         }
 
-        val mitmSocket = try {
-            performTlsHandshake(client, host)
-        } catch (e: Exception) {
-            AppLogger.w(TAG, "MITM TLS handshake failed for $host: ${e.message}")
-            safeClose(upstreamSocket)
-            safeClose(client); return
-        }
+        // Tunnel mode (SSE/WebSocket/long-poll) can stay idle for minutes. The 60s
+        // handshake-phase SO_TIMEOUT would kill any such connection mid-session
+        // (copyStream swallows the SocketTimeoutException, so the teardown looks like a
+        // silent drop) — clear it once the tunnel is established, mirroring
+        // Socks5Connector's reset to 0 after the SOCKS handshake.
+        try { mitmSocket.soTimeout = 0 } catch (_: Exception) {}
+        try { upstreamSocket.soTimeout = 0 } catch (_: Exception) {}
 
         bridge(mitmSocket, upstreamSocket)
     }

--- a/app/src/main/java/com/webtoapp/core/webview/TlsUpstreamConnector.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/TlsUpstreamConnector.kt
@@ -27,7 +27,8 @@ object TlsUpstreamConnector {
         port: Int,
         template: TlsFingerprintTemplate,
         customCipherSuites: List<String> = emptyList(),
-        upstreamSocks: LocalHttpToSocksBridge.Upstream? = null
+        upstreamSocks: LocalHttpToSocksBridge.Upstream? = null,
+        restrictAlpnTo: String? = null
     ): TlsResult {
         val rawSocket = if (upstreamSocks != null) {
             LocalHttpToSocksBridge.Socks5Connector.connect(
@@ -56,7 +57,22 @@ object TlsUpstreamConnector {
         )
 
         val sslSocket = factory.createSocket(rawSocket, host, port, true) as SSLSocket
+        if (restrictAlpnTo != null) {
+            // The MITM socket already negotiated with the WebView; offering more
+            // protocols upstream than the client side speaks would let the two ends
+            // disagree (h2 into an http/1.1 server) and break the whole host.
+            try {
+                val params = sslSocket.sslParameters
+                params.applicationProtocols = arrayOf(restrictAlpnTo)
+                sslSocket.sslParameters = params
+            } catch (_: Exception) {
+            }
+        }
         sslSocket.startHandshake()
+
+        // The raw socket's connect-phase SO_TIMEOUT must not survive into tunnel
+        // mode: an idle SSE/WebSocket stream would otherwise be dropped after 60s.
+        try { sslSocket.soTimeout = 0 } catch (_: Exception) {}
 
         val negotiatedProtocol = try {
             sslSocket.applicationProtocol


### PR DESCRIPTION
## Summary

Two defects in the TLS fingerprint-spoofing bridge: (1) the 60 s handshake-phase `SO_TIMEOUT` on both sockets survived into tunnel mode, silently killing any SSE/WebSocket/long-poll idle for over a minute (`copyStream` swallows the timeout); (2) the WebView and upstream TLS ends negotiated ALPN independently, so a WebView on `h2` facing an http/1.1-only origin streamed HTTP/2 frames into an HTTP/1.1 server — the whole host failed until fingerprint spoofing was disabled.

Fixes #754

## Change

- `TlsMitmBridge.handleConnect`: clear `SO_TIMEOUT` on both sockets once the CONNECT tunnel is established (mirroring `Socks5Connector`).
- Reorder the handshake: the client-facing TLS handshake runs first, its negotiated ALPN is read, and the upstream connects with `restrictAlpnTo` so both ends speak the same protocol.

## Test plan

- [x] `./gradlew :app:testStandardDebugUnitTest --tests "com.webtoapp.core.webview.*"` green; compile green.
- [ ] CI green on this PR.