### PR TITLE
fix(statusbar): repair show-status-bar chain and refresh content-padding UI

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2358,6 +2358,10 @@ object Strings {
     val statusBarStyleConfigLabel: String get() = StringsC.statusBarStyleConfigLabel
     val statusBarLightModeLabel: String get() = StringsC.statusBarLightModeLabel
     val statusBarDarkModeLabel: String get() = StringsC.statusBarDarkModeLabel
+    val statusBarIconsLabel: String get() = StringsC.statusBarIconsLabel
+    val statusBarIconsAuto: String get() = StringsC.statusBarIconsAuto
+    val statusBarIconsDark: String get() = StringsC.statusBarIconsDark
+    val statusBarIconsLight: String get() = StringsC.statusBarIconsLight
     val browserToolbarLabel: String get() = StringsC.browserToolbarLabel
     val toolbarShowTitleLabel: String get() = StringsC.toolbarShowTitleLabel
     val toolbarShowTitleHint: String get() = StringsC.toolbarShowTitleHint
@@ -34373,16 +34377,16 @@ object StringsC {
     }
 
     val fullscreenContentPaddingHint: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "全屏模式下给内容四周留白，让屏幕角落的按钮更容易点按，并缓解与返回手势边缘的冲突。若返回手势区仍偏小，可开启上方的“显示导航栏”恢复标准手势区。"
-        AppLanguage.ENGLISH -> "Add padding around content in fullscreen so corner buttons are easier to tap and it conflicts less with the back-gesture edge. If the back-gesture area still feels small, turn on “Show Navigation Bar” above to restore the standard gesture zone."
-        AppLanguage.ARABIC -> "أضف هامشًا حول المحتوى في وضع ملء الشاشة لتسهيل النقر على أزرار الزوايا وتقليل التعارض مع حافة إيماءة الرجوع. إذا ظل منطقة إيماءة الرجوع صغيرة، فعّل «إظهار شريط التنقل» بالأعلى لاستعادة منطقة الإيماءات القياسية."
-        AppLanguage.PORTUGUESE -> "Adicione preenchimento ao redor do conteúdo em tela cheia para facilitar tocar nos botões dos cantos e reduzir conflitos com a borda do gesto de voltar. Se a área do gesto de voltar ainda parecer pequena, ative “Mostrar Barra de Navegação” acima para restaurar a zona padrão de gestos."
-        AppLanguage.SPANISH -> "Añade relleno alrededor del contenido en pantalla completa para que los botones de las esquinas sean más fáciles de tocar y haya menos conflicto con el borde del gesto de retroceso. Si el área del gesto sigue pareciendo pequeña, activa “Mostrar Barra de Navegación” arriba para restaurar la zona estándar de gestos."
-        AppLanguage.FRENCH -> "Ajoutez une marge autour du contenu en plein écran pour faciliter l'appui sur les boutons d'angle et réduire les conflits avec la zone du geste de retour. Si la zone du geste de retour reste petite, activez « Afficher la Barre de Navigation » ci-dessus pour restaurer la zone de gestes standard."
-        AppLanguage.GERMAN -> "Fügt im Vollbildmodus einen Abstand um den Inhalt hinzu, damit Eckbuttons leichter antippbar sind und weniger Konflikte mit der Zurück-Geste-Kante entstehen. Wenn die Zone für die Zurück-Geste noch klein wirkt, aktivieren Sie oben „Navigationsleiste anzeigen“, um die Standard-Gestenzone wiederherzustellen."
-        AppLanguage.RUSSIAN -> "Добавляет отступ вокруг контента в полноэкранном режиме, чтобы кнопки в углах было легче нажимать, и уменьшает конфликт с краем жеста «назад». Если зона жеста «назад» всё ещё мала, включите выше «Показывать панель навигации», чтобы восстановить стандартную зону жестов."
-        AppLanguage.JAPANESE -> "全画面モードでコンテンツの周囲に余白を設け、画面の隅のボタンをタップしやすくし、戻るジェスチャーの縁との競合を和らげます。戻るジェスチャー領域がまだ狭い場合は、上の「ナビゲーションバーを表示」をオンにして標準のジェスチャー領域を復元してください。"
-        AppLanguage.KOREAN -> "전체 화면 모드에서 콘텐츠 주위에 여백을 추가해 화면 모서리의 버튼을 누르기 쉽게 하고, 뒤로 가기 제스처 경계와의 충돌을 줄입니다. 뒤로 가기 제스처 영역이 여전히 좁게 느껴지면 위의 “내비게이션 바 표시”를 켜서 표준 제스처 영역을 복원하세요."
+        AppLanguage.CHINESE -> "全屏时给内容留边，角落按钮更好点，也能缓解返回手势冲突"
+        AppLanguage.ENGLISH -> "Pad content in fullscreen: easier corner taps, fewer edge-gesture conflicts"
+        AppLanguage.ARABIC -> "هامش حول المحتوى في ملء الشاشة: نقر أسهل على أزرار الزوايا وتعاوض أقل مع إيماءات الحافة"
+        AppLanguage.PORTUGUESE -> "Margem no conteúdo em tela cheia: cantos mais fáceis de tocar, menos conflito com gestos de borda"
+        AppLanguage.SPANISH -> "Margen en pantalla completa: esquinas más fáciles y menos conflicto con gestos de borde"
+        AppLanguage.FRENCH -> "Marge en plein écran : boutons d'angle plus faciles, moins de conflits de gestes"
+        AppLanguage.GERMAN -> "Abstand im Vollbild: leichtere Eckbuttons, weniger Kantengesten-Konflikte"
+        AppLanguage.RUSSIAN -> "Отступ в полноэкранном режиме: кнопки в углах удобнее, меньше конфликтов с жестами"
+        AppLanguage.JAPANESE -> "全画面で余白を設け、隅のボタンを押しやすくし、エッジジェスチャーとの競合を軽減"
+        AppLanguage.KOREAN -> "전체 화면 여백: 모서리 버튼이 쉬워지고 가장자리 제스처 충돌 감소"
     }
 
     val statusBarStyleConfigLabel: String get() = when (Strings.lang) {
@@ -34422,6 +34426,58 @@ object StringsC {
         AppLanguage.RUSSIAN -> "Тёмный режим"
         AppLanguage.JAPANESE -> "ダークモード"
         AppLanguage.KOREAN -> "다크 모드"
+    }
+
+    val statusBarIconsLabel: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "状态栏图标"
+        AppLanguage.ENGLISH -> "Status bar icons"
+        AppLanguage.ARABIC -> "أيقونات شريط الحالة"
+        AppLanguage.PORTUGUESE -> "Ícones da barra de status"
+        AppLanguage.SPANISH -> "Iconos de la barra de estado"
+        AppLanguage.FRENCH -> "Icônes de la barre d'état"
+        AppLanguage.GERMAN -> "Symbole der Statusleiste"
+        AppLanguage.RUSSIAN -> "Значки строки состояния"
+        AppLanguage.JAPANESE -> "ステータスバーのアイコン"
+        AppLanguage.KOREAN -> "상태 표시줄 아이콘"
+    }
+
+    val statusBarIconsAuto: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "自动"
+        AppLanguage.ENGLISH -> "Auto"
+        AppLanguage.ARABIC -> "تلقائي"
+        AppLanguage.PORTUGUESE -> "Automático"
+        AppLanguage.SPANISH -> "Automático"
+        AppLanguage.FRENCH -> "Auto"
+        AppLanguage.GERMAN -> "Auto"
+        AppLanguage.RUSSIAN -> "Авто"
+        AppLanguage.JAPANESE -> "自動"
+        AppLanguage.KOREAN -> "자동"
+    }
+
+    val statusBarIconsDark: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "深色"
+        AppLanguage.ENGLISH -> "Dark"
+        AppLanguage.ARABIC -> "داكن"
+        AppLanguage.PORTUGUESE -> "Escuros"
+        AppLanguage.SPANISH -> "Oscuros"
+        AppLanguage.FRENCH -> "Sombres"
+        AppLanguage.GERMAN -> "Dunkel"
+        AppLanguage.RUSSIAN -> "Тёмные"
+        AppLanguage.JAPANESE -> "ダーク"
+        AppLanguage.KOREAN -> "어둡게"
+    }
+
+    val statusBarIconsLight: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "浅色"
+        AppLanguage.ENGLISH -> "Light"
+        AppLanguage.ARABIC -> "فاتح"
+        AppLanguage.PORTUGUESE -> "Claros"
+        AppLanguage.SPANISH -> "Claros"
+        AppLanguage.FRENCH -> "Claires"
+        AppLanguage.GERMAN -> "Hell"
+        AppLanguage.RUSSIAN -> "Светлые"
+        AppLanguage.JAPANESE -> "ライト"
+        AppLanguage.KOREAN -> "밝게"
     }
 
     val browserToolbarLabel: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -321,7 +321,7 @@ data class WebViewConfig(
 
     val statusBarColorModeDark: StatusBarColorMode = StatusBarColorMode.THEME,
     val statusBarColorDark: String? = null,
-    val statusBarDarkIconsDark: Boolean = false,
+    val statusBarDarkIconsDark: Boolean? = null,
     val statusBarBackgroundTypeDark: StatusBarBackgroundType = StatusBarBackgroundType.COLOR,
     val statusBarBackgroundImageDark: String? = null,
     val statusBarBackgroundAlphaDark: Float = 1.0f,

--- a/app/src/main/java/com/webtoapp/ui/components/StatusBarBackground.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/StatusBarBackground.kt
@@ -85,8 +85,13 @@ fun StatusBarBackground(
             }
             else -> {
 
-                val bgColor = try {
-                    val hex = backgroundColor?.removePrefix("#") ?: "000000"
+                // A null color means TRANSPARENT mode (the only resolver path that
+                // yields null). It must stay see-through: falling back to black
+                // painted an opaque band over the content (issue #762).
+                val bgColor = if (backgroundColor == null) {
+                    Color.Transparent
+                } else try {
+                    val hex = backgroundColor.removePrefix("#")
                     when (hex.length) {
                         6 -> Color(android.graphics.Color.parseColor("#$hex")).copy(alpha = alpha)
                         8 -> Color(android.graphics.Color.parseColor("#$hex")).copy(alpha = alpha)
@@ -175,8 +180,12 @@ fun StatusBarOverlay(
             }
             else -> {
 
-                val bgColor = try {
-                    val hex = backgroundColor?.removePrefix("#") ?: "000000"
+                // Same TRANSPARENT rule as StatusBarBackground above: null stays
+                // see-through instead of degrading to a black band (issue #762).
+                val bgColor = if (backgroundColor == null) {
+                    Color.Transparent
+                } else try {
+                    val hex = backgroundColor.removePrefix("#")
                     when (hex.length) {
                         6 -> Color(android.graphics.Color.parseColor("#$hex")).copy(alpha = alpha)
                         8 -> Color(android.graphics.Color.parseColor("#$hex")).copy(alpha = alpha)

--- a/app/src/main/java/com/webtoapp/ui/components/StatusBarConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/StatusBarConfigCard.kt
@@ -32,7 +32,7 @@ import com.webtoapp.ui.design.WtaRadius
 import com.webtoapp.ui.design.WtaSettingRow
 import com.webtoapp.ui.design.WtaSpacing
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun StatusBarConfigCard(
     config: WebViewConfig,
@@ -150,29 +150,36 @@ fun StatusBarConfigCard(
             StatusBarBackgroundType.COLOR -> {
                 Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
                     GroupLabel(Strings.backgroundColor)
-                    Row(
+                    // Four modes no longer fit one weighted row in every locale
+                    // ("Transparent" overflows a quarter-width chip in English),
+                    // so this group wraps like the viewport-mode chips do.
+                    FlowRow(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+                        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
                     ) {
                         WtaChip(
                             selected = config.statusBarColorMode == StatusBarColorMode.THEME,
                             onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.THEME)) },
                             label = Strings.tagTheme,
-                            modifier = Modifier.weight(1f),
                             showSelectedCheck = false
                         )
                         WtaChip(
                             selected = config.statusBarColorMode == StatusBarColorMode.PAGE_TOP,
                             onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.PAGE_TOP)) },
                             label = Strings.followPageTop,
-                            modifier = Modifier.weight(1f),
                             showSelectedCheck = false
                         )
                         WtaChip(
                             selected = config.statusBarColorMode == StatusBarColorMode.CUSTOM,
                             onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.CUSTOM)) },
                             label = Strings.backgroundColor,
-                            modifier = Modifier.weight(1f),
+                            showSelectedCheck = false
+                        )
+                        WtaChip(
+                            selected = config.statusBarColorMode == StatusBarColorMode.TRANSPARENT,
+                            onClick = { onConfigChange(config.copy(statusBarColorMode = StatusBarColorMode.TRANSPARENT)) },
+                            label = Strings.transparent,
                             showSelectedCheck = false
                         )
                     }
@@ -187,6 +194,40 @@ fun StatusBarConfigCard(
                     currentImagePath = config.statusBarBackgroundImage,
                     onSelectImage = { imagePickerLauncher.launch("image/*") },
                     onClearImage = { onConfigChange(config.copy(statusBarBackgroundImage = null, statusBarBackgroundType = StatusBarBackgroundType.COLOR)) }
+                )
+            }
+        }
+
+        // Icon shade used to be permanently auto: the model field was plumbed
+        // end-to-end but the editor exposed no control, so a wrong auto guess
+        // could never be overridden. Tri-state (auto/dark/light) for both tabs —
+        // the dark tab maps through the shared slot like the color fields do.
+        Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+            GroupLabel(Strings.statusBarIconsLabel)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+            ) {
+                WtaChip(
+                    selected = config.statusBarDarkIcons == null,
+                    onClick = { onConfigChange(config.copy(statusBarDarkIcons = null)) },
+                    label = Strings.statusBarIconsAuto,
+                    modifier = Modifier.weight(1f),
+                    showSelectedCheck = false
+                )
+                WtaChip(
+                    selected = config.statusBarDarkIcons == true,
+                    onClick = { onConfigChange(config.copy(statusBarDarkIcons = true)) },
+                    label = Strings.statusBarIconsDark,
+                    modifier = Modifier.weight(1f),
+                    showSelectedCheck = false
+                )
+                WtaChip(
+                    selected = config.statusBarDarkIcons == false,
+                    onClick = { onConfigChange(config.copy(statusBarDarkIcons = false)) },
+                    label = Strings.statusBarIconsLight,
+                    modifier = Modifier.weight(1f),
+                    showSelectedCheck = false
                 )
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt
+++ b/app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -535,6 +537,7 @@ fun WtaTextFieldRow(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun WtaSliderRow(
     title: String,
@@ -544,7 +547,8 @@ fun WtaSliderRow(
     subtitle: String? = null,
     valueLabel: String? = null,
     valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    presets: List<Pair<String, Float>>? = null
 ) {
     Column(
         modifier = modifier
@@ -568,6 +572,25 @@ fun WtaSliderRow(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+            }
+        }
+        if (!presets.isNullOrEmpty()) {
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = WtaSpacing.Small),
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
+                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+            ) {
+                presets.forEach { (label, presetValue) ->
+                    com.webtoapp.ui.design.WtaChip(
+                        selected = value == presetValue,
+                        onClick = { onValueChange(presetValue) },
+                        label = label,
+                        showSelectedCheck = false,
+                        enabled = enabled
+                    )
+                }
             }
         }
         Slider(

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -2301,7 +2301,8 @@ fun FullscreenModeCard(
                         )
                     },
                     valueLabel = "${webViewConfig.fullscreenContentPaddingDp}dp",
-                    valueRange = 0f..48f
+                    valueRange = 0f..48f,
+                    presets = listOf("0dp" to 0f, "8dp" to 8f, "16dp" to 16f, "24dp" to 24f)
                 )
 
                 AnimatedVisibility(
@@ -2372,10 +2373,14 @@ fun FullscreenModeCard(
                                                 webViewConfig.copy(
                                                     statusBarColorModeDark = newConfig.statusBarColorMode,
                                                     statusBarColorDark = newConfig.statusBarColor,
-                                                    statusBarDarkIconsDark = newConfig.statusBarDarkIcons ?: false,
+                                                    statusBarDarkIconsDark = newConfig.statusBarDarkIcons,
                                                     statusBarBackgroundTypeDark = newConfig.statusBarBackgroundType,
                                                     statusBarBackgroundImageDark = newConfig.statusBarBackgroundImage,
-                                                    statusBarBackgroundAlphaDark = newConfig.statusBarBackgroundAlpha
+                                                    statusBarBackgroundAlphaDark = newConfig.statusBarBackgroundAlpha,
+                                                    // statusBarHeightDp is a shared (non-per-theme)
+                                                    // field: the dark tab edits it in place, so it
+                                                    // must be written back like the light tab does.
+                                                    statusBarHeightDp = newConfig.statusBarHeightDp
                                                 )
                                             )
                                         }

--- a/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
@@ -98,7 +98,6 @@ object WindowHelper {
         hideNavBar: Boolean = true,
         isDarkTheme: Boolean = false,
         showStatusBar: Boolean = false,
-        forceHideSystemUi: Boolean = false,
         statusBarColorMode: String = "THEME",
         statusBarCustomColor: String? = null,
         statusBarDarkIcons: Boolean? = null,
@@ -132,7 +131,7 @@ object WindowHelper {
                     if (!classicKeyboardResize) {
                         activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
                     }
-                    val shouldShowStatusBar = if (forceHideSystemUi) false else showStatusBar
+                    val shouldShowStatusBar = showStatusBar
 
                     if (shouldShowStatusBar) {
                         decorFitsSystemWindows = classicKeyboardResize
@@ -183,7 +182,7 @@ object WindowHelper {
                         controller.hide(WindowInsetsCompat.Type.statusBars())
                     }
 
-                    if (hideNavBar || forceHideSystemUi) {
+                    if (hideNavBar) {
                         controller.hide(WindowInsetsCompat.Type.navigationBars())
                         controller.systemBarsBehavior =
                             WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -64,7 +64,6 @@ class ShellActivity : AppCompatActivity() {
     private var statusBarBackgroundImageDark: String? = null
     private var statusBarBackgroundAlphaDark: Float = 1.0f
     private var statusBarAutoColor: String? = null
-    private var forceHideSystemUi: Boolean = false
     private var keyboardAdjustMode: KeyboardAdjustMode = KeyboardAdjustMode.RESIZE
 
     private var pendingFloatingWindowLaunch = false
@@ -106,7 +105,7 @@ class ShellActivity : AppCompatActivity() {
     private fun refreshStatusBarAppearance() {
         if (customView != null) return
         val systemDark = isSystemInDarkMode()
-        if (immersiveFullscreenEnabled || forceHideSystemUi) {
+        if (immersiveFullscreenEnabled) {
             applyImmersiveFullscreen(true, isDarkTheme = systemDark)
             return
         }
@@ -138,7 +137,6 @@ class ShellActivity : AppCompatActivity() {
             hideNavBar = shouldHideNavBar,
             isDarkTheme = isDarkTheme,
             showStatusBar = effectiveShowStatusBar,
-            forceHideSystemUi = forceHideSystemUi,
             statusBarColorMode = resolved.first,
             statusBarCustomColor = resolved.second,
             statusBarDarkIcons = if (systemDark) statusBarDarkIconsDark else statusBarDarkIcons,
@@ -767,7 +765,7 @@ class ShellActivity : AppCompatActivity() {
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         if (hasFocus) {
-            if (customView != null || immersiveFullscreenEnabled || forceHideSystemUi) {
+            if (customView != null || immersiveFullscreenEnabled) {
                 applyImmersiveFullscreen(true, isDarkTheme = isSystemInDarkMode())
             } else {
                 val systemDark = isSystemInDarkMode()

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -169,8 +169,10 @@ class WebViewActivity : AppCompatActivity() {
 
     private var statusBarColorModeDark: com.webtoapp.data.model.StatusBarColorMode = com.webtoapp.data.model.StatusBarColorMode.THEME
     private var statusBarCustomColorDark: String? = null
-    private var statusBarDarkIconsDark: Boolean = false
+    private var statusBarDarkIconsDark: Boolean? = null
     private var statusBarBackgroundTypeDark: com.webtoapp.data.model.StatusBarBackgroundType = com.webtoapp.data.model.StatusBarBackgroundType.COLOR
+    private var statusBarBackgroundAlpha: Float = 1.0f
+    private var statusBarBackgroundAlphaDark: Float = 1.0f
     private var statusBarAutoColor: String? = null
     internal var keyboardAdjustMode: KeyboardAdjustMode = KeyboardAdjustMode.RESIZE
 
@@ -207,7 +209,8 @@ class WebViewActivity : AppCompatActivity() {
         val effectiveColorMode = if (currentIsDarkTheme) statusBarColorModeDark else statusBarColorMode
         val effectiveCustomColor = if (currentIsDarkTheme) statusBarCustomColorDark else statusBarCustomColor
         val effectiveDarkIcons = if (currentIsDarkTheme) statusBarDarkIconsDark else statusBarDarkIcons
-        applyStatusBarColor(effectiveColorMode, effectiveCustomColor, effectiveDarkIcons, currentIsDarkTheme)
+        val effectiveAlpha = if (currentIsDarkTheme) statusBarBackgroundAlphaDark else statusBarBackgroundAlpha
+        applyStatusBarColor(effectiveColorMode, effectiveCustomColor, effectiveDarkIcons, currentIsDarkTheme, effectiveAlpha)
     }
 
     private fun applyStatusBarColor(
@@ -790,18 +793,20 @@ class WebViewActivity : AppCompatActivity() {
                 previewApp = previewApp,
                 testUrl = testUrl,
                 testModuleIds = testModuleIds,
-                onStatusBarConfigChanged = { colorMode, customColor, darkIcons, showStatusBar, backgroundType, colorModeDark, customColorDark, darkIconsDark, backgroundTypeDark ->
+                onStatusBarConfigChanged = { colorMode, customColor, darkIcons, showStatusBar, backgroundType, backgroundAlpha, colorModeDark, customColorDark, darkIconsDark, backgroundTypeDark, backgroundAlphaDark ->
 
                     statusBarColorMode = colorMode
                     statusBarCustomColor = customColor
                     statusBarDarkIcons = darkIcons
                     showStatusBarInFullscreen = showStatusBar
                     statusBarBackgroundType = backgroundType
+                    statusBarBackgroundAlpha = backgroundAlpha
 
                     statusBarColorModeDark = colorModeDark
                     statusBarCustomColorDark = customColorDark
                     statusBarDarkIconsDark = darkIconsDark
                     statusBarBackgroundTypeDark = backgroundTypeDark
+                    statusBarBackgroundAlphaDark = backgroundAlphaDark
                 },
                 onStatusBarAutoColorChanged = { color ->
                     if (statusBarAutoColor == color) return@WebViewScreen
@@ -1097,7 +1102,7 @@ fun WebViewScreen(
     previewApp: com.webtoapp.data.model.WebApp? = null,
     testUrl: String? = null,
     testModuleIds: List<String>? = null,
-    onStatusBarConfigChanged: ((com.webtoapp.data.model.StatusBarColorMode, String?, Boolean?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType, com.webtoapp.data.model.StatusBarColorMode, String?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType) -> Unit)? = null,
+    onStatusBarConfigChanged: ((com.webtoapp.data.model.StatusBarColorMode, String?, Boolean?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType, Float, com.webtoapp.data.model.StatusBarColorMode, String?, Boolean?, com.webtoapp.data.model.StatusBarBackgroundType, Float) -> Unit)? = null,
     onStatusBarAutoColorChanged: ((String?) -> Unit)? = null,
     onSavedAppLoaded: ((WebApp) -> Unit)? = null,
     onWebViewCreated: (WebView, WebApp?) -> Unit,
@@ -1240,10 +1245,12 @@ fun WebViewScreen(
                 app.webViewConfig.statusBarDarkIcons,
                 app.webViewConfig.showStatusBarInFullscreen,
                 app.webViewConfig.statusBarBackgroundType,
+                app.webViewConfig.statusBarBackgroundAlpha,
                 app.webViewConfig.statusBarColorModeDark,
                 app.webViewConfig.statusBarColorDark,
                 app.webViewConfig.statusBarDarkIconsDark,
-                app.webViewConfig.statusBarBackgroundTypeDark
+                app.webViewConfig.statusBarBackgroundTypeDark,
+                app.webViewConfig.statusBarBackgroundAlphaDark
             )
 
             statusBarBackgroundType = app.webViewConfig.statusBarBackgroundType.name
@@ -3002,6 +3009,12 @@ fun WebViewScreen(
 
         val actualStatusBarPadding = if (statusBarHeightDp >= 0) statusBarHeightDp.dp else systemStatusBarHeightDp
 
+        // Fullscreen content padding mirrors the exported shell (ShellScaffoldLayout):
+        // reserve the status-bar height on top when the bar is shown, pad the
+        // remaining edges so corner controls stay tappable. Preview used to ignore
+        // this setting entirely, so the slider appeared dead until export.
+        val contentPad = (webApp?.webViewConfig?.fullscreenContentPaddingDp ?: 0).dp
+
         val contentModifier = when {
             hideToolbar && showToolbarInPreview -> {
 
@@ -3009,11 +3022,16 @@ fun WebViewScreen(
             }
             hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true -> {
 
-                Modifier.fillMaxSize().padding(top = actualStatusBarPadding)
+                Modifier.fillMaxSize().padding(
+                    top = actualStatusBarPadding,
+                    start = contentPad,
+                    end = contentPad,
+                    bottom = contentPad
+                )
             }
             hideToolbar -> {
 
-                Modifier.fillMaxSize()
+                Modifier.fillMaxSize().padding(contentPad)
             }
             else -> {
 

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
@@ -68,7 +68,7 @@ class WebViewConfigBooleanCoverageTest {
             "databaseEnabled", "primeUserActivation", "failoverEnabled",
             "hostsMappingEnabled", "autoRefreshEnabled", "autoRefreshShowCountdown",
             "allowFileAccessFromFileURLs", "allowUniversalAccessFromFileURLs",
-            "tlsFingerprintEnabled", "statusBarDarkIconsDark"
+            "tlsFingerprintEnabled"
         )
 
         val missing = allBooleanFields - listedFields
@@ -232,6 +232,23 @@ class WebViewConfigBooleanCoverageTest {
         readShell("pageZoomPercent", 125)
     }
 
+    @Test
+    fun `nullable statusBarDarkIconsDark round-trips through export`() {
+        fun shellDarkIconsOf(config: WebViewConfig): Any? {
+            val shellWv = shellWvOf(roundTrip(WebApp(name = "t", url = "https://t.example.com", webViewConfig = config)))
+            val field = shellWv.javaClass.declaredFields.associateBy { it.name }["statusBarDarkIconsDark"]
+                ?: throw AssertionError("ShellWebViewConfig missing field 'statusBarDarkIconsDark'")
+            field.isAccessible = true
+            return field.get(shellWv)
+        }
+
+        // Explicit choices survive; the default (auto) stays null instead of
+        // degrading to false, so the runtime keeps its luminance fallback.
+        assertThat(shellDarkIconsOf(WebViewConfig(statusBarDarkIconsDark = true))).isEqualTo(true)
+        assertThat(shellDarkIconsOf(WebViewConfig(statusBarDarkIconsDark = false))).isEqualTo(false)
+        assertThat(shellDarkIconsOf(WebViewConfig())).isNull()
+    }
+
     // ────────────────────────────────────────────────────────────
     //  Helpers
     // ────────────────────────────────────────────────────────────
@@ -346,8 +363,7 @@ class WebViewConfigBooleanCoverageTest {
             autoRefreshShowCountdown = bool("autoRefreshShowCountdown"),
             allowFileAccessFromFileURLs = bool("allowFileAccessFromFileURLs"),
             allowUniversalAccessFromFileURLs = bool("allowUniversalAccessFromFileURLs"),
-            tlsFingerprintEnabled = bool("tlsFingerprintEnabled"),
-            statusBarDarkIconsDark = bool("statusBarDarkIconsDark")
+            tlsFingerprintEnabled = bool("tlsFingerprintEnabled")
         )
     }
 }

--- a/app/src/test/java/com/webtoapp/data/model/WebViewConfigDarkModeTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/WebViewConfigDarkModeTest.kt
@@ -11,7 +11,7 @@ class WebViewConfigDarkModeTest {
 
         assertThat(config.statusBarColorModeDark).isEqualTo(StatusBarColorMode.THEME)
         assertThat(config.statusBarColorDark).isNull()
-        assertThat(config.statusBarDarkIconsDark).isFalse()
+        assertThat(config.statusBarDarkIconsDark).isNull()
         assertThat(config.statusBarBackgroundTypeDark).isEqualTo(StatusBarBackgroundType.COLOR)
         assertThat(config.statusBarBackgroundImageDark).isNull()
         assertThat(config.statusBarBackgroundAlphaDark).isWithin(0.01f).of(1.0f)


### PR DESCRIPTION
Fixes #762

## Summary
Repairs the Show-status-bar-in-fullscreen chain (preview/export divergence, dead editor controls, TRANSPARENT black band, icon shade with no UI, stale preview refresh, dead shell param) and refreshes the Content Padding UI with presets.

## What / Why
- Preview now applies `fullscreenContentPaddingDp` exactly like the exported shell (`WebViewActivity` content modifier mirrors `ShellScaffoldLayout`); previously the slider did nothing in preview but changed exported APKs.
- Dark-tab write-back in `FullscreenModeCard` now persists shared `statusBarHeightDp` (was silently dropped) and passes icon choice through.
- `TRANSPARENT` color mode is selectable in the editor (4th chip in a wrapping FlowRow); `StatusBarOverlay`/`StatusBarBackground` render null color as truly transparent instead of a black band, in preview and exported APKs.
- Icon shade tri-state (Auto/Dark/Light) added to `StatusBarConfigCard` for both theme tabs (4 new strings x 10 locales); model `statusBarDarkIconsDark` becomes nullable (auto default) to match the shell/config layers, which were already nullable.
- Preview passes effective background alpha to the window bar (matches shell); alpha fields flow through the status-bar config callback.
- Removes never-used `forceHideSystemUi` (always false) from `WindowHelper` + `ShellActivity`.
- Content Padding UI: preset chips (0/8/16/24dp) via new optional `WtaSliderRow(presets)` slot + one-line hint (was a 3-line paragraph).

## Test plan
- [x] `:app:compileStandardDebugKotlin` + `:shell:compileDebugKotlin` green
- [x] Full `:app:testStandardDebugUnitTest` green (984 tests, incl. new nullable dark-icons round-trip + updated dark-mode defaults + i18n parity)
- [x] `:app:checkConfigFieldDrift` green (no field renames, only nullability)
- [ ] Android CI `check` green on this PR
- [ ] Emulator spot-check of FullscreenModeCard (expanded + dark tab)