### PR TITLE
refactor(extensions): drop redundant Import JS package entry

### DIFF
--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionFileManager.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionFileManager.kt
@@ -321,39 +321,6 @@ class ExtensionFileManager(private val context: Context) {
         }
     }
 
-    suspend fun importJsZipPackage(uri: Uri): ImportResult = withContext(Dispatchers.IO) {
-        try {
-            val tempFile = File(tempDir, "jszip_${System.currentTimeMillis()}")
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                FileOutputStream(tempFile).use { output ->
-                    val copied = input.copyTo(output)
-                    if (copied > MAX_EXTENSION_SIZE) {
-                        tempFile.delete()
-                        return@withContext ImportResult.Error("ZIP too large (max 50MB)")
-                    }
-                }
-            } ?: return@withContext ImportResult.Error("Cannot read file")
-
-            val extractDir = File(tempDir, "jszip_extract_${System.currentTimeMillis()}")
-            extractDir.mkdirs()
-
-            try {
-                extractZipToDirectory(tempFile, extractDir)
-                val result = tryImportAsJsPackage(extractDir)
-                if (result != null) {
-                    return@withContext result
-                }
-                return@withContext ImportResult.Error("No JS files found in ZIP")
-            } finally {
-                tempFile.delete()
-                extractDir.deleteRecursively()
-            }
-        } catch (e: Exception) {
-            AppLogger.e(TAG, "Failed to import JS ZIP package", e)
-            ImportResult.Error("Import failed: ${e.message}")
-        }
-    }
-
     private fun tryImportAsJsPackage(dir: File): ImportResult? {
         val jsFiles = dir.walkTopDown()
             .filter { it.isFile && (it.extension.equals("js", true) || it.extension.equals("mjs", true)) }

--- a/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
@@ -168,27 +168,6 @@ fun ExtensionModuleScreen(
         }
     }
 
-    val jsZipPickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
-    ) { uri ->
-        uri?.let {
-            isImporting = true
-            scope.launch {
-                val result = extensionFileManager.importJsZipPackage(it)
-                isImporting = false
-                when (result) {
-                    is ExtensionFileManager.ImportResult.JsPackage -> {
-                        showJsPackagePreview = result
-                    }
-                    is ExtensionFileManager.ImportResult.Error -> {
-                        Toast.makeText(context, Strings.moduleImportFailed(result.message), Toast.LENGTH_SHORT).show()
-                    }
-                    else -> {}
-                }
-            }
-        }
-    }
-
     val qrCodeImagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
@@ -322,11 +301,6 @@ fun ExtensionModuleScreen(
                                 text = { Text(Strings.importChromeExtension) },
                                 onClick = { showMoreMenu = false; chromeExtPickerLauncher.launch("*/*") },
                                 leadingIcon = { Icon(Icons.Default.Extension, null, Modifier.size(20.dp)) }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(Strings.importJsPackage) },
-                                onClick = { showMoreMenu = false; jsZipPickerLauncher.launch("*/*") },
-                                leadingIcon = { Icon(Icons.Default.FolderZip, null, Modifier.size(20.dp)) }
                             )
                             DropdownMenuItem(
                                 text = { Text(Strings.importFromFile) },


### PR DESCRIPTION
Fixes #766

## Summary
Removes the Import JS package menu entry, its picker launcher, and the now-unused `ExtensionFileManager.importJsZipPackage` (pure deletion, -59 lines).

## What / Why
- `importChromeExtension` already accepts CRX or ZIP and falls back to `tryImportAsJsPackage` for manifest-less ZIPs, so the JS-package entry was a strict subset behind an identical unfiltered picker.
- Users no longer need to know upfront whether a ZIP is a Chrome extension or a plain JS bundle; one entry handles both, with the JS-package preview dialog kept for the fallback path.
- Kept deliberately: Import userscript (text parser), Import from file (`.wtamod`), Import from QR image (receiving side of the reachable per-module Share -> QR poster flow).

## Test plan
- [x] `:app:compileStandardDebugKotlin` + extension/market unit tests green locally
- [ ] Android CI `check` green