### PR TITLE
fix(download): make notification pause/resume intents explicit for Android 14+

### DIFF
--- a/app/src/main/java/com/webtoapp/core/download/DependencyDownloadNotification.kt
+++ b/app/src/main/java/com/webtoapp/core/download/DependencyDownloadNotification.kt
@@ -139,9 +139,11 @@ class DependencyDownloadNotification private constructor(private val context: Co
             append(dl.url)
         }
 
+        // The receiver is registered RECEIVER_NOT_EXPORTED; on Android 14+ an implicit
+        // intent is dropped before it ever reaches it, so the action must carry the package.
         val pauseIntent = PendingIntent.getBroadcast(
             context, 0,
-            Intent(ACTION_PAUSE),
+            Intent(ACTION_PAUSE).setPackage(context.packageName),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
@@ -172,7 +174,7 @@ class DependencyDownloadNotification private constructor(private val context: Co
 
         val resumeIntent = PendingIntent.getBroadcast(
             context, 0,
-            Intent(ACTION_RESUME),
+            Intent(ACTION_RESUME).setPackage(context.packageName),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 


### PR DESCRIPTION
## Summary

The Pause/Resume PendingIntents on the runtime-dependency download notification were implicit intents, but the receiver is registered `RECEIVER_NOT_EXPORTED`. Android 14 (targeting U+) drops implicit intents addressed to dynamically-registered non-exported receivers, so both buttons silently did nothing on Android 14/15 devices.

Fixes #756

## Change

`.setPackage(context.packageName)` on the Pause and Resume action intents.

## Test plan

- [x] `./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache` green.
- [ ] CI green on this PR.