### PR TITLE
feat(share): compact WTA2 codec so bigger modules fit one QR code

### DIFF
--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionModule.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionModule.kt
@@ -568,6 +568,28 @@ data class ExtensionModule(
 
         private const val SHARE_CODE_PREFIX_V1 = "WTA1:"
         private const val SHARE_CODE_PREFIX_V0 = ""
+        /**
+         * Compact share frame (issue #768). V1 carries the full Gson payload; V2
+         * carries only entries that differ from a fresh [ExtensionModule] default
+         * (id/timestamps are always excluded — import regenerates them), so the
+         * same module compresses ~40-60% smaller before gzip and fits bigger
+         * modules into a single QR code. Decode keeps reading every generation.
+         */
+        private const val SHARE_CODE_PREFIX_V2 = "WTA2:"
+
+        /** JSON keys never carried in a share payload (regenerated on import). */
+        private val shareExcludedKeys = setOf("id", "createdAt", "updatedAt")
+
+        /**
+         * Physical single-QR ceiling in bytes: version 40, ECC-L, byte mode.
+         * Lives here (rather than QrCodeUtils, which is host-only and excluded
+         * from the shell sync) so [toShareCode] stays compilable in generated
+         * APKs. ASCII payloads such as Base64 share codes are 1 byte/char.
+         */
+        const val QR_SINGLE_CODE_MAX_BYTES = 2953
+
+        /** Diff baseline: `name` is the only parameter without a default. */
+        private val shareDefaultsInstance = ExtensionModule(name = "")
 
         fun fromJson(json: String): ExtensionModule? {
             return try {
@@ -580,6 +602,14 @@ data class ExtensionModule(
         fun fromShareCode(shareCode: String): ExtensionModule? {
             return try {
                 val json = when {
+
+                    shareCode.startsWith(SHARE_CODE_PREFIX_V2) -> {
+                        val compressed = android.util.Base64.decode(
+                            shareCode.removePrefix(SHARE_CODE_PREFIX_V2),
+                            android.util.Base64.DEFAULT
+                        )
+                        expandShareJson(decompressGzip(compressed))
+                    }
 
                     shareCode.startsWith(SHARE_CODE_PREFIX_V1) -> {
                         val compressed = android.util.Base64.decode(
@@ -599,6 +629,37 @@ data class ExtensionModule(
             }
         }
 
+        /**
+         * Merges a compact V2 payload onto a fresh default instance. A plain
+         * [fromJson] would leave Java defaults (false/0) in omitted primitive
+         * fields instead of the declared Kotlin defaults (e.g. enabled=true),
+         * so the merge must happen before parsing.
+         */
+        private fun expandShareJson(compactJson: String): String {
+            val base = gson.toJsonTree(shareDefaultsInstance).asJsonObject
+            val compact = gson.fromJson(compactJson, com.google.gson.JsonObject::class.java)
+            for ((key, value) in compact.entrySet()) {
+                base.add(key, value)
+            }
+            return gson.toJson(base)
+        }
+
+        /**
+         * Emits only payload entries that differ from a fresh default instance
+         * (deep-compared, so partially customized nested objects are kept whole).
+         */
+        private fun compactShareJson(module: ExtensionModule): String {
+            val full = gson.toJsonTree(module).asJsonObject
+            val defaults = gson.toJsonTree(shareDefaultsInstance).asJsonObject
+            val out = com.google.gson.JsonObject()
+            for ((key, value) in full.entrySet()) {
+                if (key in shareExcludedKeys) continue
+                if (value == defaults.get(key)) continue
+                out.add(key, value)
+            }
+            return gson.toJson(out)
+        }
+
         private fun decompressGzip(compressed: ByteArray): String {
             java.util.zip.GZIPInputStream(java.io.ByteArrayInputStream(compressed)).use { gzip ->
                 return gzip.bufferedReader().readText()
@@ -608,6 +669,23 @@ data class ExtensionModule(
         private fun compressGzip(data: String): ByteArray {
             val bos = java.io.ByteArrayOutputStream()
             java.util.zip.GZIPOutputStream(bos).use { gzip ->
+                gzip.write(data.toByteArray())
+            }
+            return bos.toByteArray()
+        }
+
+        /**
+         * Same gzip framing as [compressGzip] (decoders are unaffected) but with
+         * the deflater at maximum strength. `def` is protected in
+         * [java.util.zip.DeflaterOutputStream], hence the anonymous subclass.
+         */
+        private fun compressGzipBest(data: String): ByteArray {
+            val bos = java.io.ByteArrayOutputStream()
+            object : java.util.zip.GZIPOutputStream(bos) {
+                init {
+                    def.setLevel(java.util.zip.Deflater.BEST_COMPRESSION)
+                }
+            }.use { gzip ->
                 gzip.write(data.toByteArray())
             }
             return bos.toByteArray()
@@ -658,8 +736,21 @@ data class ExtensionModule(
     fun toJson(): String = gson.toJson(this)
 
     fun toShareCode(): String {
+        // Prefer V1 while it fits a single QR code so older app versions can
+        // still read the share; V2 is only emitted when V1 would not fit.
+        val v1 = toShareCodeV1()
+        if (v1.toByteArray(Charsets.UTF_8).size <= QR_SINGLE_CODE_MAX_BYTES) return v1
+        return toShareCodeV2()
+    }
+
+    fun toShareCodeV1(): String {
         val compressed = compressGzip(toJson())
         return SHARE_CODE_PREFIX_V1 + android.util.Base64.encodeToString(compressed, android.util.Base64.NO_WRAP)
+    }
+
+    fun toShareCodeV2(): String {
+        val compressed = compressGzipBest(compactShareJson(this))
+        return SHARE_CODE_PREFIX_V2 + android.util.Base64.encodeToString(compressed, android.util.Base64.NO_WRAP)
     }
 
     fun toShareCodeLegacy(): String {

--- a/app/src/main/java/com/webtoapp/core/extension/QrCodeUtils.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/QrCodeUtils.kt
@@ -17,7 +17,12 @@ object QrCodeUtils {
 
     private const val TAG = "QrCodeUtils"
 
-    private const val QR_MAX_BYTES = 4200
+    /**
+     * Physical single-QR ceiling: version 40, ECC-L, byte mode holds 2953 data
+     * bytes (ASCII payloads such as Base64 share codes use byte mode). The old
+     * 4200 cap let through codes that then failed to encode.
+     */
+    private const val QR_MAX_BYTES = ExtensionModule.QR_SINGLE_CODE_MAX_BYTES
 
     fun generateQrCode(
         content: String,

--- a/app/src/test/java/com/webtoapp/core/extension/ModuleShareCodeTest.kt
+++ b/app/src/test/java/com/webtoapp/core/extension/ModuleShareCodeTest.kt
@@ -1,0 +1,125 @@
+package com.webtoapp.core.extension
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards the share-code codec contract (issue #768):
+ *
+ * - V2 (`WTA2:`) round-trips every customized field while dropping defaults,
+ *   so bigger modules fit into a single QR code.
+ * - V1 (`WTA1:`) and legacy codes keep decoding (old shares stay importable).
+ * - `toShareCode()` prefers V1 while it fits, so older app versions can still
+ *   read small shares; V2 is only emitted when V1 would not fit one QR code.
+ *
+ * Needs Robolectric: the codec uses `android.util.Base64`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ModuleShareCodeTest {
+
+    private fun richModule() = ExtensionModule(
+        name = "Share Codec Probe",
+        description = "round-trip sentinel",
+        code = "console.log('share-code-probe');".repeat(40),
+        cssCode = ".probe{color:red}".repeat(10),
+        urlMatches = listOf(
+            UrlMatchRule(pattern = "*example.com*"),
+            UrlMatchRule(pattern = "https://admin.example.com/*", exclude = true)
+        ),
+        configItems = listOf(
+            ModuleConfigItem(key = "token", name = "Token", defaultValue = "abc")
+        ),
+        configValues = mapOf("token" to "xyz"),
+        enabled = false,
+        category = ModuleCategory.CONTENT_FILTER,
+        tags = listOf("probe", "share")
+    )
+
+    /** Deterministic high-entropy payload: fixed seed, unique tokens per line. */
+    private fun bulkyCode(lines: Int): String {
+        val random = kotlin.random.Random(42)
+        val hex = "0123456789abcdef"
+        return (1..lines).joinToString("\n") { i ->
+            val token = (1..32).map { hex[random.nextInt(16)] }.joinToString("")
+            "const sessionToken$i = \"$token\"; // binding $i"
+        }
+    }
+
+    @Test
+    fun `V2 round-trips every customized field`() {
+        val original = richModule()
+
+        val decoded = ExtensionModule.fromShareCode(original.toShareCodeV2())
+
+        assertThat(decoded).isNotNull()
+        decoded!!
+        assertThat(decoded.name).isEqualTo(original.name)
+        assertThat(decoded.description).isEqualTo(original.description)
+        assertThat(decoded.code).isEqualTo(original.code)
+        assertThat(decoded.cssCode).isEqualTo(original.cssCode)
+        assertThat(decoded.urlMatches).isEqualTo(original.urlMatches)
+        assertThat(decoded.configItems).isEqualTo(original.configItems)
+        assertThat(decoded.configValues).isEqualTo(original.configValues)
+        assertThat(decoded.enabled).isFalse()
+        assertThat(decoded.category).isEqualTo(original.category)
+        assertThat(decoded.tags).isEqualTo(original.tags)
+    }
+
+    @Test
+    fun `V2 default module keeps enabled true (no primitive-default trap)`() {
+        // `enabled` defaults to true but Gson leaves omitted primitives as false;
+        // the V2 merge onto defaults must restore it.
+        val decoded = ExtensionModule.fromShareCode(ExtensionModule(name = "Plain").toShareCodeV2())
+
+        assertThat(decoded).isNotNull()
+        assertThat(decoded!!.enabled).isTrue()
+        assertThat(decoded.name).isEqualTo("Plain")
+    }
+
+    @Test
+    fun `V1 codes from older versions still decode`() {
+        // Generated once with stock gzip+Base64 over {"name","code","enabled"}.
+        val legacyV1 = "WTA1:H4sIANWEmWoC/6tWykvMTVWyUvJJTU9MrlTwzczLVNJRSs5PAQkm5qQWlWgYagJFUvMSk3JSU5Ss0hJzilNrAb++qF84AAAA"
+
+        val decoded = ExtensionModule.fromShareCode(legacyV1)
+
+        assertThat(decoded).isNotNull()
+        assertThat(decoded!!.name).isEqualTo("Legacy Mini")
+        assertThat(decoded.code).isEqualTo("alert(1)")
+        assertThat(decoded.enabled).isFalse()
+    }
+
+    @Test
+    fun `V2 is strictly smaller than V1 for a customized module`() {
+        val module = richModule()
+
+        assertThat(module.toShareCodeV2().length).isLessThan(module.toShareCodeV1().length)
+    }
+
+    @Test
+    fun `toShareCode prefers V1 while it fits, V2 once V1 overflows`() {
+        val smallCode = ExtensionModule(name = "Tiny", code = "1").toShareCode()
+        assertThat(smallCode.startsWith("WTA1:")).isTrue()
+        assertThat(ExtensionModule.fromShareCode(smallCode)!!.name).isEqualTo("Tiny")
+
+        val big = richModule().copy(code = bulkyCode(56))
+        val bigCode = big.toShareCode()
+        assertThat(bigCode.startsWith("WTA2:")).isTrue()
+        assertThat(QrCodeUtils.canGenerateQrCode(bigCode)).isTrue()
+        assertThat(ExtensionModule.fromShareCode(bigCode)!!.code).isEqualTo(big.code)
+    }
+
+    @Test
+    fun `QR capacity cap matches the physical single-code ceiling`() {
+        assertThat(QrCodeUtils.canGenerateQrCode("x".repeat(2953))).isTrue()
+        assertThat(QrCodeUtils.canGenerateQrCode("x".repeat(2954))).isFalse()
+    }
+
+    @Test
+    fun `garbage share codes fail closed`() {
+        assertThat(ExtensionModule.fromShareCode("WTA2:!!!not-base64!!!")).isNull()
+        assertThat(ExtensionModule.fromShareCode("")).isNull()
+    }
+}


### PR DESCRIPTION
Fixes #768

## Summary
Single-QR-max share codec: new WTA2 frame (defaults-diff payload + max-strength gzip) with V1-preferred emission, plus a corrected capacity cap. No new dependencies, no UX change.

## What / Why
- toShareCodeV2: generic diff against share defaults (id/timestamps excluded, import regenerates them) + Deflater BEST_COMPRESSION.
- toShareCode: emits V1 while it fits one QR (old apps keep reading small shares), V2 only on overflow. Decode reads V2/V1/legacy.
- V2 decode merges onto defaults before Gson parsing, so omitted primitives (e.g. enabled=true) are restored.
- Capacity cap fixed to the physical 2953-byte ceiling (was a bogus 4200). Constant lives on shell-synced ExtensionModule so generated APKs still compile.
- 7 new tests in ModuleShareCodeTest: V2 round-trip, default-enabled trap, hardcoded-V1 backward compat, V2 smaller, emission policy + fit, cap boundary, garbage fails closed.

## Test plan
- Full app unit tests green (991), shell compile green locally
- Android CI check green on this PR