### PR TITLE
refactor(ui): unify editor cards on WtaChip/WtaButton design system

### DIFF
--- a/.github/scripts/ui_design_allowlist.txt
+++ b/.github/scripts/ui_design_allowlist.txt
@@ -55,7 +55,6 @@ app/src/main/java/com/webtoapp/ui/components/RuntimeScreenComponents.kt|raw_surf
 app/src/main/java/com/webtoapp/ui/components/SampleProjectCard.kt|raw_corner_shape|3
 app/src/main/java/com/webtoapp/ui/components/Shimmer.kt|hardcoded_color|2
 app/src/main/java/com/webtoapp/ui/components/Shimmer.kt|raw_corner_shape|7
-app/src/main/java/com/webtoapp/ui/components/StatusBarConfigCard.kt|raw_corner_shape|6
 app/src/main/java/com/webtoapp/ui/components/StatusBarImageCropper.kt|raw_corner_shape|3
 app/src/main/java/com/webtoapp/ui/components/StatusBarImageCropper.kt|raw_card|2
 app/src/main/java/com/webtoapp/ui/components/TypedSampleProjectCard.kt|raw_corner_shape|3

--- a/app/src/main/java/com/webtoapp/ui/agent/components/ContextPickerDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/ContextPickerDialog.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.FilterChip
+import com.webtoapp.ui.design.WtaChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
@@ -129,16 +129,18 @@ private fun AppsPage(
                     .padding(vertical = WtaSpacing.Small),
                 horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
-                FilterChip(
+                WtaChip(
                     selected = selectedCategory == null,
                     onClick = { onSelectCategory(null) },
-                    label = { Text(Strings.agentContextAllCategories) }
+                    label = Strings.agentContextAllCategories,
+                    showSelectedCheck = false
                 )
                 categories.forEach { category ->
-                    FilterChip(
+                    WtaChip(
                         selected = selectedCategory == category.id,
                         onClick = { onSelectCategory(category.id) },
-                        label = { Text("${category.icon} ${category.name}") }
+                        label = "${category.icon} ${category.name}",
+                        showSelectedCheck = false
                     )
                 }
             }

--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -2,7 +2,11 @@ package com.webtoapp.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
 import com.webtoapp.ui.design.WtaChoiceRow
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaButton
+import com.webtoapp.ui.design.WtaButtonVariant
 import com.webtoapp.ui.design.WtaSectionDivider
+import com.webtoapp.ui.design.WtaSize
 import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaSwitch
 import com.webtoapp.ui.design.WtaToggleRow
@@ -188,7 +192,12 @@ fun ActivationCodeCard(
 
                     WtaSectionDivider()
 
-                    if (!remoteConfig.enabled) {
+                    androidx.compose.animation.AnimatedVisibility(
+                        visible = !remoteConfig.enabled,
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
+                    ) {
+                        Column {
                         WtaChoiceRow(
                             title = Strings.activationSectionCodes,
                             subtitle = if (activationCodes.isNotEmpty())
@@ -213,32 +222,32 @@ fun ActivationCodeCard(
                             ) {
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                                 ) {
-                                    PremiumButton(
+                                    WtaButton(
                                         onClick = { showAddDialog = true },
                                         modifier = Modifier.weight(1f)
                                     ) {
-                                        Icon(Icons.Default.Add, null, modifier = Modifier.size(18.dp))
-                                        Spacer(modifier = Modifier.width(6.dp))
+                                        Icon(Icons.Default.Add, null, modifier = Modifier.size(WtaSize.IconSmall))
+                                        Spacer(modifier = Modifier.width(WtaSpacing.Tiny))
                                         Text(Strings.addActivationCode, maxLines = 1, overflow = TextOverflow.Ellipsis)
                                     }
-                                    PremiumOutlinedButton(
+                                    WtaButton(
                                         onClick = { showBatchDialog = true },
-                                        shape = RoundedCornerShape(12.dp)
+                                        variant = WtaButtonVariant.Outlined
                                     ) {
-                                        Icon(Icons.Outlined.AutoAwesome, null, modifier = Modifier.size(18.dp))
-                                        Spacer(modifier = Modifier.width(4.dp))
+                                        Icon(Icons.Outlined.AutoAwesome, null, modifier = Modifier.size(WtaSize.IconSmall))
+                                        Spacer(modifier = Modifier.width(WtaSpacing.Tiny))
                                         Text(Strings.batchGenerate, maxLines = 1)
                                     }
                                 }
-                                PremiumOutlinedButton(
+                                WtaButton(
                                     onClick = { showBatchImportDialog = true },
-                                    shape = RoundedCornerShape(12.dp),
+                                    variant = WtaButtonVariant.Outlined,
                                     modifier = Modifier.fillMaxWidth()
                                 ) {
-                                    Icon(Icons.Outlined.PostAdd, null, modifier = Modifier.size(18.dp))
-                                    Spacer(modifier = Modifier.width(6.dp))
+                                    Icon(Icons.Outlined.PostAdd, null, modifier = Modifier.size(WtaSize.IconSmall))
+                                    Spacer(modifier = Modifier.width(WtaSpacing.Tiny))
                                     Text(Strings.batchImport, maxLines = 1, overflow = TextOverflow.Ellipsis)
                                 }
                                 if (activationCodes.isNotEmpty()) {
@@ -285,7 +294,13 @@ fun ActivationCodeCard(
                                 }
                             }
                         }
-                    } else {
+                        }
+                    }
+                    androidx.compose.animation.AnimatedVisibility(
+                        visible = remoteConfig.enabled,
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
+                    ) {
                         RemoteActivationSection(
                             remoteConfig = remoteConfig,
                             onRemoteConfigChange = onRemoteConfigChange,
@@ -1139,18 +1154,14 @@ private fun AddActivationCodeDialog(
                 ) {
                     ActivationCodeType.entries.forEach { type ->
                         val theme = getCodeTypeTheme(type)
-                        FilterChip(
+                        WtaChip(
                             selected = codeType == type,
                             onClick = { codeType = type },
-                            label = { Text(getActivationTypeName(type)) },
-                            leadingIcon = {
-                                Icon(
-                                    theme.icon,
-                                    null,
-                                    modifier = Modifier.size(16.dp),
-                                    tint = if (codeType == type) theme.color else MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
+                            label = getActivationTypeName(type),
+                            leadingIcon = theme.icon,
+                            showSelectedCheck = false,
+                            selectedContainerColor = theme.labelBg,
+                            selectedContentColor = theme.color
                         )
                     }
                 }
@@ -1442,23 +1453,14 @@ private fun BatchGenerateDialog(
                     ActivationCodeType.values().forEach { type ->
                         val theme = getCodeTypeTheme(type)
                         val isSelected = codeType == type
-                        FilterChip(
+                        WtaChip(
                             selected = isSelected,
                             onClick = { codeType = type },
-                            label = {
-                                Text(
-                                    getActivationTypeName(type),
-                                    style = MaterialTheme.typography.labelSmall
-                                )
-                            },
-                            leadingIcon = {
-                                Icon(theme.icon, null, modifier = Modifier.size(14.dp))
-                            },
-                            colors = FilterChipDefaults.filterChipColors(
-                                selectedContainerColor = theme.labelBg,
-                                selectedLabelColor = theme.color,
-                                selectedLeadingIconColor = theme.color
-                            )
+                            label = getActivationTypeName(type),
+                            leadingIcon = theme.icon,
+                            showSelectedCheck = false,
+                            selectedContainerColor = theme.labelBg,
+                            selectedContentColor = theme.color
                         )
                     }
                 }

--- a/app/src/main/java/com/webtoapp/ui/components/AutoStartCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/AutoStartCard.kt
@@ -25,6 +25,7 @@ import com.webtoapp.core.autostart.AutoStartManager
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.AutoStartConfig
 import com.webtoapp.ui.design.WtaSettingCard
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaToggleRow
 import com.webtoapp.ui.design.WtaSectionDivider
 import com.webtoapp.ui.design.WtaSpacing
@@ -256,7 +257,7 @@ fun AutoStartCard(
                                 dayNames.forEachIndexed { index, name ->
                                     val day = index + 1
                                     val isSelected = scheduledDays.contains(day)
-                                    PremiumFilterChip(
+                                    WtaChip(
                                         selected = isSelected,
                                         onClick = {
                                             scheduledDays = if (isSelected) {
@@ -266,8 +267,7 @@ fun AutoStartCard(
                                             }
                                             updateConfig()
                                         },
-                                        label = { Text(name) },
-                                        modifier = Modifier.padding(horizontal = 2.dp)
+                                        label = name
                                     )
                                 }
                             }

--- a/app/src/main/java/com/webtoapp/ui/components/BgmSelector.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/BgmSelector.kt
@@ -1,6 +1,8 @@
 package com.webtoapp.ui.components
 
 import com.webtoapp.core.logging.AppLogger
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaSwitch
 import android.content.Context
 import android.media.MediaPlayer
@@ -316,23 +318,25 @@ fun BgmSelectorDialog(
                     }
 
                     LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         item {
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = selectedTagFilter == null,
                                 onClick = { selectedTagFilter = null },
-                                label = { Text(Strings.allTag) }
+                                label = Strings.allTag,
+                                showSelectedCheck = false
                             )
                         }
                         items(BgmTag.entries.take(10)) { tag ->
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = selectedTagFilter == tag,
                                 onClick = {
                                     selectedTagFilter = if (selectedTagFilter == tag) null else tag
                                 },
-                                label = { Text(tag.displayName) }
+                                label = tag.displayName,
+                                showSelectedCheck = false
                             )
                         }
                     }
@@ -451,21 +455,24 @@ fun BgmSelectorDialog(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(Strings.playMode, style = MaterialTheme.typography.bodyMedium)
-                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                            PremiumFilterChip(
+                        Row(horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+                            WtaChip(
                                 selected = playMode == BgmPlayMode.LOOP,
                                 onClick = { playMode = BgmPlayMode.LOOP },
-                                label = { Text(Strings.loopMode, style = MaterialTheme.typography.labelSmall) }
+                                label = Strings.loopMode,
+                                showSelectedCheck = false
                             )
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = playMode == BgmPlayMode.SEQUENTIAL,
                                 onClick = { playMode = BgmPlayMode.SEQUENTIAL },
-                                label = { Text(Strings.sequentialMode, style = MaterialTheme.typography.labelSmall) }
+                                label = Strings.sequentialMode,
+                                showSelectedCheck = false
                             )
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = playMode == BgmPlayMode.SHUFFLE,
                                 onClick = { playMode = BgmPlayMode.SHUFFLE },
-                                label = { Text(Strings.shuffleMode, style = MaterialTheme.typography.labelSmall) }
+                                label = Strings.shuffleMode,
+                                showSelectedCheck = false
                             )
                         }
                     }
@@ -1198,11 +1205,11 @@ private fun EditTagsDialog(
 
                 FlowRow(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                 ) {
                     BgmTag.entries.forEach { tag ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = tag in selectedTags,
                             onClick = {
                                 selectedTags = if (tag in selectedTags) {
@@ -1211,7 +1218,7 @@ private fun EditTagsDialog(
                                     selectedTags + tag
                                 }
                             },
-                            label = { Text(tag.displayName) }
+                            label = tag.displayName
                         )
                     }
                 }

--- a/app/src/main/java/com/webtoapp/ui/components/CodeSnippetSelector.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/CodeSnippetSelector.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.window.DialogProperties
 import com.webtoapp.core.extension.CodeSnippet
 import com.webtoapp.core.extension.CodeSnippetCategory
 import com.webtoapp.core.extension.CodeSnippets
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import androidx.compose.ui.graphics.Color
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -118,32 +120,26 @@ fun CodeSnippetSelectorDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .horizontalScroll(rememberScrollState()),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
 
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = selectedCategory == null && searchQuery.isBlank(),
                             onClick = {
                                 selectedCategory = null
                                 searchQuery = ""
                             },
-                            label = { Text(com.webtoapp.core.i18n.Strings.hotTag) },
-                            leadingIcon = if (selectedCategory == null && searchQuery.isBlank()) {
-                                { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                            } else null
+                            label = com.webtoapp.core.i18n.Strings.hotTag
                         )
 
                         allCategories.forEach { category ->
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = selectedCategory == category,
                                 onClick = {
                                     selectedCategory = if (selectedCategory == category) null else category
                                     searchQuery = ""
                                 },
-                                label = { Text(category.name) },
-                                leadingIcon = if (selectedCategory == category) {
-                                    { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                                } else null
+                                label = category.name
                             )
                         }
                     }
@@ -531,19 +527,15 @@ fun CodeSnippetQuickPicker(
                 modifier = Modifier
                     .fillMaxWidth()
                     .horizontalScroll(rememberScrollState()),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
                 popularSnippets.forEach { snippet ->
-                    SuggestionChip(
+                    WtaChip(
+                        selected = false,
                         onClick = { onSelect(snippet) },
-                        label = { Text(snippet.name, maxLines = 1) },
-                        icon = {
-                            Icon(
-                                Icons.Outlined.Code,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp)
-                            )
-                        }
+                        label = snippet.name,
+                        leadingIcon = Icons.Outlined.Code,
+                        showSelectedCheck = false
                     )
                 }
             }

--- a/app/src/main/java/com/webtoapp/ui/components/DnsConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/DnsConfigCard.kt
@@ -116,7 +116,7 @@ fun DnsConfigCard(
                     Text(
                         text = Strings.advancedOptions,
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(horizontal = WtaSpacing.Tiny)
                     )
 
@@ -227,7 +227,7 @@ private fun DnsProviderSection(
         Text(
             text = Strings.dnsProviderLabel,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.primary
         )
         DnsProvider.entries.chunked(3).forEach { row ->
             Row(
@@ -260,7 +260,7 @@ private fun DohModeSection(
         Text(
             text = Strings.dohModeLabel,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.primary
         )
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/webtoapp/ui/components/ExtensionModuleCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ExtensionModuleCard.kt
@@ -4,8 +4,10 @@ import com.webtoapp.ui.design.WtaAlertDialog
 import com.webtoapp.ui.design.WtaBadge
 import com.webtoapp.ui.design.WtaCard
 import com.webtoapp.ui.design.WtaCardTone
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaDivider
 import com.webtoapp.ui.design.WtaRadius
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaSwitch
 
 import android.content.Intent
@@ -395,7 +397,7 @@ private fun SelectedModulesSection(
             Text(
                 text = Strings.extensionEnabledModulesLabel,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.primary
             )
             Row(
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
@@ -668,7 +670,7 @@ private fun FabIconSelector(
     Text(
         text = Strings.extensionFabIconLabel,
         style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
+        color = MaterialTheme.colorScheme.primary
     )
 
     Spacer(modifier = Modifier.height(6.dp))
@@ -917,28 +919,22 @@ fun ExtensionModuleSelectorDialog(
                     Spacer(modifier = Modifier.height(12.dp))
 
                     LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
                         item {
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = selectedCategory == null,
                                 onClick = { selectedCategory = null },
-                                label = { Text(Strings.all) },
-                                leadingIcon = if (selectedCategory == null) {
-                                    { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                                } else null
+                                label = Strings.all
                             )
                         }
                         items(ModuleCategory.values().toList()) { category ->
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = selectedCategory == category,
                                 onClick = {
                                     selectedCategory = if (selectedCategory == category) null else category
                                 },
-                                label = { Text(category.getDisplayName()) },
-                                leadingIcon = if (selectedCategory == category) {
-                                    { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                                } else null
+                                label = category.getDisplayName()
                             )
                         }
                     }
@@ -1214,16 +1210,13 @@ fun ModuleTestDialog(
                     )
 
                     LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
                         items(testPages) { page ->
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = selectedTestPage?.id == page.id,
                                 onClick = { selectedTestPage = page },
-                                label = { Text("${page.icon} ${page.name}") },
-                                leadingIcon = if (selectedTestPage?.id == page.id) {
-                                    { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                                } else null
+                                label = "${page.icon} ${page.name}"
                             )
                         }
                     }

--- a/app/src/main/java/com/webtoapp/ui/components/ExtensionModuleSelector.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ExtensionModuleSelector.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.unit.sp
 import com.webtoapp.core.extension.*
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.design.WtaAlertDialog
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaBadge
 import com.webtoapp.ui.design.WtaCard
 import com.webtoapp.ui.design.WtaCardTone
@@ -189,40 +191,40 @@ fun ModuleSelectionDialog(
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
-                PremiumFilterChip(
+                WtaChip(
                     selected = selectedCategory == null,
                     onClick = { selectedCategory = null },
-                    label = { Text(Strings.filterAll, style = MaterialTheme.typography.labelSmall) },
-                    modifier = Modifier.height(28.dp)
+                    label = Strings.filterAll,
+                    showSelectedCheck = false
                 )
-                PremiumFilterChip(
+                WtaChip(
                     selected = selectedCategory == ModuleCategory.CONTENT_FILTER,
                     onClick = {
                         selectedCategory = if (selectedCategory == ModuleCategory.CONTENT_FILTER) null
                                           else ModuleCategory.CONTENT_FILTER
                     },
-                    label = { Text(Strings.filterContent, style = MaterialTheme.typography.labelSmall) },
-                    modifier = Modifier.height(28.dp)
+                    label = Strings.filterContent,
+                    showSelectedCheck = false
                 )
-                PremiumFilterChip(
+                WtaChip(
                     selected = selectedCategory == ModuleCategory.STYLE_MODIFIER,
                     onClick = {
                         selectedCategory = if (selectedCategory == ModuleCategory.STYLE_MODIFIER) null
                                           else ModuleCategory.STYLE_MODIFIER
                     },
-                    label = { Text(Strings.filterStyle, style = MaterialTheme.typography.labelSmall) },
-                    modifier = Modifier.height(28.dp)
+                    label = Strings.filterStyle,
+                    showSelectedCheck = false
                 )
-                PremiumFilterChip(
+                WtaChip(
                     selected = selectedCategory == ModuleCategory.FUNCTION_ENHANCE,
                     onClick = {
                         selectedCategory = if (selectedCategory == ModuleCategory.FUNCTION_ENHANCE) null
                                           else ModuleCategory.FUNCTION_ENHANCE
                     },
-                    label = { Text(Strings.filterFunction, style = MaterialTheme.typography.labelSmall) },
-                    modifier = Modifier.height(28.dp)
+                    label = Strings.filterFunction,
+                    showSelectedCheck = false
                 )
             }
 
@@ -353,7 +355,7 @@ fun QuickModuleSelector(
         Text(
             Strings.quickEnable,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.primary
         )
         Spacer(modifier = Modifier.height(8.dp))
 
@@ -363,7 +365,7 @@ fun QuickModuleSelector(
         ) {
             quickModules.forEach { module ->
                 val isSelected = module.id in selectedModuleIds
-                PremiumFilterChip(
+                WtaChip(
                     selected = isSelected,
                     onClick = {
                         onSelectionChange(
@@ -371,9 +373,18 @@ fun QuickModuleSelector(
                             else selectedModuleIds + module.id
                         )
                     },
-                    label = { Text(module.name.take(4)) },
-                    leadingIcon = { ModuleIcon(iconId = module.icon, contentDescription = null, modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onSurface) }
-                )
+                    showSelectedCheck = false,
+                    leadingContent = {
+                        ModuleIcon(
+                            iconId = module.icon,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = LocalContentColor.current
+                        )
+                    }
+                ) {
+                    Text(module.name.take(4))
+                }
             }
         }
     }

--- a/app/src/main/java/com/webtoapp/ui/components/FloatingWindowConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/FloatingWindowConfigCard.kt
@@ -4,11 +4,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -25,7 +20,6 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -36,6 +30,7 @@ import com.webtoapp.data.model.FloatingWindowConfig
 import com.webtoapp.ui.animation.CardCollapseTransition
 import com.webtoapp.ui.animation.CardExpandTransition
 import com.webtoapp.ui.design.WtaDivider
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaFeatureCard
 import com.webtoapp.ui.design.WtaFeatureCardHeader
 import com.webtoapp.ui.design.WtaRadius
@@ -121,8 +116,8 @@ fun FloatingWindowConfigCard(
 
                     AnimatedVisibility(
                         visible = aspectRatioMode == FloatingWindowAspectRatioMode.FREE,
-                        enter = fadeIn(tween(200)) + expandVertically(tween(300)),
-                        exit = fadeOut(tween(200)) + shrinkVertically(tween(300))
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
                     ) {
                         SliderWithLabel(
                             label = Strings.fwHeightLabel,
@@ -138,12 +133,13 @@ fun FloatingWindowConfigCard(
                     Spacer(Modifier.height(4.dp))
                     Text(
                         text = Strings.fwAspectRatio,
-                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-                        modifier = Modifier.padding(bottom = 6.dp)
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(bottom = WtaSpacing.Tiny)
                     )
                     FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
                         data class AspectOption(
                             val mode: FloatingWindowAspectRatioMode,
@@ -159,7 +155,7 @@ fun FloatingWindowConfigCard(
                             AspectOption(FloatingWindowAspectRatioMode.CUSTOM, Strings.fwAspectCustom)
                         )
                         aspectOptions.forEach { option ->
-                            FilterChip(
+                            WtaChip(
                                 selected = aspectRatioMode == option.mode,
                                 onClick = {
                                     onConfigChange(config.copy(
@@ -167,24 +163,15 @@ fun FloatingWindowConfigCard(
                                         lockAspectRatio = option.mode != FloatingWindowAspectRatioMode.FREE
                                     ))
                                 },
-                                label = { Text(option.label, style = MaterialTheme.typography.labelSmall) },
-                                leadingIcon = if (aspectRatioMode == option.mode) {
-                                    {
-                                        Icon(
-                                            Icons.Outlined.Check,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(16.dp)
-                                        )
-                                    }
-                                } else null
+                                label = option.label
                             )
                         }
                     }
 
                     AnimatedVisibility(
                         visible = aspectRatioMode == FloatingWindowAspectRatioMode.CUSTOM,
-                        enter = fadeIn(tween(200)) + expandVertically(tween(300)),
-                        exit = fadeOut(tween(200)) + shrinkVertically(tween(300))
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
                     ) {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -246,12 +233,13 @@ fun FloatingWindowConfigCard(
                     Spacer(Modifier.height(4.dp))
                     Text(
                         text = Strings.fwBorderStyle,
-                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-                        modifier = Modifier.padding(bottom = 6.dp)
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(bottom = WtaSpacing.Tiny)
                     )
                     FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
                         data class BorderOption(
                             val style: FloatingBorderStyle,
@@ -266,17 +254,12 @@ fun FloatingWindowConfigCard(
                         )
                         borderOptions.forEach { option ->
                             val isSelected = config.borderStyle == option.style
-                            FilterChip(
+                            WtaChip(
                                 selected = isSelected,
                                 onClick = { onConfigChange(config.copy(borderStyle = option.style)) },
-                                label = { Text(option.label, style = MaterialTheme.typography.labelSmall) },
-                                leadingIcon = {
-                                    Icon(
-                                        option.icon,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp)
-                                    )
-                                }
+                                label = option.label,
+                                leadingIcon = option.icon,
+                                showSelectedCheck = false
                             )
                         }
                     }
@@ -327,8 +310,8 @@ fun FloatingWindowConfigCard(
 
                     AnimatedVisibility(
                         visible = config.showTitleBar,
-                        enter = fadeIn(tween(200)) + expandVertically(tween(200)),
-                        exit = fadeOut(tween(200)) + shrinkVertically(tween(200))
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
                     ) {
                         ToggleRow(
                             title = Strings.fwAutoHideTitleBar,
@@ -386,8 +369,8 @@ fun FloatingWindowConfigCard(
 
                     AnimatedVisibility(
                         visible = showAdvanced,
-                        enter = fadeIn(tween(200)) + expandVertically(tween(300)),
-                        exit = fadeOut(tween(200)) + shrinkVertically(tween(300))
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
                     ) {
                         Column(
                             modifier = Modifier.padding(top = 12.dp),
@@ -496,8 +479,8 @@ private fun FloatingWindowMinimizedIconPicker(
                 }
                 AnimatedVisibility(
                     visible = hasIcon,
-                    enter = fadeIn(tween(150)),
-                    exit = fadeOut(tween(150))
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
                 ) {
                     TextButton(
                         onClick = onClear,

--- a/app/src/main/java/com/webtoapp/ui/components/GreasyForkSearchContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/GreasyForkSearchContent.kt
@@ -62,6 +62,7 @@ import com.webtoapp.ui.design.WtaButtonSize
 import com.webtoapp.ui.design.WtaButtonVariant
 import com.webtoapp.ui.design.WtaCard
 import com.webtoapp.ui.design.WtaCardTone
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaRadius
 import com.webtoapp.ui.design.WtaSpacing
 
@@ -151,10 +152,11 @@ fun GreasyForkSearchContent(
                     contentPadding = PaddingValues(vertical = 4.dp)
                 ) {
                     items(GfBrowseCategory.browseOrder(), key = { it.name }) { category ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = browseCategory == category,
                             onClick = { onBrowseCategoryChange(category) },
-                            label = { Text(gfBrowseCategoryLabel(category)) }
+                            label = gfBrowseCategoryLabel(category),
+                            showSelectedCheck = false
                         )
                     }
                 }
@@ -292,10 +294,11 @@ private fun GfSortRow(
             )
         }
         items(GfSort.values().toList(), key = { it.name }) { mode ->
-            PremiumFilterChip(
+            WtaChip(
                 selected = sortMode == mode,
                 onClick = { onSortModeChange(mode) },
-                label = { Text(gfSortLabel(mode)) }
+                label = gfSortLabel(mode),
+                showSelectedCheck = false
             )
         }
     }

--- a/app/src/main/java/com/webtoapp/ui/components/IsolationConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/IsolationConfigCard.kt
@@ -1,6 +1,10 @@
 package com.webtoapp.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
+import com.webtoapp.ui.animation.CardCollapseTransition
+import com.webtoapp.ui.animation.CardExpandTransition
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaSwitch
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -95,48 +99,43 @@ fun IsolationConfigCard(
                 )
             }
 
-            AnimatedVisibility(visible = config.enabled) {
+            AnimatedVisibility(
+                visible = config.enabled,
+                enter = CardExpandTransition,
+                exit = CardCollapseTransition
+            ) {
                 Column(
-                    modifier = Modifier.padding(top = 16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    modifier = Modifier.padding(top = WtaSpacing.ContentGap),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.ContentGap)
                 ) {
 
                     Text(
                         text = Strings.isolationLevel,
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.primary
                     )
 
                     FlowRow(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = isBasicConfig(config),
                             onClick = { onConfigChange(IsolationConfig.BASIC) },
-                            label = { Text(Strings.basic) },
-                            leadingIcon = if (isBasicConfig(config)) {
-                                { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                            } else null
+                            label = Strings.basic
                         )
 
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = isStandardConfig(config),
                             onClick = { onConfigChange(IsolationConfig.STANDARD) },
-                            label = { Text(Strings.standard) },
-                            leadingIcon = if (isStandardConfig(config)) {
-                                { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                            } else null
+                            label = Strings.standard
                         )
 
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = isMaximumConfig(config),
                             onClick = { onConfigChange(IsolationConfig.MAXIMUM) },
-                            label = { Text(Strings.maximum) },
-                            leadingIcon = if (isMaximumConfig(config)) {
-                                { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                            } else null
+                            label = Strings.maximum
                         )
                     }
 
@@ -237,9 +236,14 @@ fun IsolationConfigCard(
                             }
                         )
 
-                        AnimatedVisibility(visible = config.ipSpoofConfig.enabled) {
+                        AnimatedVisibility(
+                            visible = config.ipSpoofConfig.enabled,
+                            enter = CardExpandTransition,
+                            exit = CardCollapseTransition
+                        ) {
                             Column(
-                                modifier = Modifier.padding(start = 16.dp, top = 8.dp)
+                                modifier = Modifier.padding(start = WtaSpacing.RowHorizontal, top = WtaSpacing.ContentGap),
+                                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)
                             ) {
                                 Text(
                                     text = Strings.ipRegion,
@@ -247,26 +251,29 @@ fun IsolationConfigCard(
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                                 Row(
-                                    modifier = Modifier.padding(top = 4.dp),
-                                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)
                                 ) {
                                     IpRange.entries.forEach { range ->
-                                        PremiumFilterChip(
+                                        WtaChip(
                                             selected = config.ipSpoofConfig.randomIpRange == range,
                                             onClick = {
                                                 onConfigChange(config.copy(
                                                     ipSpoofConfig = config.ipSpoofConfig.copy(randomIpRange = range)
                                                 ))
                                             },
-                                            label = { Text(range.displayName, style = MaterialTheme.typography.labelSmall) },
-                                            modifier = Modifier.height(28.dp)
+                                            label = range.displayName,
+                                            showSelectedCheck = false
                                         )
                                     }
                                 }
 
-                                AnimatedVisibility(visible = config.ipSpoofConfig.randomIpRange == IpRange.SEARCH) {
+                                AnimatedVisibility(
+                                    visible = config.ipSpoofConfig.randomIpRange == IpRange.SEARCH,
+                                    enter = CardExpandTransition,
+                                    exit = CardCollapseTransition
+                                ) {
                                     Column(
-                                        modifier = Modifier.padding(top = 8.dp)
+                                        modifier = Modifier.padding(top = WtaSpacing.ContentGap)
                                     ) {
                                         PremiumTextField(
                                             value = config.ipSpoofConfig.searchKeyword ?: "",

--- a/app/src/main/java/com/webtoapp/ui/components/NotificationConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/NotificationConfigCard.kt
@@ -11,11 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Notifications
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -38,7 +35,11 @@ import com.webtoapp.ui.design.WtaDivider
 import com.webtoapp.ui.design.WtaFeatureCard
 import com.webtoapp.ui.design.WtaFeatureCardHeader
 import com.webtoapp.ui.design.WtaSpacing
+import com.webtoapp.ui.design.WtaStatusBanner
+import com.webtoapp.ui.design.WtaStatusTone
 import com.webtoapp.ui.design.WtaSwitch
+import com.webtoapp.ui.animation.CardCollapseTransition
+import com.webtoapp.ui.animation.CardExpandTransition
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,7 +66,11 @@ fun NotificationConfigCard(
             }
         )
 
-        AnimatedVisibility(visible = enabled) {
+        AnimatedVisibility(
+            visible = enabled,
+            enter = CardExpandTransition,
+            exit = CardCollapseTransition
+        ) {
             Column(
                 modifier = Modifier.padding(top = WtaSpacing.Large),
                 verticalArrangement = Arrangement.spacedBy(WtaSpacing.Medium)
@@ -76,7 +81,7 @@ fun NotificationConfigCard(
                 Text(
                     Strings.notificationTypeLabel,
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.primary
                 )
                 Row(
                     modifier = Modifier
@@ -106,23 +111,23 @@ fun NotificationConfigCard(
                     )
                 }
 
-                if (config.type == NotificationType.WEB_API) {
-                    Card(
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                        ),
-                        shape = RoundedCornerShape(8.dp)
-                    ) {
-                        Text(
-                            Strings.notificationWebApiDesc,
-                            modifier = Modifier.padding(12.dp),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+                AnimatedVisibility(
+                    visible = config.type == NotificationType.WEB_API,
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
+                    WtaStatusBanner(
+                        message = Strings.notificationWebApiDesc,
+                        tone = WtaStatusTone.Info
+                    )
                 }
 
-                if (config.type == NotificationType.POLLING) {
+                AnimatedVisibility(
+                    visible = config.type == NotificationType.POLLING,
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Medium)) {
                     PremiumTextField(
                         value = config.pollUrl,
                         onValueChange = { onConfigChange(config.copy(pollUrl = it)) },
@@ -172,7 +177,11 @@ fun NotificationConfigCard(
                         Text(if (expanded) Strings.hideAdvanced else Strings.showAdvanced)
                     }
 
-                    AnimatedVisibility(visible = expanded) {
+                    AnimatedVisibility(
+                        visible = expanded,
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
+                    ) {
                         Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Medium)) {
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
@@ -219,22 +228,19 @@ fun NotificationConfigCard(
                             )
                         }
                     }
+                    }
                 }
 
-                if (config.type == NotificationType.WEBSOCKET) {
-                    Card(
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                        ),
-                        shape = RoundedCornerShape(8.dp)
-                    ) {
-                        Text(
-                            Strings.notificationWebsocketDesc,
-                            modifier = Modifier.padding(12.dp),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+                AnimatedVisibility(
+                    visible = config.type == NotificationType.WEBSOCKET,
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Medium)) {
+                    WtaStatusBanner(
+                        message = Strings.notificationWebsocketDesc,
+                        tone = WtaStatusTone.Info
+                    )
 
                     PremiumTextField(
                         value = config.wsUrl,
@@ -270,7 +276,11 @@ fun NotificationConfigCard(
                         Text(if (expanded) Strings.hideAdvanced else Strings.showAdvanced)
                     }
 
-                    AnimatedVisibility(visible = expanded) {
+                    AnimatedVisibility(
+                        visible = expanded,
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
+                    ) {
                         Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Medium)) {
                             PremiumTextField(
                                 value = config.wsHeaders,
@@ -302,22 +312,19 @@ fun NotificationConfigCard(
                             )
                         }
                     }
+                    }
                 }
 
-                if (config.type == NotificationType.FCM) {
-                    Card(
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                        ),
-                        shape = RoundedCornerShape(8.dp)
-                    ) {
-                        Text(
-                            Strings.notificationFcmDesc,
-                            modifier = Modifier.padding(12.dp),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+                AnimatedVisibility(
+                    visible = config.type == NotificationType.FCM,
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Medium)) {
+                    WtaStatusBanner(
+                        message = Strings.notificationFcmDesc,
+                        tone = WtaStatusTone.Info
+                    )
 
                     PremiumTextField(
                         value = config.fcmGoogleServicesJson,
@@ -396,7 +403,11 @@ fun NotificationConfigCard(
                         Text(if (expanded) Strings.hideAdvanced else Strings.showAdvanced)
                     }
 
-                    AnimatedVisibility(visible = expanded) {
+                    AnimatedVisibility(
+                        visible = expanded,
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
+                    ) {
                         Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Medium)) {
                             PremiumTextField(
                                 value = config.authToken,
@@ -424,6 +435,7 @@ fun NotificationConfigCard(
                                 singleLine = true
                             )
                         }
+                    }
                     }
                 }
             }

--- a/app/src/main/java/com/webtoapp/ui/components/OnlineMusicSearchDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/OnlineMusicSearchDialog.kt
@@ -43,6 +43,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.webtoapp.core.bgm.ChannelStatus
 import com.webtoapp.core.bgm.MusicChannel
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.core.bgm.OnlineMusicApi
 import com.webtoapp.core.bgm.OnlineMusicDownloader
 import com.webtoapp.core.bgm.OnlineMusicTrack
@@ -731,37 +732,11 @@ private fun ChannelChip(
 
     val isRecommended = channel.id == "netease_official"
 
-    PremiumFilterChip(
+    WtaChip(
         selected = isSelected,
         onClick = onClick,
-        label = {
-            Column {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(channel.displayName, fontSize = 13.sp)
-                    if (isRecommended) {
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Surface(
-                            shape = RoundedCornerShape(4.dp),
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(start = 2.dp)
-                        ) {
-                            Text(
-                                Strings.recommendedLabel,
-                                fontSize = 8.sp,
-                                color = MaterialTheme.colorScheme.onPrimary,
-                                modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp)
-                            )
-                        }
-                    }
-                }
-                Text(
-                    statusText,
-                    fontSize = 10.sp,
-                    color = statusColor
-                )
-            }
-        },
-        leadingIcon = if (isTesting) {
+        showSelectedCheck = false,
+        leadingContent = if (isTesting) {
             {
                 CircularProgressIndicator(
                     modifier = Modifier.size(14.dp),
@@ -778,7 +753,33 @@ private fun ChannelChip(
                 )
             }
         }
-    )
+    ) {
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(channel.displayName, fontSize = 13.sp)
+                if (isRecommended) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Surface(
+                        shape = RoundedCornerShape(4.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(start = 2.dp)
+                    ) {
+                        Text(
+                            Strings.recommendedLabel,
+                            fontSize = 8.sp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp)
+                        )
+                    }
+                }
+            }
+            Text(
+                statusText,
+                fontSize = 10.sp,
+                color = statusColor
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/webtoapp/ui/components/PremiumComponents.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/PremiumComponents.kt
@@ -85,37 +85,6 @@ fun PremiumTextField(
 }
 
 @Composable
-fun PremiumFilterChip(
-    selected: Boolean,
-    onClick: () -> Unit,
-    label: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    leadingIcon: @Composable (() -> Unit)? = null,
-) {
-
-    WtaChip(
-        selected = selected,
-        onClick = onClick,
-        modifier = modifier,
-        enabled = enabled,
-        showSelectedCheck = false
-    ) {
-        if (leadingIcon != null) {
-            androidx.compose.foundation.layout.Row(
-                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(6.dp)
-            ) {
-                leadingIcon()
-                label()
-            }
-        } else {
-            label()
-        }
-    }
-}
-
-@Composable
 fun PremiumButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/webtoapp/ui/components/StatusBarConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/StatusBarConfigCard.kt
@@ -5,12 +5,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
-import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -27,6 +25,12 @@ import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.StatusBarBackgroundType
 import com.webtoapp.data.model.StatusBarColorMode
 import com.webtoapp.data.model.WebViewConfig
+import com.webtoapp.ui.design.WtaButton
+import com.webtoapp.ui.design.WtaButtonVariant
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaRadius
+import com.webtoapp.ui.design.WtaSettingRow
+import com.webtoapp.ui.design.WtaSpacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -95,9 +99,12 @@ fun StatusBarConfigCard(
         )
     }
 
+    // Zone content: the caller (FullscreenModeCard) already provides the
+    // 16dp padded zone, so this column only spaces sections like its
+    // neighbours (DnsProviderSection / staticAssetPack block).
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap)
     ) {
         StatusBarPreviewBox(
             heightDp = currentHeightDp,
@@ -114,62 +121,65 @@ fun StatusBarConfigCard(
             onHeightChange = { onConfigChange(config.copy(statusBarHeightDp = it)) }
         )
 
-        HorizontalDivider()
-
-        Text(Strings.backgroundType, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            PremiumFilterChip(
-                selected = config.statusBarBackgroundType == StatusBarBackgroundType.COLOR,
-                onClick = { onConfigChange(config.copy(statusBarBackgroundType = StatusBarBackgroundType.COLOR)) },
-                label = { Text(Strings.solidColor) },
-                leadingIcon = if (config.statusBarBackgroundType == StatusBarBackgroundType.COLOR) {
-                    { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                } else { { Icon(Icons.Outlined.Palette, null, Modifier.size(18.dp)) } }
-            )
-            PremiumFilterChip(
-                selected = config.statusBarBackgroundType == StatusBarBackgroundType.IMAGE,
-                onClick = { onConfigChange(config.copy(statusBarBackgroundType = StatusBarBackgroundType.IMAGE)) },
-                label = { Text(Strings.image) },
-                leadingIcon = if (config.statusBarBackgroundType == StatusBarBackgroundType.IMAGE) {
-                    { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                } else { { Icon(Icons.Outlined.Image, null, Modifier.size(18.dp)) } }
-            )
+        Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+            GroupLabel(Strings.backgroundType)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+            ) {
+                WtaChip(
+                    selected = config.statusBarBackgroundType == StatusBarBackgroundType.COLOR,
+                    onClick = { onConfigChange(config.copy(statusBarBackgroundType = StatusBarBackgroundType.COLOR)) },
+                    label = Strings.solidColor,
+                    modifier = Modifier.weight(1f),
+                    leadingIcon = Icons.Default.Palette,
+                    showSelectedCheck = false
+                )
+                WtaChip(
+                    selected = config.statusBarBackgroundType == StatusBarBackgroundType.IMAGE,
+                    onClick = { onConfigChange(config.copy(statusBarBackgroundType = StatusBarBackgroundType.IMAGE)) },
+                    label = Strings.image,
+                    modifier = Modifier.weight(1f),
+                    leadingIcon = Icons.Default.Image,
+                    showSelectedCheck = false
+                )
+            }
         }
 
         when (config.statusBarBackgroundType) {
             StatusBarBackgroundType.COLOR -> {
-                Text(Strings.backgroundColor, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+                    GroupLabel(Strings.backgroundColor)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+                    ) {
+                        WtaChip(
+                            selected = config.statusBarColorMode == StatusBarColorMode.THEME,
+                            onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.THEME)) },
+                            label = Strings.tagTheme,
+                            modifier = Modifier.weight(1f),
+                            showSelectedCheck = false
+                        )
+                        WtaChip(
+                            selected = config.statusBarColorMode == StatusBarColorMode.PAGE_TOP,
+                            onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.PAGE_TOP)) },
+                            label = Strings.followPageTop,
+                            modifier = Modifier.weight(1f),
+                            showSelectedCheck = false
+                        )
+                        WtaChip(
+                            selected = config.statusBarColorMode == StatusBarColorMode.CUSTOM,
+                            onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.CUSTOM)) },
+                            label = Strings.backgroundColor,
+                            modifier = Modifier.weight(1f),
+                            showSelectedCheck = false
+                        )
+                    }
 
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    PremiumFilterChip(
-                        selected = config.statusBarColorMode == StatusBarColorMode.THEME,
-                        onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.THEME)) },
-                        label = { Text(Strings.tagTheme) },
-                        leadingIcon = if (config.statusBarColorMode == StatusBarColorMode.THEME) {
-                            { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                        } else { { Icon(Icons.Outlined.Palette, null, Modifier.size(18.dp)) } }
-                    )
-                    PremiumFilterChip(
-                        selected = config.statusBarColorMode == StatusBarColorMode.PAGE_TOP,
-                        onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.PAGE_TOP)) },
-                        label = { Text(Strings.followPageTop) },
-                        leadingIcon = if (config.statusBarColorMode == StatusBarColorMode.PAGE_TOP) {
-                            { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                        } else { { Icon(Icons.Outlined.Language, null, Modifier.size(18.dp)) } }
-                    )
-                    PremiumFilterChip(
-                        selected = config.statusBarColorMode == StatusBarColorMode.CUSTOM,
-                        onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.CUSTOM)) },
-                        label = { Text(Strings.backgroundColor) },
-                        leadingIcon = if (config.statusBarColorMode == StatusBarColorMode.CUSTOM) {
-                            { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                        } else { { Icon(Icons.Outlined.Edit, null, Modifier.size(18.dp)) } }
-                    )
-                }
-
-                if (config.statusBarColorMode == StatusBarColorMode.CUSTOM) {
-                    ColorSelectionRow(currentColor = config.statusBarColor, onColorClick = { showColorPicker = true })
+                    if (config.statusBarColorMode == StatusBarColorMode.CUSTOM) {
+                        ColorSelectionRow(currentColor = config.statusBarColor, onColorClick = { showColorPicker = true })
+                    }
                 }
             }
             StatusBarBackgroundType.IMAGE -> {
@@ -181,11 +191,19 @@ fun StatusBarConfigCard(
             }
         }
 
-        HorizontalDivider()
-
         AlphaSlider(alpha = config.statusBarBackgroundAlpha, onAlphaChange = { onConfigChange(config.copy(statusBarBackgroundAlpha = it)) })
     }
 }
+
+@Composable
+private fun GroupLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary
+    )
+}
+
 @Composable
 private fun StatusBarPreviewBox(
     heightDp: Int,
@@ -206,12 +224,15 @@ private fun StatusBarPreviewBox(
         }
     }
 
-    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text(Strings.statusBarPreview, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+    ) {
+        GroupLabel(Strings.statusBarPreview)
 
         Box(
-            modifier = Modifier.fillMaxWidth().height(heightDp.dp).clip(RoundedCornerShape(4.dp))
-                .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(4.dp))
+            modifier = Modifier.fillMaxWidth().height(heightDp.dp).clip(RoundedCornerShape(WtaRadius.Control))
+                .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(WtaRadius.Control))
         ) {
             when (backgroundType) {
                 StatusBarBackgroundType.COLOR -> {
@@ -230,10 +251,10 @@ private fun StatusBarPreviewBox(
                     }
                 }
             }
-            Row(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+            Row(modifier = Modifier.fillMaxSize().padding(horizontal = WtaSpacing.RowHorizontal),
                 horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Text("12:00", style = MaterialTheme.typography.labelSmall, color = Color.White, fontSize = 11.sp)
-                Row(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalAlignment = Alignment.CenterVertically) {
+                Row(horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny), verticalAlignment = Alignment.CenterVertically) {
                     Icon(Icons.Default.SignalCellularAlt, null, Modifier.size(12.dp), tint = Color.White)
                     Icon(Icons.Default.Wifi, null, Modifier.size(12.dp), tint = Color.White)
                     Icon(Icons.Default.BatteryFull, null, Modifier.size(12.dp), tint = Color.White)
@@ -245,9 +266,12 @@ private fun StatusBarPreviewBox(
 
 @Composable
 private fun HeightSlider(currentHeight: Int, systemDefaultHeight: Int, onHeightChange: (Int) -> Unit) {
-    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    // Same slider-in-zone pattern as the staticAssetPack block: primary group
+    // label plus a raw Slider (WtaSliderRow is a full-bleed row and would
+    // double-pad inside the caller's padded zone).
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-            Text(Strings.statusBarHeight, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            GroupLabel(Strings.statusBarHeight)
             Text("${currentHeight}dp", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
         }
 
@@ -255,7 +279,7 @@ private fun HeightSlider(currentHeight: Int, systemDefaultHeight: Int, onHeightC
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Text("0dp", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
 
-            TextButton(onClick = { onHeightChange(-1) }, contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp)) {
+            TextButton(onClick = { onHeightChange(-1) }, contentPadding = PaddingValues(horizontal = WtaSpacing.Small, vertical = 0.dp)) {
                 Text("${Strings.restoreDefault} (${systemDefaultHeight}dp)", fontSize = 12.sp)
             }
             Text("48dp", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -266,24 +290,30 @@ private fun HeightSlider(currentHeight: Int, systemDefaultHeight: Int, onHeightC
 @Composable
 private fun ColorSelectionRow(currentColor: String?, onColorClick: () -> Unit) {
     val color = remember(currentColor) { currentColor?.let { parseColor(it) } ?: Color.Black }
-    Row(modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)).clickable(onClick = onColorClick).padding(12.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
-        Box(modifier = Modifier.size(40.dp).clip(RoundedCornerShape(8.dp)).background(color).border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp)))
-        Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
-            Text(Strings.backgroundColor, style = MaterialTheme.typography.bodyMedium)
-            Text(currentColor?.uppercase() ?: "#000000", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    WtaSettingRow(
+        title = Strings.backgroundColor,
+        subtitle = currentColor?.uppercase() ?: "#000000",
+        onClick = onColorClick,
+        iconContent = {
+            Box(
+                modifier = Modifier.size(WtaSpacing.ExtraLarge)
+                    .clip(RoundedCornerShape(WtaRadius.Chip))
+                    .background(color)
+                    .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(WtaRadius.Chip))
+            )
         }
+    ) {
         Icon(Icons.Default.Edit, contentDescription = Strings.selectColor, tint = MaterialTheme.colorScheme.primary)
     }
 }
 
 @Composable
 private fun ImageSelectionRow(currentImagePath: String?, onSelectImage: () -> Unit, onClearImage: () -> Unit) {
-    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
         if (currentImagePath != null) {
-            Row(modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)).border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp)).padding(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
-                AsyncImage(model = currentImagePath, contentDescription = null, modifier = Modifier.width(80.dp).height(32.dp).clip(RoundedCornerShape(4.dp)), contentScale = ContentScale.Crop)
+            Row(modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(WtaRadius.Control)).border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(WtaRadius.Control)).padding(WtaSpacing.Small),
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Medium), verticalAlignment = Alignment.CenterVertically) {
+                AsyncImage(model = currentImagePath, contentDescription = null, modifier = Modifier.width(80.dp).height(32.dp).clip(RoundedCornerShape(WtaRadius.Chip)), contentScale = ContentScale.Crop)
                 Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
                     Text(Strings.imageSelected, style = MaterialTheme.typography.bodyMedium)
                     Text(Strings.clickToChangeOrClear, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -292,20 +322,22 @@ private fun ImageSelectionRow(currentImagePath: String?, onSelectImage: () -> Un
                 IconButton(onClick = onClearImage) { Icon(Icons.Default.Delete, Strings.clearImage, tint = MaterialTheme.colorScheme.error) }
             }
         } else {
-            PremiumOutlinedButton(onClick = onSelectImage, modifier = Modifier.fillMaxWidth()) {
-                Icon(Icons.Default.AddPhotoAlternate, null, Modifier.size(20.dp))
-                Spacer(Modifier.width(8.dp))
-                Text(Strings.selectBackgroundImage)
-            }
+            WtaButton(
+                onClick = onSelectImage,
+                text = Strings.selectBackgroundImage,
+                variant = WtaButtonVariant.Outlined,
+                leadingIcon = Icons.Default.AddPhotoAlternate,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }
 
 @Composable
 private fun AlphaSlider(alpha: Float, onAlphaChange: (Float) -> Unit) {
-    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-            Text(Strings.backgroundAlpha, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            GroupLabel(Strings.backgroundAlpha)
             Text("${(alpha * 100).toInt()}%", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
         }
         Slider(value = alpha, onValueChange = onAlphaChange, valueRange = 0f..1f, modifier = Modifier.fillMaxWidth())

--- a/app/src/main/java/com/webtoapp/ui/components/WtaCodeEditorDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/WtaCodeEditorDialog.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FindReplace
 import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -61,6 +60,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.webtoapp.core.i18n.Strings
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaRadius
 
 @Composable
@@ -371,18 +371,14 @@ fun WtaCodeEditorDialog(
                                     .padding(top = 4.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                FilterChip(
+                                WtaChip(
                                     selected = matchCase,
                                     onClick = {
                                         matchCase = !matchCase
                                         activeMatchIndex = 0
                                     },
-                                    label = {
-                                        Text(
-                                            Strings.codeEditorMatchCase,
-                                            style = MaterialTheme.typography.labelSmall
-                                        )
-                                    }
+                                    label = Strings.codeEditorMatchCase,
+                                    showSelectedCheck = false
                                 )
                                 Spacer(Modifier.width(8.dp))
                                 if (searchQuery.isNotBlank() && matches.isEmpty()) {

--- a/app/src/main/java/com/webtoapp/ui/components/ZoomPresetsDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ZoomPresetsDialog.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ZoomIn
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -17,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.webtoapp.core.i18n.Strings
+import com.webtoapp.ui.design.WtaChip
 
 /** Page-zoom preset percentages offered in the overflow menu. Mirrors Chrome's stops. */
 val PAGE_ZOOM_PRESETS: List<Int> = listOf(50, 67, 75, 80, 90, 100, 110, 125, 150)
@@ -47,21 +46,11 @@ fun ZoomPresetsDialog(
             ) {
                 PAGE_ZOOM_PRESETS.forEach { preset ->
                     val isSelected = preset == selected
-                    AssistChip(
+                    WtaChip(
+                        selected = isSelected,
                         onClick = { onSelect(preset); onDismiss() },
-                        label = { Text("$preset%") },
-                        colors = AssistChipDefaults.assistChipColors(
-                            containerColor = if (isSelected) {
-                                MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
-                            } else {
-                                MaterialTheme.colorScheme.surfaceVariant
-                            },
-                            labelColor = if (isSelected) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            }
-                        )
+                        label = "$preset%",
+                        showSelectedCheck = false
                     )
                 }
             }

--- a/app/src/main/java/com/webtoapp/ui/design/WtaControls.kt
+++ b/app/src/main/java/com/webtoapp/ui/design/WtaControls.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -187,7 +188,11 @@ fun WtaChip(
     enabled: Boolean = true,
     leadingIcon: ImageVector? = null,
     showSelectedCheck: Boolean = true,
-    onLongClick: (() -> Unit)? = null
+    onLongClick: (() -> Unit)? = null,
+    selectedContainerColor: Color? = null,
+    selectedContentColor: Color? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable RowScope.() -> Unit)? = null
 ) {
     WtaChip(
         selected = selected,
@@ -196,7 +201,11 @@ fun WtaChip(
         enabled = enabled,
         leadingIcon = leadingIcon,
         showSelectedCheck = showSelectedCheck,
-        onLongClick = onLongClick
+        onLongClick = onLongClick,
+        selectedContainerColor = selectedContainerColor,
+        selectedContentColor = selectedContentColor,
+        leadingContent = leadingContent,
+        trailingContent = trailingContent
     ) {
         Text(label, style = MaterialTheme.typography.labelLarge)
     }
@@ -212,6 +221,10 @@ fun WtaChip(
     leadingIcon: ImageVector? = null,
     showSelectedCheck: Boolean = true,
     onLongClick: (() -> Unit)? = null,
+    selectedContainerColor: Color? = null,
+    selectedContentColor: Color? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable RowScope.() -> Unit)? = null,
     label: @Composable () -> Unit
 ) {
     val colors = MaterialTheme.colorScheme
@@ -219,13 +232,14 @@ fun WtaChip(
     val hapticClick = rememberHapticClick(onClick)
 
     val containerColor by animateColorAsState(
-        targetValue = if (selected) colors.primary
+        targetValue = if (selected) selectedContainerColor ?: colors.primary
         else colors.surfaceContainerHigh,
         animationSpec = WtaMotion.standardTween(),
         label = "chipBg"
     )
     val contentColor by animateColorAsState(
-        targetValue = if (selected) colors.onPrimary else colors.onSurfaceVariant,
+        targetValue = if (selected) selectedContentColor ?: colors.onPrimary
+        else colors.onSurfaceVariant,
         animationSpec = WtaMotion.standardTween(),
         label = "chipContent"
     )
@@ -247,7 +261,10 @@ fun WtaChip(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center
         ) {
-            if (selected && showSelectedCheck) {
+            if (leadingContent != null) {
+                leadingContent()
+                Spacer(Modifier.width(6.dp))
+            } else if (selected && showSelectedCheck) {
                 Icon(
                     Icons.Default.Check,
                     contentDescription = null,
@@ -266,6 +283,10 @@ fun WtaChip(
             }
             CompositionLocalProvider(LocalContentColor provides contentColor) {
                 label()
+            }
+            if (trailingContent != null) {
+                Spacer(Modifier.width(4.dp))
+                trailingContent()
             }
         }
     }

--- a/app/src/main/java/com/webtoapp/ui/screens/AiSettingsScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AiSettingsScreen.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 import androidx.compose.foundation.BorderStroke
 import com.webtoapp.ui.components.PremiumButton
-import com.webtoapp.ui.components.PremiumFilterChip
+import com.webtoapp.ui.design.WtaChip
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.*
@@ -1027,14 +1027,14 @@ private fun AddModelDialog(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
 
-                                    PremiumFilterChip(
+                                    WtaChip(
                                         selected = isBatchMode,
                                         onClick = {
                                             isBatchMode = !isBatchMode
                                             if (!isBatchMode) selectedModels = emptySet()
                                         },
-                                        label = { Text(Strings.batchSelectModels, style = MaterialTheme.typography.labelSmall) },
-                                        modifier = Modifier.height(28.dp)
+                                        label = Strings.batchSelectModels,
+                                        showSelectedCheck = false
                                     )
                                 }
                             }
@@ -1154,14 +1154,15 @@ private fun AddModelDialog(
 
                             FlowRow(
                                 modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                             ) {
                                 ModelCapability.entries.forEach { capability ->
-                                    PremiumFilterChip(
+                                    WtaChip(
                                         selected = selectedCategory == capability,
                                         onClick = { selectedCategory = capability },
-                                        label = { Text(capability.displayName) }
+                                        label = capability.displayName,
+                                        showSelectedCheck = false
                                     )
                                 }
                             }
@@ -1312,14 +1313,15 @@ private fun EditModelDialog(
 
                     FlowRow(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
                         ModelCapability.entries.forEach { capability ->
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = selectedCategory == capability,
                                 onClick = { selectedCategory = capability },
-                                label = { Text(capability.displayName) }
+                                label = capability.displayName,
+                                showSelectedCheck = false
                             )
                         }
                     }

--- a/app/src/main/java/com/webtoapp/ui/screens/BatchImportDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/BatchImportDialog.kt
@@ -23,7 +23,8 @@ import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.UploadFile
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilterChip
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -125,23 +126,19 @@ fun BatchImportDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                 ) {
-                    FilterChip(
+                    WtaChip(
                         selected = tab == 0,
                         onClick = {
                             tab = 0
                             importResult = null
                             parseError = null
                         },
-                        label = {
-                            Text(
-                                Strings.batchImportFromText,
-                                style = MaterialTheme.typography.labelMedium
-                            )
-                        }
+                        label = Strings.batchImportFromText,
+                        showSelectedCheck = false
                     )
-                    FilterChip(
+                    WtaChip(
                         selected = tab == 1,
                         onClick = {
                             tab = 1
@@ -149,12 +146,8 @@ fun BatchImportDialog(
                             parseError = null
                             parseResult = BatchImportService.ParseResult(emptyList())
                         },
-                        label = {
-                            Text(
-                                Strings.batchImportFromBookmarks,
-                                style = MaterialTheme.typography.labelMedium
-                            )
-                        }
+                        label = Strings.batchImportFromBookmarks,
+                        showSelectedCheck = false
                     )
                 }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppAnnouncementCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppAnnouncementCard.kt
@@ -441,17 +441,19 @@ private fun AnnouncementTriggerSection(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = WtaSpacing.RowHorizontal),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
-                PremiumFilterChip(
+                WtaChip(
                     selected = announcement.showOnce,
                     onClick = { onAnnouncementChange(announcement.copy(showOnce = true)) },
-                    label = { Text(Strings.showOnce) }
+                    label = Strings.showOnce,
+                    showSelectedCheck = false
                 )
-                PremiumFilterChip(
+                WtaChip(
                     selected = !announcement.showOnce,
                     onClick = { onAnnouncementChange(announcement.copy(showOnce = false)) },
-                    label = { Text(Strings.everyLaunch) }
+                    label = Strings.everyLaunch,
+                    showSelectedCheck = false
                 )
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppApkSection.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppApkSection.kt
@@ -1,6 +1,5 @@
 package com.webtoapp.ui.screens
 
-import com.webtoapp.ui.components.PremiumFilterChip
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -196,11 +195,12 @@ fun ApkExportSection(
                     ) {
                         ApkArchitecture.entries.forEach { arch ->
                             val isSelected = config.architecture == arch
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = isSelected,
                                 onClick = { onConfigChange(config.copy(architecture = arch)) },
-                                label = { Text(arch.displayName) },
+                                label = arch.displayName,
                                 modifier = Modifier.weight(1f),
+                                showSelectedCheck = false
                             )
                         }
                     }
@@ -1289,12 +1289,13 @@ private fun CreateKeystoreDialog(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
                     listOf(2048, 4096).forEach { size ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = keySize == size,
                             onClick = { keySize = size },
-                            label = { Text("$size") }
+                            label = "$size",
+                            showSelectedCheck = false
                         )
                     }
                 }
@@ -1442,10 +1443,11 @@ private fun TargetSdkOverrideSection(
                     horizontalArrangement = Arrangement.spacedBy(WtaSpacing.ContentGap)
                 ) {
                     TARGET_SDK_OVERRIDE_CHOICES.forEach { value ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = config.targetSdk == value,
                             onClick = { onConfigChange(config.copy(targetSdk = value)) },
-                            label = { Text(value.toString()) }
+                            label = value.toString(),
+                            showSelectedCheck = false
                         )
                     }
                 }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppSplashCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppSplashCard.kt
@@ -1,7 +1,6 @@
 package com.webtoapp.ui.screens
 
 import android.net.Uri
-import com.webtoapp.ui.components.PremiumOutlinedButton
 import androidx.compose.animation.AnimatedVisibility
 import com.webtoapp.ui.animation.CardExpandTransition
 import com.webtoapp.ui.animation.CardCollapseTransition
@@ -235,84 +234,103 @@ fun SplashScreenCard(
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                 ) {
-                    PremiumOutlinedButton(
+                    WtaButton(
                         onClick = onSelectImage,
+                        variant = WtaButtonVariant.Outlined,
                         modifier = Modifier.weight(weight = 1f, fill = true)
                     ) {
-                        Icon(Icons.Outlined.Image, null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(Icons.Outlined.Image, null, modifier = Modifier.size(WtaSize.IconSmall))
+                        Spacer(modifier = Modifier.width(WtaSpacing.Tiny))
                         Text(Strings.selectImage)
                     }
-                    PremiumOutlinedButton(
+                    WtaButton(
                         onClick = onSelectVideo,
+                        variant = WtaButtonVariant.Outlined,
                         modifier = Modifier.weight(weight = 1f, fill = true)
                     ) {
-                        Icon(Icons.Outlined.VideoFile, null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(Icons.Outlined.VideoFile, null, modifier = Modifier.size(WtaSize.IconSmall))
+                        Spacer(modifier = Modifier.width(WtaSpacing.Tiny))
                         Text(Strings.selectVideo)
                     }
                 }
 
-                if (splashMediaUri != null && mediaExists) {
-
-                    if (splashConfig.type == SplashType.IMAGE) {
-                        WtaSliderRow(
-                            title = Strings.displayDuration,
-                            subtitle = Strings.displayDurationSeconds.replace("%d", splashConfig.duration.toString()),
-                            value = splashConfig.duration.toFloat(),
-                            onValueChange = { onDurationChange(it.toInt()) },
-                            valueLabel = "${splashConfig.duration}s",
-                            valueRange = 1f..5f
-                        )
-                    }
-
-                    WtaToggleRow(
-                        title = Strings.allowSkip,
-                        subtitle = Strings.allowSkipHint,
-                        icon = Icons.Outlined.TouchApp,
-                        checked = splashConfig.clickToSkip,
-                        onCheckedChange = onClickToSkipChange
-                    )
-
-                    WtaToggleRow(
-                        title = Strings.splashShowCountdownLabel,
-                        subtitle = Strings.splashShowCountdownHint,
-                        icon = Icons.Outlined.Timer,
-                        checked = splashConfig.showCountdown,
-                        onCheckedChange = onShowCountdownChange
-                    )
-
-                    WtaToggleRow(
-                        title = Strings.landscapeDisplay,
-                        subtitle = Strings.landscapeDisplayHint,
-                        icon = Icons.Outlined.ScreenRotation,
-                        checked = splashConfig.orientation == SplashOrientation.LANDSCAPE,
-                        onCheckedChange = { isLandscape ->
-                            onOrientationChange(
-                                if (isLandscape) SplashOrientation.LANDSCAPE
-                                else SplashOrientation.PORTRAIT
-                            )
+                AnimatedVisibility(
+                    visible = splashMediaUri != null && mediaExists,
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
+                    Column {
+                        AnimatedVisibility(
+                            visible = splashConfig.type == SplashType.IMAGE,
+                            enter = CardExpandTransition,
+                            exit = CardCollapseTransition
+                        ) {
+                            Column {
+                                WtaSliderRow(
+                                    title = Strings.displayDuration,
+                                    subtitle = Strings.displayDurationSeconds.replace("%d", splashConfig.duration.toString()),
+                                    value = splashConfig.duration.toFloat(),
+                                    onValueChange = { onDurationChange(it.toInt()) },
+                                    valueLabel = "${splashConfig.duration}s",
+                                    valueRange = 1f..5f
+                                )
+                            }
                         }
-                    )
 
-                    WtaToggleRow(
-                        title = Strings.fillScreen,
-                        subtitle = Strings.fillScreenHint,
-                        icon = Icons.Outlined.AspectRatio,
-                        checked = splashConfig.fillScreen,
-                        onCheckedChange = onFillScreenChange
-                    )
-
-                    if (splashConfig.type == SplashType.VIDEO) {
                         WtaToggleRow(
-                            title = Strings.enableAudio,
-                            subtitle = Strings.enableAudioHint,
-                            icon = Icons.AutoMirrored.Outlined.VolumeUp,
-                            checked = splashConfig.enableAudio,
-                            onCheckedChange = onEnableAudioChange
+                            title = Strings.allowSkip,
+                            subtitle = Strings.allowSkipHint,
+                            icon = Icons.Outlined.TouchApp,
+                            checked = splashConfig.clickToSkip,
+                            onCheckedChange = onClickToSkipChange
                         )
+
+                        WtaToggleRow(
+                            title = Strings.splashShowCountdownLabel,
+                            subtitle = Strings.splashShowCountdownHint,
+                            icon = Icons.Outlined.Timer,
+                            checked = splashConfig.showCountdown,
+                            onCheckedChange = onShowCountdownChange
+                        )
+
+                        WtaToggleRow(
+                            title = Strings.landscapeDisplay,
+                            subtitle = Strings.landscapeDisplayHint,
+                            icon = Icons.Outlined.ScreenRotation,
+                            checked = splashConfig.orientation == SplashOrientation.LANDSCAPE,
+                            onCheckedChange = { isLandscape ->
+                                onOrientationChange(
+                                    if (isLandscape) SplashOrientation.LANDSCAPE
+                                    else SplashOrientation.PORTRAIT
+                                )
+                            }
+                        )
+
+                        WtaToggleRow(
+                            title = Strings.fillScreen,
+                            subtitle = Strings.fillScreenHint,
+                            icon = Icons.Outlined.AspectRatio,
+                            checked = splashConfig.fillScreen,
+                            onCheckedChange = onFillScreenChange
+                        )
+
+                        AnimatedVisibility(
+                            visible = splashConfig.type == SplashType.VIDEO,
+                            enter = CardExpandTransition,
+                            exit = CardCollapseTransition
+                        ) {
+                            Column {
+                                WtaToggleRow(
+                                    title = Strings.enableAudio,
+                                    subtitle = Strings.enableAudioHint,
+                                    icon = Icons.AutoMirrored.Outlined.VolumeUp,
+                                    checked = splashConfig.enableAudio,
+                                    onCheckedChange = onEnableAudioChange
+                                )
+                            }
+                        }
                     }
                 }
               }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -112,19 +112,12 @@ fun LongPressMenuCard(
                     ) {
                         styleOptions.forEach { option ->
                             val isSelected = option.style == style
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = isSelected,
                                 onClick = { onStyleChange(option.style) },
-                                label = { Text(option.name) },
-                                leadingIcon = {
-                                    Icon(
-                                        option.icon,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(18.dp),
-                                        tint = if (isSelected) option.accentColor
-                                               else MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
+                                label = option.name,
+                                leadingIcon = option.icon,
+                                showSelectedCheck = false
                             )
                         }
                     }
@@ -518,8 +511,8 @@ fun AdBlockCard(
 
             AnimatedVisibility(
                 visible = enabled,
-                enter = expandVertically() + fadeIn(),
-                exit = shrinkVertically() + fadeOut()
+                enter = CardExpandTransition,
+                exit = CardCollapseTransition
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
                     if (validSubscriptions.isEmpty()) {
@@ -568,7 +561,7 @@ fun AdBlockCard(
                             Text(
                                 text = Strings.adBlockEnabledSourcesLabel,
                                 style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                color = MaterialTheme.colorScheme.primary
                             )
                             IconButton(
                                 onClick = {
@@ -627,15 +620,13 @@ fun AdBlockCard(
                     }
 
                     if (downloadedSources.isNotEmpty()) {
-                        com.webtoapp.ui.components.PremiumButton(
+                        WtaButton(
                             onClick = { showSubscriptionDialog = true },
+                            leadingIcon = Icons.Outlined.Add,
+                            text = if (validSubscriptions.isEmpty()) Strings.adBlockSelectSubscriptions
+                                else Strings.adBlockAddMoreSources,
                             modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Icon(Icons.Outlined.Add, null, Modifier.size(18.dp))
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(if (validSubscriptions.isEmpty()) Strings.adBlockSelectSubscriptions
-                                else Strings.adBlockAddMoreSources)
-                        }
+                        )
                     }
 
                     com.webtoapp.ui.design.WtaDivider()
@@ -858,7 +849,7 @@ private fun CustomRulesSection(
             Text(
                 text = Strings.customBlockRules,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.primary
             )
             if (rulesCount > 0) {
                 WtaBadge(
@@ -1149,15 +1140,17 @@ fun BrowserAdvancedConfigCard(
                                     ),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
-                                FilterChip(
+                                WtaChip(
                                     selected = config.backButtonBehavior == "GO_BACK",
                                     onClick = { onConfigChange(config.copy(backButtonBehavior = "GO_BACK")) },
-                                    label = { Text(Strings.backButtonGoBack) }
+                                    label = Strings.backButtonGoBack,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = config.backButtonBehavior == "EXIT",
                                     onClick = { onConfigChange(config.copy(backButtonBehavior = "EXIT")) },
-                                    label = { Text(Strings.backButtonExitApp) }
+                                    label = Strings.backButtonExitApp,
+                                    showSelectedCheck = false
                                 )
                             }
                         }
@@ -1197,10 +1190,11 @@ fun BrowserAdvancedConfigCard(
                                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                                     ) {
                                         listOf(30, 60, 120, 300).forEach { sec ->
-                                            FilterChip(
+                                            WtaChip(
                                                 selected = config.autoRefreshIntervalSec == sec,
                                                 onClick = { onConfigChange(config.copy(autoRefreshIntervalSec = sec)) },
-                                                label = { Text(Strings.autoRefreshIntervalValue(sec)) }
+                                                label = Strings.autoRefreshIntervalValue(sec),
+                                                showSelectedCheck = false
                                             )
                                         }
                                     }
@@ -1398,17 +1392,11 @@ fun BrowserAdvancedConfigCard(
                                         "PAC" to Strings.proxyModePac
                                     )
                                     proxyModes.forEach { (mode, label) ->
-                                        FilterChip(
+                                        WtaChip(
                                             selected = config.proxyMode == mode,
                                             onClick = { onConfigChange(config.copy(proxyMode = mode)) },
-                                            label = { Text(label, style = MaterialTheme.typography.bodySmall) },
-                                            leadingIcon = if (config.proxyMode == mode) {{
-                                                Icon(
-                                                    Icons.Filled.Check,
-                                                    contentDescription = null,
-                                                    modifier = Modifier.size(16.dp)
-                                                )
-                                            }} else null
+                                            label = label,
+                                            showSelectedCheck = false
                                         )
                                     }
                                 }
@@ -1438,10 +1426,11 @@ fun BrowserAdvancedConfigCard(
                                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                                     ) {
                                         listOf("HTTP", "HTTPS", "SOCKS5").forEach { type ->
-                                            FilterChip(
+                                            WtaChip(
                                                 selected = config.proxyType == type,
                                                 onClick = { onConfigChange(config.copy(proxyType = type)) },
-                                                label = { Text(type, style = MaterialTheme.typography.bodySmall) }
+                                                label = type,
+                                                showSelectedCheck = false
                                             )
                                         }
                                     }
@@ -1705,17 +1694,11 @@ fun BrowserAdvancedConfigCard(
                                             "CUSTOM" to "Custom"
                                         )
                                         templates.forEach { (id, label) ->
-                                            FilterChip(
+                                            WtaChip(
                                                 selected = config.tlsFingerprintTemplate == id,
                                                 onClick = { onConfigChange(config.copy(tlsFingerprintTemplate = id)) },
-                                                label = { Text(label, style = MaterialTheme.typography.bodySmall) },
-                                                leadingIcon = if (config.tlsFingerprintTemplate == id) {{
-                                                    Icon(
-                                                        Icons.Filled.Check,
-                                                        contentDescription = null,
-                                                        modifier = Modifier.size(16.dp)
-                                                    )
-                                                }} else null
+                                                label = label,
+                                                showSelectedCheck = false
                                             )
                                         }
                                     }
@@ -1923,12 +1906,17 @@ private fun ViewportModeSelector(
         enter = CardExpandTransition,
         exit = CardCollapseTransition
     ) {
-        Column(modifier = Modifier.padding(start = 8.dp, top = 4.dp, bottom = 4.dp)) {
+        Column(
+            modifier = Modifier.padding(
+                horizontal = WtaSpacing.RowHorizontal,
+                vertical = WtaSpacing.ContentGap
+            ),
+            verticalArrangement = Arrangement.spacedBy(WtaSpacing.ContentGap)
+        ) {
             Text(
                 text = Strings.viewportModeDescription,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(bottom = 12.dp)
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
             val viewportOptions = listOf(
@@ -1940,106 +1928,69 @@ private fun ViewportModeSelector(
 
             FlowRow(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
                 viewportOptions.forEach { (mode, pair) ->
                     val (label, icon) = pair
                     val selected = config.viewportMode == mode
-                    FilterChip(
+                    WtaChip(
                         selected = selected,
                         onClick = { onConfigChange(config.copy(viewportMode = mode)) },
-                        label = {
-                            Text(
-                                text = label,
-                                style = MaterialTheme.typography.labelMedium,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        },
-                        leadingIcon = if (selected) {
-                            {
-                                Icon(
-                                    icon,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                            }
-                        } else null,
-                        colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                            selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer
-                        )
+                        label = label,
+                        leadingIcon = if (selected) icon else null,
+                        showSelectedCheck = false
                     )
                 }
             }
 
-            if (config.viewportMode == ViewportMode.CUSTOM) {
-                Spacer(modifier = Modifier.height(12.dp))
+            AnimatedVisibility(
+                visible = config.viewportMode == ViewportMode.CUSTOM,
+                enter = CardExpandTransition,
+                exit = CardCollapseTransition
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.ContentGap)) {
+                    Text(
+                        text = Strings.viewportCustomWidthPresets,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
 
-                Text(
-                    text = Strings.viewportCustomWidthPresets,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(bottom = 6.dp)
-                )
+                    val presets = listOf(
+                        320 to "Mobile S",
+                        375 to "Mobile",
+                        414 to "Mobile L",
+                        768 to "Tablet",
+                        1024 to "iPad Pro",
+                        1280 to "Laptop",
+                        1920 to "Desktop"
+                    )
+                    val currentWidth = config.customViewportWidth.coerceIn(0, 3840)
+                    val displayWidth = if (currentWidth == 0) 0 else currentWidth
 
-                val presets = listOf(
-                    320 to "Mobile S",
-                    375 to "Mobile",
-                    414 to "Mobile L",
-                    768 to "Tablet",
-                    1024 to "iPad Pro",
-                    1280 to "Laptop",
-                    1920 to "Desktop"
-                )
-                val currentWidth = config.customViewportWidth.coerceIn(0, 3840)
-                val displayWidth = if (currentWidth == 0) 0 else currentWidth
-
-                FlowRow(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalArrangement = Arrangement.spacedBy(6.dp)
-                ) {
-                    presets.forEach { (px, label) ->
-                        val isSelected = displayWidth == px
-                        SuggestionChip(
-                            onClick = {
-                                onConfigChange(config.copy(customViewportWidth = px))
-                            },
-                            label = {
-                                Text(
-                                    text = "$label ($px)",
-                                    style = MaterialTheme.typography.labelSmall
-                                )
-                            },
-                            modifier = Modifier.height(28.dp),
-                            colors = SuggestionChipDefaults.suggestionChipColors(
-                                containerColor = if (isSelected)
-                                    MaterialTheme.colorScheme.primaryContainer
-                                else
-                                    MaterialTheme.colorScheme.surfaceVariant,
-                                labelColor = if (isSelected)
-                                    MaterialTheme.colorScheme.onPrimaryContainer
-                                else
-                                    MaterialTheme.colorScheme.onSurfaceVariant
-                            ),
-                            border = if (isSelected) BorderStroke(
-                                1.dp,
-                                MaterialTheme.colorScheme.primary
-                            ) else null
-                        )
+                    FlowRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny),
+                        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)
+                    ) {
+                        presets.forEach { (px, label) ->
+                            val isSelected = displayWidth == px
+                            WtaChip(
+                                selected = isSelected,
+                                onClick = {
+                                    onConfigChange(config.copy(customViewportWidth = px))
+                                },
+                                label = "$label ($px)",
+                                showSelectedCheck = false
+                            )
+                        }
                     }
-                }
 
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+                    ) {
                     OutlinedTextField(
                         value = if (displayWidth == 0) "" else displayWidth.toString(),
                         onValueChange = { input ->
@@ -2073,6 +2024,7 @@ private fun ViewportModeSelector(
     }
 }
 
+}
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun UserAgentCard(
@@ -2082,186 +2034,126 @@ fun UserAgentCard(
     var expanded by remember { mutableStateOf(false) }
     val isEnabled = config.userAgentMode != UserAgentMode.DEFAULT
 
-    EnhancedElevatedCard(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { expanded = !expanded },
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+    WtaSettingCard {
+        Column {
+            WtaChoiceRow(
+                title = Strings.userAgentMode,
+                subtitle = if (isEnabled) config.userAgentMode.displayName else Strings.userAgentDefault,
+                icon = Icons.Outlined.Language,
+                value = "",
+                isExpanded = expanded,
+                onClick = { expanded = !expanded }
+            )
+
+            AnimatedVisibility(
+                visible = expanded,
+                enter = CardExpandTransition,
+                exit = CardCollapseTransition
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(
-                                if (isEnabled) MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
-                                else MaterialTheme.colorScheme.surfaceVariant
-                            ),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            Icons.Outlined.Language,
-                            null,
-                            tint = if (isEnabled) MaterialTheme.colorScheme.primary
-                                   else MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(22.dp)
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column {
-                        Text(
-                            text = Strings.userAgentMode,
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = if (isEnabled) config.userAgentMode.displayName else Strings.userAgentDefault,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-                Icon(
-                    if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
-                    contentDescription = null
-                )
-            }
-
-            AnimatedVisibility(visible = expanded) {
-                Column(modifier = Modifier.padding(top = 12.dp)) {
-                Surface(
-                    color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
-                    shape = RoundedCornerShape(8.dp)
+                Column(
+                    modifier = Modifier.padding(
+                        horizontal = WtaSpacing.RowHorizontal,
+                        vertical = WtaSpacing.ContentGap
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap)
                 ) {
-                    Row(
-                        modifier = Modifier.padding(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            Icons.Outlined.Info,
-                            null,
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = Strings.bypassWebViewDetection,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSecondaryContainer
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                Text(
-                    text = Strings.mobileVersion,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-
-                FlowRow(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    listOf(
-                        UserAgentMode.DEFAULT to Strings.userAgentDefault,
-                        UserAgentMode.CHROME_MOBILE to "Chrome",
-                        UserAgentMode.SAFARI_MOBILE to "Safari",
-                        UserAgentMode.FIREFOX_MOBILE to "Firefox",
-                        UserAgentMode.EDGE_MOBILE to "Edge"
-                    ).forEach { (mode, name) ->
-                        PremiumFilterChip(
-                            selected = config.userAgentMode == mode,
-                            onClick = { onConfigChange(config.copy(userAgentMode = mode)) },
-                            label = { Text(name) },
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                Text(
-                    text = Strings.desktopVersion,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.tertiary
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-
-                FlowRow(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    listOf(
-                        UserAgentMode.CHROME_DESKTOP to "Chrome",
-                        UserAgentMode.SAFARI_DESKTOP to "Safari",
-                        UserAgentMode.FIREFOX_DESKTOP to "Firefox",
-                        UserAgentMode.EDGE_DESKTOP to "Edge"
-                    ).forEach { (mode, name) ->
-                        PremiumFilterChip(
-                            selected = config.userAgentMode == mode,
-                            onClick = { onConfigChange(config.copy(userAgentMode = mode)) },
-                            label = { Text(name) },
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                PremiumFilterChip(
-                    selected = config.userAgentMode == UserAgentMode.CUSTOM,
-                    onClick = { onConfigChange(config.copy(userAgentMode = UserAgentMode.CUSTOM)) },
-                    label = { Text(Strings.userAgentCustom) },
-                    leadingIcon = {
-                        Icon(
-                            Icons.Outlined.Edit,
-                            null,
-                            modifier = Modifier.size(16.dp)
-                        )
-                    },
-                )
-
-                if (config.userAgentMode == UserAgentMode.CUSTOM) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    PremiumTextField(
-                        value = config.customUserAgent ?: "",
-                        onValueChange = { onConfigChange(config.copy(customUserAgent = it.ifBlank { null })) },
-                        label = { Text("User-Agent") },
-                        placeholder = { Text(Strings.userAgentCustomHint) },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = false,
-                        minLines = 2,
-                        maxLines = 4
+                    WtaStatusBanner(
+                        message = Strings.bypassWebViewDetection,
+                        tone = WtaStatusTone.Info
                     )
-                }
 
-                    if (config.userAgentMode != UserAgentMode.DEFAULT && config.userAgentMode != UserAgentMode.CUSTOM) {
-                        Spacer(modifier = Modifier.height(12.dp))
-                        Surface(
-                            color = MaterialTheme.colorScheme.surfaceVariant,
-                            shape = RoundedCornerShape(8.dp)
+                    Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+                        Text(
+                            text = Strings.mobileVersion,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                            verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                         ) {
-                            Column(modifier = Modifier.padding(12.dp)) {
-                                Text(
-                                    text = Strings.currentUserAgent,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                                Spacer(modifier = Modifier.height(4.dp))
-                                Text(
-                                    text = config.userAgentMode.userAgentString ?: "",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                    maxLines = 3,
-                                    overflow = TextOverflow.Ellipsis
+                            listOf(
+                                UserAgentMode.DEFAULT to Strings.userAgentDefault,
+                                UserAgentMode.CHROME_MOBILE to "Chrome",
+                                UserAgentMode.SAFARI_MOBILE to "Safari",
+                                UserAgentMode.FIREFOX_MOBILE to "Firefox",
+                                UserAgentMode.EDGE_MOBILE to "Edge"
+                            ).forEach { (mode, name) ->
+                                WtaChip(
+                                    selected = config.userAgentMode == mode,
+                                    onClick = { onConfigChange(config.copy(userAgentMode = mode)) },
+                                    label = name,
+                                    showSelectedCheck = false
                                 )
                             }
                         }
+                    }
+
+                    Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+                        Text(
+                            text = Strings.desktopVersion,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                            verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+                        ) {
+                            listOf(
+                                UserAgentMode.CHROME_DESKTOP to "Chrome",
+                                UserAgentMode.SAFARI_DESKTOP to "Safari",
+                                UserAgentMode.FIREFOX_DESKTOP to "Firefox",
+                                UserAgentMode.EDGE_DESKTOP to "Edge"
+                            ).forEach { (mode, name) ->
+                                WtaChip(
+                                    selected = config.userAgentMode == mode,
+                                    onClick = { onConfigChange(config.copy(userAgentMode = mode)) },
+                                    label = name,
+                                    showSelectedCheck = false
+                                )
+                            }
+                        }
+                    }
+
+                    WtaChip(
+                        selected = config.userAgentMode == UserAgentMode.CUSTOM,
+                        onClick = { onConfigChange(config.copy(userAgentMode = UserAgentMode.CUSTOM)) },
+                        label = Strings.userAgentCustom,
+                        leadingIcon = Icons.Outlined.Edit,
+                        showSelectedCheck = false
+                    )
+
+                    AnimatedVisibility(
+                        visible = config.userAgentMode == UserAgentMode.CUSTOM,
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
+                    ) {
+                        PremiumTextField(
+                            value = config.customUserAgent ?: "",
+                            onValueChange = { onConfigChange(config.copy(customUserAgent = it.ifBlank { null })) },
+                            label = { Text("User-Agent") },
+                            placeholder = { Text(Strings.userAgentCustomHint) },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = false,
+                            minLines = 2,
+                            maxLines = 4
+                        )
+                    }
+
+                    AnimatedVisibility(
+                        visible = config.userAgentMode != UserAgentMode.DEFAULT && config.userAgentMode != UserAgentMode.CUSTOM,
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
+                    ) {
+                        WtaStatusBanner(
+                            title = Strings.currentUserAgent,
+                            message = config.userAgentMode.userAgentString ?: "",
+                            tone = WtaStatusTone.Info
+                        )
                     }
                 }
             }
@@ -2367,6 +2259,7 @@ fun FullscreenModeCard(
     onWebViewConfigChange: (WebViewConfig) -> Unit = {}
 ) {
     var statusBarConfigExpanded by remember { mutableStateOf(false) }
+    var statusBarModeTab by remember { mutableStateOf(0) }
 
     WtaSettingCard {
         WtaToggleRow(
@@ -2411,73 +2304,83 @@ fun FullscreenModeCard(
                     valueRange = 0f..48f
                 )
 
-                if (showStatusBar) {
-                    WtaSectionDivider()
+                AnimatedVisibility(
+                    visible = showStatusBar,
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
+                    Column {
+                        WtaSectionDivider()
 
-                    WtaChoiceRow(
-                        title = Strings.statusBarStyleConfigLabel,
-                        icon = Icons.Outlined.Tune,
-                        value = if (statusBarConfigExpanded) Strings.collapse else Strings.expand,
-                        onClick = { statusBarConfigExpanded = !statusBarConfigExpanded }
-                    )
+                        WtaChoiceRow(
+                            title = Strings.statusBarStyleConfigLabel,
+                            icon = Icons.Outlined.Tune,
+                            value = if (statusBarConfigExpanded) Strings.collapse else Strings.expand,
+                            isExpanded = statusBarConfigExpanded,
+                            onClick = { statusBarConfigExpanded = !statusBarConfigExpanded }
+                        )
 
-                    AnimatedVisibility(
-                        visible = statusBarConfigExpanded,
-                        enter = CardExpandTransition,
-                        exit = CardCollapseTransition
-                    ) {
-                        Column {
-                            Spacer(modifier = Modifier.height(12.dp))
-
-                            var statusBarModeTab by remember { mutableStateOf(0) }
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .horizontalScroll(rememberScrollState()),
-                                horizontalArrangement = Arrangement.Center
+                        AnimatedVisibility(
+                            visible = statusBarConfigExpanded,
+                            enter = CardExpandTransition,
+                            exit = CardCollapseTransition
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(
+                                    horizontal = WtaSpacing.RowHorizontal,
+                                    vertical = WtaSpacing.ContentGap
+                                ),
+                                verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap)
                             ) {
-                                FilterChip(
-                                    selected = statusBarModeTab == 0,
-                                    onClick = { statusBarModeTab = 0 },
-                                    label = { Text(Strings.statusBarLightModeLabel) }
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                FilterChip(
-                                    selected = statusBarModeTab == 1,
-                                    onClick = { statusBarModeTab = 1 },
-                                    label = { Text(Strings.statusBarDarkModeLabel) }
-                                )
-                            }
-                            Spacer(modifier = Modifier.height(8.dp))
-                            if (statusBarModeTab == 0) {
-                                StatusBarConfigCard(
-                                    config = webViewConfig,
-                                    onConfigChange = onWebViewConfigChange
-                                )
-                            } else {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+                                ) {
+                                    WtaChip(
+                                        selected = statusBarModeTab == 0,
+                                        onClick = { statusBarModeTab = 0 },
+                                        label = Strings.statusBarLightModeLabel,
+                                        modifier = Modifier.weight(1f),
+                                        showSelectedCheck = false
+                                    )
+                                    WtaChip(
+                                        selected = statusBarModeTab == 1,
+                                        onClick = { statusBarModeTab = 1 },
+                                        label = Strings.statusBarDarkModeLabel,
+                                        modifier = Modifier.weight(1f),
+                                        showSelectedCheck = false
+                                    )
+                                }
+                                if (statusBarModeTab == 0) {
+                                    StatusBarConfigCard(
+                                        config = webViewConfig,
+                                        onConfigChange = onWebViewConfigChange
+                                    )
+                                } else {
 
-                                StatusBarConfigCard(
-                                    config = webViewConfig.copy(
-                                        statusBarColorMode = webViewConfig.statusBarColorModeDark,
-                                        statusBarColor = webViewConfig.statusBarColorDark,
-                                        statusBarDarkIcons = webViewConfig.statusBarDarkIconsDark,
-                                        statusBarBackgroundType = webViewConfig.statusBarBackgroundTypeDark,
-                                        statusBarBackgroundImage = webViewConfig.statusBarBackgroundImageDark,
-                                        statusBarBackgroundAlpha = webViewConfig.statusBarBackgroundAlphaDark
-                                    ),
-                                    onConfigChange = { newConfig ->
-                                        onWebViewConfigChange(
-                                            webViewConfig.copy(
-                                                statusBarColorModeDark = newConfig.statusBarColorMode,
-                                                statusBarColorDark = newConfig.statusBarColor,
-                                                statusBarDarkIconsDark = newConfig.statusBarDarkIcons ?: false,
-                                                statusBarBackgroundTypeDark = newConfig.statusBarBackgroundType,
-                                                statusBarBackgroundImageDark = newConfig.statusBarBackgroundImage,
-                                                statusBarBackgroundAlphaDark = newConfig.statusBarBackgroundAlpha
+                                    StatusBarConfigCard(
+                                        config = webViewConfig.copy(
+                                            statusBarColorMode = webViewConfig.statusBarColorModeDark,
+                                            statusBarColor = webViewConfig.statusBarColorDark,
+                                            statusBarDarkIcons = webViewConfig.statusBarDarkIconsDark,
+                                            statusBarBackgroundType = webViewConfig.statusBarBackgroundTypeDark,
+                                            statusBarBackgroundImage = webViewConfig.statusBarBackgroundImageDark,
+                                            statusBarBackgroundAlpha = webViewConfig.statusBarBackgroundAlphaDark
+                                        ),
+                                        onConfigChange = { newConfig ->
+                                            onWebViewConfigChange(
+                                                webViewConfig.copy(
+                                                    statusBarColorModeDark = newConfig.statusBarColorMode,
+                                                    statusBarColorDark = newConfig.statusBarColor,
+                                                    statusBarDarkIconsDark = newConfig.statusBarDarkIcons ?: false,
+                                                    statusBarBackgroundTypeDark = newConfig.statusBarBackgroundType,
+                                                    statusBarBackgroundImageDark = newConfig.statusBarBackgroundImage,
+                                                    statusBarBackgroundAlphaDark = newConfig.statusBarBackgroundAlpha
+                                                )
                                             )
-                                        )
-                                    }
-                                )
+                                        }
+                                    )
+                                }
                             }
                         }
                     }
@@ -2797,8 +2700,8 @@ fun KeepScreenOnCard(
 
                     AnimatedVisibility(
                         visible = screenAwakeMode == com.webtoapp.data.model.ScreenAwakeMode.TIMED,
-                        enter = fadeIn(animationSpec = tween(200)) + expandVertically(animationSpec = tween(300)),
-                        exit = fadeOut(animationSpec = tween(200)) + shrinkVertically(animationSpec = tween(300))
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
                     ) {
                         Column {
                             WtaSectionDivider()
@@ -2813,20 +2716,19 @@ fun KeepScreenOnCard(
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .horizontalScroll(rememberScrollState()),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    .horizontalScroll(rememberScrollState())
+                                    .padding(
+                                        horizontal = WtaSpacing.RowHorizontal,
+                                        vertical = WtaSpacing.ContentGap
+                                    ),
+                                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                             ) {
                                 listOf(10, 30, 60, 120).forEach { minutes ->
-                                    val isPresetSelected = screenAwakeTimeoutMinutes == minutes
-                                    FilterChip(
-                                        selected = isPresetSelected,
+                                    WtaChip(
+                                        selected = screenAwakeTimeoutMinutes == minutes,
                                         onClick = { onScreenAwakeTimeoutChange(minutes) },
-                                        label = {
-                                            Text(
-                                                text = Strings.screenAwakeTimeoutValue(minutes),
-                                                style = MaterialTheme.typography.labelSmall
-                                            )
-                                        }
+                                        label = Strings.screenAwakeTimeoutValue(minutes),
+                                        showSelectedCheck = false
                                     )
                                 }
                             }
@@ -2850,47 +2752,37 @@ fun KeepScreenOnCard(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .horizontalScroll(rememberScrollState()),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            .horizontalScroll(rememberScrollState())
+                            .padding(
+                                horizontal = WtaSpacing.RowHorizontal,
+                                vertical = WtaSpacing.ContentGap
+                            ),
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
                         val isAuto = screenBrightness < 0
-                        FilterChip(
+                        WtaChip(
                             selected = isAuto,
                             onClick = { onScreenBrightnessChange(-1) },
-                            label = { Text(Strings.screenBrightnessAuto) },
-                            leadingIcon = if (isAuto) {
-                                {
-                                    Icon(
-                                        Icons.Filled.CheckCircle,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp)
-                                    )
-                                }
-                            } else null
+                            label = Strings.screenBrightnessAuto,
+                            showSelectedCheck = false
                         )
-                        FilterChip(
+                        WtaChip(
                             selected = !isAuto,
                             onClick = { if (isAuto) onScreenBrightnessChange(80) },
-                            label = { Text(Strings.screenBrightnessManual) },
-                            leadingIcon = if (!isAuto) {
-                                {
-                                    Icon(
-                                        Icons.Filled.CheckCircle,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp)
-                                    )
-                                }
-                            } else null
+                            label = Strings.screenBrightnessManual,
+                            showSelectedCheck = false
                         )
                     }
 
                     AnimatedVisibility(
                         visible = screenBrightness >= 0,
-                        enter = fadeIn(animationSpec = tween(200)) + expandVertically(animationSpec = tween(300)),
-                        exit = fadeOut(animationSpec = tween(200)) + shrinkVertically(animationSpec = tween(300))
+                        enter = CardExpandTransition,
+                        exit = CardCollapseTransition
                     ) {
                         Row(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = WtaSpacing.RowHorizontal),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Icon(
@@ -2972,32 +2864,23 @@ fun KeyboardAdjustModeCard(
 
             FlowRow(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
                 modes.forEach { (m, label) ->
-                    PremiumFilterChip(
+                    WtaChip(
                         selected = mode == m,
                         onClick = { onModeChange(m) },
-                        label = { Text(label) }
+                        label = label,
+                        showSelectedCheck = false
                     )
                 }
             }
 
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    Icons.Outlined.Info,
-                    null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(16.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = hintText,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+            WtaStatusBanner(
+                message = hintText,
+                tone = WtaStatusTone.Info
+            )
         }
     }
 }
@@ -3033,21 +2916,19 @@ fun ErrorPageConfigCard(
                 modifier = Modifier.padding(
                     horizontal = WtaSpacing.RowHorizontal,
                     vertical = WtaSpacing.ContentGap
-                )
+                ),
+                verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap)
             ) {
                     Text(
                         text = Strings.errorPageSubtitle,
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(bottom = 4.dp)
+                        color = MaterialTheme.colorScheme.primary
                     )
-
-                    Spacer(modifier = Modifier.height(12.dp))
 
                     FlowRow(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
                         val modes = listOf(
                             com.webtoapp.core.errorpage.ErrorPageMode.BUILTIN_STYLE to Strings.errorPageModeBuiltIn,
@@ -3056,10 +2937,11 @@ fun ErrorPageConfigCard(
                             com.webtoapp.core.errorpage.ErrorPageMode.SUPPRESSED to Strings.errorPageModeSuppressed
                         )
                         modes.forEach { (mode, label) ->
-                            PremiumFilterChip(
+                            WtaChip(
                                 selected = config.mode == mode,
                                 onClick = { onConfigChange(config.copy(mode = mode)) },
-                                label = { Text(label) }
+                                label = label,
+                                showSelectedCheck = false
                             )
                         }
                     }
@@ -3069,21 +2951,17 @@ fun ErrorPageConfigCard(
                         enter = CardExpandTransition,
                         exit = CardCollapseTransition
                     ) {
-                        Column {
-                            Spacer(modifier = Modifier.height(12.dp))
-
+                        Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.ContentGap)) {
                             Text(
                                 text = Strings.errorPageStyleLabel,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary
                             )
-
-                            Spacer(modifier = Modifier.height(8.dp))
 
                             FlowRow(
                                 modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                             ) {
                                 val styles = listOf(
                                     com.webtoapp.core.errorpage.ErrorPageStyle.MATERIAL to Strings.errorPageStyleMaterial,
@@ -3094,15 +2972,14 @@ fun ErrorPageConfigCard(
                                     com.webtoapp.core.errorpage.ErrorPageStyle.NEON to Strings.errorPageStyleNeon
                                 )
                                 styles.forEach { (style, label) ->
-                                    PremiumFilterChip(
+                                    WtaChip(
                                         selected = config.builtInStyle == style,
                                         onClick = { onConfigChange(config.copy(builtInStyle = style)) },
-                                        label = { Text(label) }
+                                        label = label,
+                                        showSelectedCheck = false
                                     )
                                 }
                             }
-
-                            Spacer(modifier = Modifier.height(12.dp))
 
                             WtaToggleRow(
                                 title = Strings.errorPageMiniGameLabel,
@@ -3116,13 +2993,11 @@ fun ErrorPageConfigCard(
                                 enter = CardExpandTransition,
                                 exit = CardCollapseTransition
                             ) {
-                                Column {
-                                    Spacer(modifier = Modifier.height(8.dp))
-
+                                Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
                                     FlowRow(
                                         modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                                        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                                     ) {
                                         val games = listOf(
                                             com.webtoapp.core.errorpage.MiniGameType.RANDOM to Strings.errorPageGameRandom,
@@ -3132,10 +3007,11 @@ fun ErrorPageConfigCard(
                                             com.webtoapp.core.errorpage.MiniGameType.INK_ZEN to Strings.errorPageGameInkZen
                                         )
                                         games.forEach { (type, label) ->
-                                            PremiumFilterChip(
+                                            WtaChip(
                                                 selected = config.miniGameType == type,
                                                 onClick = { onConfigChange(config.copy(miniGameType = type)) },
-                                                label = { Text(label) }
+                                                label = label,
+                                                showSelectedCheck = false
                                             )
                                         }
                                     }
@@ -3149,13 +3025,10 @@ fun ErrorPageConfigCard(
                         enter = CardExpandTransition,
                         exit = CardCollapseTransition
                     ) {
-                        Column {
-                            Spacer(modifier = Modifier.height(12.dp))
-                            CustomHtmlEditorRow(
-                                customHtml = config.customHtml,
-                                onCustomHtmlChange = { onConfigChange(config.copy(customHtml = it)) }
-                            )
-                        }
+                        CustomHtmlEditorRow(
+                            customHtml = config.customHtml,
+                            onCustomHtmlChange = { onConfigChange(config.copy(customHtml = it)) }
+                        )
                     }
 
                     AnimatedVisibility(
@@ -3163,16 +3036,11 @@ fun ErrorPageConfigCard(
                         enter = CardExpandTransition,
                         exit = CardCollapseTransition
                     ) {
-                        Column {
-                            Spacer(modifier = Modifier.height(12.dp))
-                            CustomMediaPickerRow(
-                                customMediaPath = config.customMediaPath,
-                                onCustomMediaPathChange = { onConfigChange(config.copy(customMediaPath = it)) }
-                            )
-                        }
+                        CustomMediaPickerRow(
+                            customMediaPath = config.customMediaPath,
+                            onCustomMediaPathChange = { onConfigChange(config.copy(customMediaPath = it)) }
+                        )
                     }
-
-                    Spacer(modifier = Modifier.height(12.dp))
 
                     WtaToggleRow(
                         title = Strings.errorPageAutoRetryLabel,
@@ -3190,9 +3058,7 @@ fun ErrorPageConfigCard(
                         enter = CardExpandTransition,
                         exit = CardCollapseTransition
                     ) {
-                        Column {
-                            Spacer(modifier = Modifier.height(8.dp))
-
+                        Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)) {
                             Text(
                                 text = "${config.autoRetrySeconds}${Strings.seconds}",
                                 style = MaterialTheme.typography.labelLarge,
@@ -3205,11 +3071,7 @@ fun ErrorPageConfigCard(
                                     onConfigChange(config.copy(autoRetrySeconds = it.toInt()))
                                 },
                                 valueRange = 5f..60f,
-                                steps = 10,
-                                colors = SliderDefaults.colors(
-                                    thumbColor = MaterialTheme.colorScheme.primary,
-                                    activeTrackColor = MaterialTheme.colorScheme.primary
-                                )
+                                steps = 10
                             )
                         }
                     }
@@ -3575,114 +3437,133 @@ fun SpecialSettingsCard(
                             Text(
                                 text = Strings.nativeBridgeCapabilitiesTitle,
                                 style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                modifier = Modifier.padding(top = 4.dp, bottom = 4.dp)
+                                color = MaterialTheme.colorScheme.primary
                             )
 
                             FlowRow(
                                 modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                             ) {
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.clipboard,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(clipboard = !caps.clipboard))) },
-                                    label = { Text(Strings.nativeBridgeCapsClipboard) }
+                                    label = Strings.nativeBridgeCapsClipboard,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.vibration,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(vibration = !caps.vibration))) },
-                                    label = { Text(Strings.nativeBridgeCapsVibration) }
+                                    label = Strings.nativeBridgeCapsVibration,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.geolocation,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(geolocation = !caps.geolocation))) },
-                                    label = { Text(Strings.nativeBridgeCapsGeolocation) }
+                                    label = Strings.nativeBridgeCapsGeolocation,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.brightness,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(brightness = !caps.brightness))) },
-                                    label = { Text(Strings.nativeBridgeCapsBrightness) }
+                                    label = Strings.nativeBridgeCapsBrightness,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.notification,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(notification = !caps.notification))) },
-                                    label = { Text(Strings.nativeBridgeCapsNotification) }
+                                    label = Strings.nativeBridgeCapsNotification,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.notificationScheduled,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(notificationScheduled = !caps.notificationScheduled))) },
-                                    label = { Text(Strings.nativeBridgeCapsNotificationScheduled) }
+                                    label = Strings.nativeBridgeCapsNotificationScheduled,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.notificationPersistent,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(notificationPersistent = !caps.notificationPersistent))) },
-                                    label = { Text(Strings.nativeBridgeCapsNotificationPersistent) }
+                                    label = Strings.nativeBridgeCapsNotificationPersistent,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.download,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(download = !caps.download))) },
-                                    label = { Text(Strings.nativeBridgeCapsDownload) }
+                                    label = Strings.nativeBridgeCapsDownload,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.privateNetwork,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(privateNetwork = !caps.privateNetwork))) },
-                                    label = { Text(Strings.nativeBridgeCapsPrivateNetwork) }
+                                    label = Strings.nativeBridgeCapsPrivateNetwork,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.screenWake,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(screenWake = !caps.screenWake))) },
-                                    label = { Text(Strings.nativeBridgeCapsScreenWake) }
+                                    label = Strings.nativeBridgeCapsScreenWake,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.openExternal,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(openExternal = !caps.openExternal))) },
-                                    label = { Text(Strings.nativeBridgeCapsOpenExternal) }
+                                    label = Strings.nativeBridgeCapsOpenExternal,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.deviceInfo,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(deviceInfo = !caps.deviceInfo))) },
-                                    label = { Text(Strings.nativeBridgeCapsDeviceInfo) }
+                                    label = Strings.nativeBridgeCapsDeviceInfo,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.securityInfo,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(securityInfo = !caps.securityInfo))) },
-                                    label = { Text(Strings.nativeBridgeCapsSecurityInfo) }
+                                    label = Strings.nativeBridgeCapsSecurityInfo,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.networkInfo,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(networkInfo = !caps.networkInfo))) },
-                                    label = { Text(Strings.nativeBridgeCapsNetworkInfo) }
+                                    label = Strings.nativeBridgeCapsNetworkInfo,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.toast,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(toast = !caps.toast))) },
-                                    label = { Text(Strings.nativeBridgeCapsToast) }
+                                    label = Strings.nativeBridgeCapsToast,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.logging,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(logging = !caps.logging))) },
-                                    label = { Text(Strings.nativeBridgeCapsLogging) }
+                                    label = Strings.nativeBridgeCapsLogging,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.findInPage,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(findInPage = !caps.findInPage))) },
-                                    label = { Text(Strings.nativeBridgeCapsFindInPage) }
+                                    label = Strings.nativeBridgeCapsFindInPage,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.orientation,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(orientation = !caps.orientation))) },
-                                    label = { Text(Strings.nativeBridgeCapsOrientation) }
+                                    label = Strings.nativeBridgeCapsOrientation,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.fullscreen,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(fullscreen = !caps.fullscreen))) },
-                                    label = { Text(Strings.nativeBridgeCapsFullscreen) }
+                                    label = Strings.nativeBridgeCapsFullscreen,
+                                    showSelectedCheck = false
                                 )
-                                FilterChip(
+                                WtaChip(
                                     selected = caps.print,
                                     onClick = { onConfigChange(config.copy(nativeBridgeCapabilities = caps.copy(print = !caps.print))) },
-                                    label = { Text(Strings.nativeBridgeCapsPrint) }
+                                    label = Strings.nativeBridgeCapsPrint,
+                                    showSelectedCheck = false
                                 )
                             }
                         }
@@ -3958,12 +3839,10 @@ private fun SpecialAdvancedRow(
             ) {
                 Column(
                     modifier = Modifier.padding(
-                        start = WtaSpacing.RowHorizontal,
-                        end = WtaSpacing.RowHorizontal,
-                        top = 4.dp,
-                        bottom = 12.dp
+                        horizontal = WtaSpacing.RowHorizontal,
+                        vertical = WtaSpacing.ContentGap
                     ),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap),
                     content = content
                 )
             }
@@ -3979,22 +3858,23 @@ private fun <T> ChoiceChipRow(
     selected: T,
     onSelect: (T) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.primary
         )
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
+            horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
         ) {
             options.forEach { (value, text) ->
-                FilterChip(
+                WtaChip(
                     selected = selected == value,
                     onClick = { onSelect(value) },
-                    label = { Text(text) }
+                    label = text,
+                    showSelectedCheck = false
                 )
             }
         }
@@ -4043,8 +3923,7 @@ private fun FailoverAdvancedRow(
         Text(
             text = Strings.failoverUrlsLabel,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(top = 4.dp, bottom = 4.dp)
+            color = MaterialTheme.colorScheme.primary
         )
 
         com.webtoapp.ui.components.WtaReorderableUrlList(
@@ -4055,52 +3934,56 @@ private fun FailoverAdvancedRow(
             addButtonText = Strings.failoverAddUrl,
         )
 
-        Spacer(Modifier.height(12.dp))
-
         Text(
             text = Strings.failoverTriggersLabel,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(bottom = 4.dp)
+            color = MaterialTheme.colorScheme.primary
         )
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
+            horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
         ) {
             val triggers = config.failoverTriggers
-            FilterChip(
+            WtaChip(
                 selected = triggers.networkError,
                 onClick = {
                     onConfigChange(config.copy(failoverTriggers = triggers.copy(networkError = !triggers.networkError)))
                 },
-                label = { Text(Strings.failoverTriggerNetworkError) }
+                label = Strings.failoverTriggerNetworkError,
+                showSelectedCheck = false
             )
-            FilterChip(
+            WtaChip(
                 selected = triggers.http5xx,
                 onClick = {
                     onConfigChange(config.copy(failoverTriggers = triggers.copy(http5xx = !triggers.http5xx)))
                 },
-                label = { Text(Strings.failoverTriggerHttp5xx) }
+                label = Strings.failoverTriggerHttp5xx,
+                showSelectedCheck = false
             )
-            FilterChip(
+            WtaChip(
                 selected = triggers.http4xx,
                 onClick = {
                     onConfigChange(config.copy(failoverTriggers = triggers.copy(http4xx = !triggers.http4xx)))
                 },
-                label = { Text(Strings.failoverTriggerHttp4xx) }
+                label = Strings.failoverTriggerHttp4xx,
+                showSelectedCheck = false
             )
-            FilterChip(
+            WtaChip(
                 selected = triggers.timeout,
                 onClick = {
                     onConfigChange(config.copy(failoverTriggers = triggers.copy(timeout = !triggers.timeout)))
                 },
-                label = { Text(Strings.failoverTriggerTimeout) }
+                label = Strings.failoverTriggerTimeout,
+                showSelectedCheck = false
             )
         }
 
-        if (config.failoverTriggers.timeout) {
-            Spacer(Modifier.height(8.dp))
+        AnimatedVisibility(
+            visible = config.failoverTriggers.timeout,
+            enter = CardExpandTransition,
+            exit = CardCollapseTransition
+        ) {
             IntegerField(
                 label = Strings.failoverTimeoutSecondsLabel,
                 value = config.failoverTimeoutSeconds,

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateGoAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateGoAppScreen.kt
@@ -30,6 +30,8 @@ import com.webtoapp.core.golang.GoSampleManager
 import com.webtoapp.data.model.GoAppConfig
 import com.webtoapp.ui.components.TypedSampleProjectsCard
 import com.webtoapp.ui.components.*
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.screens.create.WtaCreateFlowScaffold
 import com.webtoapp.ui.screens.create.WtaCreateFlowSection
 import com.webtoapp.ui.screens.create.runtime.GoProjectSourceLoader
@@ -723,18 +725,16 @@ private fun GoTargetArchCard(
             Spacer(modifier = Modifier.height(12.dp))
 
             FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
                 architectures.forEach { (arch, label) ->
-                    PremiumFilterChip(
+                    WtaChip(
                         selected = targetArch == arch,
-                        onClick = { onArchChange(arch) },
-                        label = { Text(label, fontFamily = FontFamily.Monospace) },
-                        leadingIcon = if (targetArch == arch) {
-                            { Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp)) }
-                        } else null
-                    )
+                        onClick = { onArchChange(arch) }
+                    ) {
+                        Text(label, fontFamily = FontFamily.Monospace)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateHtmlAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateHtmlAppScreen.kt
@@ -1715,7 +1715,7 @@ private fun ZipImportSection(
                 Text(
                     text = Strings.zipResourceStats,
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.primary
                 )
                 Spacer(modifier = Modifier.height(8.dp))
 
@@ -2158,7 +2158,7 @@ private fun FolderImportSection(
                 Text(
                     text = Strings.zipResourceStats,
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.primary
                 )
                 Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateMediaAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateMediaAppScreen.kt
@@ -1,6 +1,8 @@
 package com.webtoapp.ui.screens
 
 import android.net.Uri
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaSwitch
 import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -690,22 +692,22 @@ private fun MediaPlaybackSpeedCard(
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
                 speeds.forEach { s ->
                     val isSelected = speed == s
-                    PremiumFilterChip(
+                    WtaChip(
                         selected = isSelected,
                         onClick = { onSpeedChange(s) },
-                        label = {
-                            Text(
-                                "${s}x",
-                                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                                fontFamily = FontFamily.Monospace
-                            )
-                        },
-                        modifier = Modifier.weight(weight = 1f, fill = true)
-                    )
+                        modifier = Modifier.weight(weight = 1f, fill = true),
+                        showSelectedCheck = false
+                    ) {
+                        Text(
+                            "${s}x",
+                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                            fontFamily = FontFamily.Monospace
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateMultiWebAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateMultiWebAppScreen.kt
@@ -29,6 +29,8 @@ import com.webtoapp.data.model.HtmlFileType
 import com.webtoapp.ui.components.EnhancedElevatedCard
 import com.webtoapp.ui.components.PremiumTextField
 import com.webtoapp.ui.components.RuntimeIconPickerCard
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.screens.create.WtaCreateFlowScaffold
 import com.webtoapp.ui.screens.create.WtaCreateFlowSection
 import java.util.UUID
@@ -348,62 +350,60 @@ private fun ExistingAppPicker(
 
         if (availableTypes.size > 1) {
             LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
                 modifier = Modifier.fillMaxWidth()
             ) {
                 item {
-                    FilterChip(
+                    WtaChip(
                         selected = filterType == null,
                         onClick = { onFilterTypeChange(null) },
-                        label = { Text(Strings.all, fontSize = 12.sp) }
+                        label = Strings.all,
+                        showSelectedCheck = false
                     )
                 }
                 items(availableTypes.size) { index ->
                     val type = availableTypes[index]
                     val (icon, label) = appTypeFilterInfo(type)
-                    FilterChip(
+                    WtaChip(
                         selected = filterType == type,
                         onClick = { onFilterTypeChange(if (filterType == type) null else type) },
-                        label = { Text(label, fontSize = 12.sp) },
-                        leadingIcon = { Icon(icon, null, modifier = Modifier.size(16.dp)) }
+                        label = label,
+                        leadingIcon = icon,
+                        showSelectedCheck = false
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(WtaSpacing.Tiny))
         }
 
         LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
             modifier = Modifier.fillMaxWidth()
         ) {
             item {
-                FilterChip(
+                WtaChip(
                     selected = filterCategoryId == null,
                     onClick = { onFilterCategoryChange(null) },
-                    label = { Text(Strings.allApps, fontSize = 12.sp) }
+                    label = Strings.allApps,
+                    showSelectedCheck = false
                 )
             }
             item {
-                FilterChip(
+                WtaChip(
                     selected = filterCategoryId == -1L,
                     onClick = { onFilterCategoryChange(-1L) },
-                    label = { Text(Strings.uncategorized, fontSize = 12.sp) }
+                    label = Strings.uncategorized,
+                    showSelectedCheck = false
                 )
             }
             items(categories.size) { index ->
                 val cat = categories[index]
-                FilterChip(
+                WtaChip(
                     selected = filterCategoryId == cat.id,
                     onClick = { onFilterCategoryChange(if (filterCategoryId == cat.id) null else cat.id) },
-                    label = { Text(cat.name, fontSize = 12.sp) },
-                    leadingIcon = {
-                        Icon(
-                            com.webtoapp.util.SvgIconMapper.getIcon(cat.icon),
-                            null,
-                            modifier = Modifier.size(16.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
+                    label = cat.name,
+                    leadingIcon = com.webtoapp.util.SvgIconMapper.getIcon(cat.icon),
+                    showSelectedCheck = false
                 )
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreatePhpAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreatePhpAppScreen.kt
@@ -36,6 +36,10 @@ import com.webtoapp.core.wordpress.WordPressDependencyManager
 import com.webtoapp.ui.components.TypedSampleProjectsCard
 import com.webtoapp.data.model.PhpAppConfig
 import com.webtoapp.ui.components.*
+import com.webtoapp.ui.animation.CardCollapseTransition
+import com.webtoapp.ui.animation.CardExpandTransition
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.screens.create.WtaCreateFlowScaffold
 import com.webtoapp.ui.screens.create.WtaCreateFlowSection
 import kotlinx.coroutines.Dispatchers
@@ -789,42 +793,39 @@ private fun PhpDocRootCard(
             Spacer(modifier = Modifier.height(12.dp))
 
             if (detectedWebDirs.isNotEmpty()) {
-                Text(Strings.phpDetectedDirs, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Spacer(modifier = Modifier.height(8.dp))
+                Text(Strings.phpDetectedDirs, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                Spacer(modifier = Modifier.height(WtaSpacing.Small))
                 FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                 ) {
-                    PremiumFilterChip(
+                    WtaChip(
                         selected = currentDocRoot.isBlank() && !useCustom,
                         onClick = { onSelectDir("") },
-                        label = { Text("/ (${Strings.phpProjectRoot})") },
-                        leadingIcon = if (currentDocRoot.isBlank() && !useCustom) {
-                            { Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp)) }
-                        } else null
+                        label = "/ (${Strings.phpProjectRoot})"
                     )
                     detectedWebDirs.forEach { dir ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = currentDocRoot == dir && !useCustom,
                             onClick = { onSelectDir(dir) },
-                            label = { Text("$dir/") },
-                            leadingIcon = if (currentDocRoot == dir && !useCustom) {
-                                { Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp)) }
-                            } else null
+                            label = "$dir/"
                         )
                     }
-                    PremiumFilterChip(
+                    WtaChip(
                         selected = useCustom,
                         onClick = { onToggleCustom(true) },
-                        label = { Text(Strings.phpCustomPath) },
-                        leadingIcon = if (useCustom) {
-                            { Icon(Icons.Default.Edit, null, modifier = Modifier.size(16.dp)) }
-                        } else null
+                        label = Strings.phpCustomPath,
+                        leadingIcon = Icons.Default.Edit,
+                        showSelectedCheck = false
                     )
                 }
             }
 
-            AnimatedVisibility(visible = useCustom || detectedWebDirs.isEmpty()) {
+            AnimatedVisibility(
+                visible = useCustom || detectedWebDirs.isEmpty(),
+                enter = CardExpandTransition,
+                exit = CardCollapseTransition
+            ) {
                 Column {
                     Spacer(modifier = Modifier.height(8.dp))
                     PremiumTextField(
@@ -875,18 +876,16 @@ private fun PhpExtensionsCard(
             Spacer(modifier = Modifier.height(12.dp))
 
             FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
                 extensions.forEach { (ext, enabled) ->
-                    PremiumFilterChip(
+                    WtaChip(
                         selected = enabled,
-                        onClick = { onToggle(ext, !enabled) },
-                        label = { Text(ext, fontFamily = FontFamily.Monospace) },
-                        leadingIcon = if (enabled) {
-                            { Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp)) }
-                        } else null
-                    )
+                        onClick = { onToggle(ext, !enabled) }
+                    ) {
+                        Text(ext, fontFamily = FontFamily.Monospace)
+                    }
                 }
             }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateWordPressAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateWordPressAppScreen.kt
@@ -1,5 +1,7 @@
 package com.webtoapp.ui.screens
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaSwitch
 import com.webtoapp.ui.components.PremiumButton
 import com.webtoapp.ui.components.PremiumOutlinedButton
@@ -728,7 +730,7 @@ private fun WpThemeCard(
                 Text(
                     Strings.wpInstalledThemes,
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.primary
                 )
                 Spacer(modifier = Modifier.height(6.dp))
 
@@ -976,15 +978,15 @@ private fun WpLanguageCard(
             Spacer(modifier = Modifier.height(12.dp))
 
             FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
             ) {
                 languages.forEach { (code, label) ->
-                    val isSelected = selected == code
-                    PremiumFilterChip(
-                        selected = isSelected,
+                    WtaChip(
+                        selected = selected == code,
                         onClick = { onSelect(code) },
-                        label = { Text(label, style = MaterialTheme.typography.bodySmall) }
+                        label = label,
+                        showSelectedCheck = false
                     )
                 }
             }

--- a/app/src/main/java/com/webtoapp/ui/screens/DeviceDisguiseCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/DeviceDisguiseCard.kt
@@ -16,10 +16,10 @@ import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.animation.CardExpandTransition
 import com.webtoapp.ui.animation.CardCollapseTransition
 import com.webtoapp.ui.design.WtaSettingCard
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaToggleRow
 import com.webtoapp.ui.design.WtaSectionDivider
 import com.webtoapp.ui.design.WtaSpacing
-import com.webtoapp.ui.components.PremiumFilterChip
 import com.webtoapp.ui.components.PremiumTextField
 import com.webtoapp.ui.components.SettingsSwitch
 
@@ -79,11 +79,11 @@ fun DeviceDisguiseCard(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = WtaSpacing.RowHorizontal),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                 ) {
                     deviceTypes.forEach { (type, label) ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = config.deviceType == type,
                             onClick = {
                                 val presets = DevicePresets.getPresetsForType(type)
@@ -93,7 +93,8 @@ fun DeviceDisguiseCard(
                                     onConfigChange(config.copy(deviceType = type))
                                 }
                             },
-                            label = { Text(label) }
+                            label = label,
+                            showSelectedCheck = false
                         )
                     }
                 }
@@ -104,7 +105,7 @@ fun DeviceDisguiseCard(
                 Text(
                     text = Strings.devicePopularPresets,
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.tertiary,
+                    color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.padding(
                         start = WtaSpacing.RowHorizontal,
                         top = WtaSpacing.ContentGap,
@@ -118,11 +119,11 @@ fun DeviceDisguiseCard(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = WtaSpacing.RowHorizontal),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                 ) {
                     presets.forEach { preset ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = config.deviceModel == preset.model &&
                                     config.deviceBrand == preset.brand,
                             onClick = {
@@ -130,7 +131,8 @@ fun DeviceDisguiseCard(
                                     deviceType = config.deviceType
                                 ))
                             },
-                            label = { Text(preset.name) }
+                            label = preset.name,
+                            showSelectedCheck = false
                         )
                     }
                 }
@@ -138,7 +140,11 @@ fun DeviceDisguiseCard(
                 Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
                 WtaSectionDivider()
 
-                if (config.deviceType !in listOf(DeviceType.DESKTOP, DeviceType.LAPTOP)) {
+                AnimatedVisibility(
+                    visible = config.deviceType !in listOf(DeviceType.DESKTOP, DeviceType.LAPTOP),
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
                     SettingsSwitch(
                         title = Strings.deviceDesktopViewport,
                         subtitle = Strings.deviceDesktopViewportHint,

--- a/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
@@ -1,7 +1,8 @@
 package com.webtoapp.ui.screens
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.webtoapp.ui.components.PremiumButton
-import com.webtoapp.ui.components.PremiumFilterChip
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 
 import android.Manifest
 import android.content.pm.PackageManager
@@ -1218,22 +1219,24 @@ private fun ExtensionModulesTabContent(
     Column(modifier = Modifier.fillMaxSize()) {
 
         LazyRow(
-            modifier = Modifier.padding(vertical = 8.dp),
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier.padding(vertical = WtaSpacing.Small),
+            contentPadding = PaddingValues(horizontal = WtaSpacing.ScreenHorizontal),
+            horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
         ) {
             item {
-                PremiumFilterChip(
+                WtaChip(
                     selected = selectedCategory == null,
                     onClick = { onCategoryChange(null) },
-                    label = { Text(Strings.all) }
+                    label = Strings.all,
+                    showSelectedCheck = false
                 )
             }
             items(ModuleCategory.values().toList()) { category ->
-                PremiumFilterChip(
+                WtaChip(
                     selected = selectedCategory == category,
                     onClick = { onCategoryChange(if (selectedCategory == category) null else category) },
-                    label = { Text(category.getDisplayName()) }
+                    label = category.getDisplayName(),
+                    showSelectedCheck = false
                 )
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/screens/ModelCatalogSection.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ModelCatalogSection.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -49,6 +48,7 @@ import com.webtoapp.data.model.AiModel
 import com.webtoapp.data.model.ApiKeyConfig
 import com.webtoapp.data.model.ModelCapability
 import com.webtoapp.data.model.SavedModel
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaSpacing
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -137,16 +137,18 @@ fun ModelCatalogSection(
                 .padding(horizontal = WtaSpacing.ScreenHorizontal, vertical = WtaSpacing.Small),
             horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
         ) {
-            FilterChip(
+            WtaChip(
                 selected = selectedProvider == null,
                 onClick = { selectedProvider = null },
-                label = { Text(Strings.aiCatalogAllProviders) }
+                label = Strings.aiCatalogAllProviders,
+                showSelectedCheck = false
             )
             providers.forEach { p ->
-                FilterChip(
+                WtaChip(
                     selected = selectedProvider == p.id,
                     onClick = { selectedProvider = if (selectedProvider == p.id) null else p.id },
-                    label = { Text(p.name) }
+                    label = p.name,
+                    showSelectedCheck = false
                 )
             }
         }
@@ -160,10 +162,11 @@ fun ModelCatalogSection(
             horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
         ) {
             CapabilityFilter.entries.forEach { f ->
-                FilterChip(
+                WtaChip(
                     selected = capabilityFilter == f,
                     onClick = { capabilityFilter = f },
-                    label = { Text(catalogCapabilityLabel(f)) }
+                    label = catalogCapabilityLabel(f),
+                    showSelectedCheck = false
                 )
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/screens/ModuleEditorScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ModuleEditorScreen.kt
@@ -2,7 +2,6 @@ package com.webtoapp.ui.screens
 
 import android.widget.Toast
 import com.webtoapp.ui.components.PremiumButton
-import com.webtoapp.ui.components.PremiumFilterChip
 import com.webtoapp.core.logging.AppLogger
 import androidx.compose.animation.*
 import androidx.compose.foundation.BorderStroke
@@ -48,6 +47,8 @@ import com.webtoapp.ui.design.WtaSection
 import com.webtoapp.ui.design.WtaSectionDivider
 import com.webtoapp.ui.design.WtaSettingCard
 import com.webtoapp.ui.design.WtaSettingRow
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaScreen
 import com.webtoapp.ui.design.WtaRadius
 import com.webtoapp.ui.design.WtaAlertDialog
@@ -1083,23 +1084,17 @@ private fun CodeTab(
             .padding(16.dp)
     ) {
 
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                PremiumFilterChip(
+        Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+                WtaChip(
                     selected = showJsTab,
                     onClick = { showJsTab = true },
-                    label = { Text("JavaScript") },
-                    leadingIcon = if (showJsTab) {
-                        { Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp)) }
-                    } else null
+                    label = "JavaScript"
                 )
-                PremiumFilterChip(
+                WtaChip(
                     selected = !showJsTab,
                     onClick = { showJsTab = false },
-                    label = { Text("CSS") },
-                    leadingIcon = if (!showJsTab) {
-                        { Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(18.dp)) }
-                    } else null
+                    label = "CSS"
                 )
             }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/ModuleMarketScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ModuleMarketScreen.kt
@@ -103,7 +103,6 @@ import com.webtoapp.core.market.ChromeWebStoreSearch
 import com.webtoapp.core.market.CwsSearchResult
 import com.webtoapp.core.market.CwsTags
 import com.webtoapp.core.extension.BrowserExtensionStore
-import com.webtoapp.ui.components.PremiumFilterChip
 import com.webtoapp.ui.components.PremiumTextField
 import com.webtoapp.ui.components.GreasyForkSearchContent
 import com.webtoapp.ui.components.installGreasyForkScript
@@ -113,6 +112,7 @@ import com.webtoapp.ui.design.WtaButtonSize
 import com.webtoapp.ui.design.WtaButtonVariant
 import com.webtoapp.ui.design.WtaCard
 import com.webtoapp.ui.design.WtaCardTone
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaRadius
 import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.design.WtaTab
@@ -433,19 +433,21 @@ fun ModuleMarketScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     item {
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = selectedCategory == null,
                             onClick = { selectedCategory = null },
-                            label = { Text(Strings.moduleMarketAll) }
+                            label = Strings.moduleMarketAll,
+                            showSelectedCheck = false
                         )
                     }
                     items(MarketCategoryHighlights) { category ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = selectedCategory == category,
                             onClick = {
                                 selectedCategory = if (selectedCategory == category) null else category
                             },
-                            label = { Text(category.getDisplayName()) }
+                            label = category.getDisplayName(),
+                            showSelectedCheck = false
                         )
                     }
                 }
@@ -946,10 +948,11 @@ private fun CwsSearchContent(
                     contentPadding = PaddingValues(vertical = 4.dp)
                 ) {
                     items(BrowserExtensionStore.browseCategories(), key = { it.name }) { category ->
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = browseCategory == category,
                             onClick = { browseCategory = category },
-                            label = { Text(cwsCategoryLabel(category)) }
+                            label = cwsCategoryLabel(category),
+                            showSelectedCheck = false
                         )
                     }
                 }
@@ -1046,10 +1049,11 @@ private fun CwsSortRow(
             )
         }
         items(CwsSortMode.values().toList(), key = { it.name }) { mode ->
-            PremiumFilterChip(
+            WtaChip(
                 selected = sortMode == mode,
                 onClick = { onSortModeChange(mode) },
-                label = { Text(cwsSortLabel(mode)) }
+                label = cwsSortLabel(mode),
+                showSelectedCheck = false
             )
         }
     }

--- a/app/src/main/java/com/webtoapp/ui/screens/PermissionConfigScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/PermissionConfigScreen.kt
@@ -34,6 +34,7 @@ import com.webtoapp.ui.components.IconSwitchCard
 import com.webtoapp.ui.components.PremiumButton
 import com.webtoapp.ui.components.PremiumTextField
 import com.webtoapp.ui.design.WtaBackground
+import com.webtoapp.ui.design.WtaChip
 import com.webtoapp.ui.design.WtaSettingCard
 import com.webtoapp.ui.design.WtaSettingRow
 import com.webtoapp.ui.design.WtaSectionDivider
@@ -321,17 +322,12 @@ fun PermissionConfigPanel(
         ) {
             PERMISSION_PRESETS.forEach { preset ->
                 val selected = preset.match(permissions)
-                FilterChip(
+                WtaChip(
                     selected = selected,
                     onClick = { onPermissionsTransform { preset.apply(it) } },
-                    label = { Text(preset.label()) },
-                    leadingIcon = {
-                        Icon(
-                            preset.icon,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp)
-                        )
-                    }
+                    label = preset.label(),
+                    leadingIcon = preset.icon,
+                    showSelectedCheck = false
                 )
             }
         }
@@ -566,18 +562,13 @@ private fun PermissionSchemeCard(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     savedPresets.forEach { preset ->
-                        ElevatedFilterChip(
+                        WtaChip(
                             selected = false,
                             onClick = { onApplyScheme(preset) },
-                            label = { Text(preset.name) },
-                            leadingIcon = {
-                                Icon(
-                                    Icons.Outlined.Bolt,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                            },
-                            trailingIcon = {
+                            label = preset.name,
+                            leadingIcon = Icons.Outlined.Bolt,
+                            showSelectedCheck = false,
+                            trailingContent = {
                                 IconButton(
                                     onClick = { onDeleteScheme(preset) },
                                     modifier = Modifier.size(24.dp)

--- a/app/src/main/java/com/webtoapp/ui/screens/WordPressSettingsScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/WordPressSettingsScreen.kt
@@ -2,7 +2,8 @@ package com.webtoapp.ui.screens
 
 import androidx.compose.foundation.background
 import com.webtoapp.ui.components.PremiumOutlinedButton
-import com.webtoapp.ui.components.PremiumFilterChip
+import com.webtoapp.ui.design.WtaChip
+import com.webtoapp.ui.design.WtaSpacing
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -154,38 +155,33 @@ fun WordPressSettingsScreen(
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = mirrorRegion == WordPressDependencyManager.MirrorRegion.CN,
                             onClick = {
                                 mirrorRegion = WordPressDependencyManager.MirrorRegion.CN
                                 WordPressDependencyManager.setMirrorRegion(WordPressDependencyManager.MirrorRegion.CN)
                             },
-                            label = { Text(Strings.wpMirrorCN) },
-                            leadingIcon = if (mirrorRegion == WordPressDependencyManager.MirrorRegion.CN) {
-                                { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                            } else null
+                            label = Strings.wpMirrorCN
                         )
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = mirrorRegion == WordPressDependencyManager.MirrorRegion.GLOBAL,
                             onClick = {
                                 mirrorRegion = WordPressDependencyManager.MirrorRegion.GLOBAL
                                 WordPressDependencyManager.setMirrorRegion(WordPressDependencyManager.MirrorRegion.GLOBAL)
                             },
-                            label = { Text(Strings.wpMirrorGlobal) },
-                            leadingIcon = if (mirrorRegion == WordPressDependencyManager.MirrorRegion.GLOBAL) {
-                                { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                            } else null
+                            label = Strings.wpMirrorGlobal
                         )
-                        PremiumFilterChip(
+                        WtaChip(
                             selected = mirrorRegion != WordPressDependencyManager.MirrorRegion.CN
                                     && mirrorRegion != WordPressDependencyManager.MirrorRegion.GLOBAL,
                             onClick = {
                                 WordPressDependencyManager.setMirrorRegion(null)
                                 mirrorRegion = WordPressDependencyManager.getMirrorRegion()
                             },
-                            label = { Text(Strings.wpAutoDetect) }
+                            label = Strings.wpAutoDetect,
+                            showSelectedCheck = false
                         )
                     }
                 }


### PR DESCRIPTION
Fixes #760

## Summary
Migrates editor config screens from mixed Material `FilterChip` / `PremiumFilterChip` wrapper / `PremiumButton` to the shared `WtaChip` / `WtaButton` controls with `WtaSpacing` / `WtaRadius` / `CardExpandTransition` / `CardCollapseTransition`. UI-only, no behavior change.

## What / Why
- Editor cards drifted from the card grammar (AGENTS.md recipe 12): ad-hoc spacing, radii, expand animations, and chip visuals; follow-up to #610 (FilterChip overflow) and #418 (card overhaul).
- Delete `PremiumFilterChip` wrapper in `PremiumComponents.kt`; migrate all call sites to `WtaChip(showSelectedCheck = false)` with string labels and conditional leading icons.
- Migrate eligible `PremiumButton` call sites to `WtaButton` (e.g. AdBlock sources button).
- Extend `WtaChip` (`WtaControls.kt`) with `selectedContainerColor` / `selectedContentColor` / `leadingContent` / `trailingContent` slots for migrated call sites.
- Unify group labels (`labelMedium + primary`), spacing (`WtaSpacing`), radii (`WtaRadius.Control`), expansions (card transitions) across `CreateAppWebViewCards`, `StatusBarConfigCard`, `CreateAppSplashCard`, notification/isolation/floating-window/DNS cards, dialogs, and create-app screens (38 files).
- Remove fixed `StatusBarConfigCard|raw_corner_shape` entry from `.github/scripts/ui_design_allowlist.txt`.

## Test plan
- [ ] Android CI `check` job green: `:app:compileStandardDebugKotlin :shell:compileDebugKotlin :app:testStandardDebugUnitTest :app:checkConfigFieldDrift`
- [ ] UI design-system audit allowlist accurate, no new violations
- [ ] Emulator spot-check: changed cards share content columns / row heights with neighbours