### PR TITLE
feat(blocker): copy blocked selector as adblock rule from panel

### DIFF
--- a/app/src/main/java/com/webtoapp/core/extension/BuiltInModules.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/BuiltInModules.kt
@@ -136,7 +136,7 @@ object BuiltInModules {
         icon = "block",
         category = ModuleCategory.CONTENT_FILTER,
         tags = listOf(Strings.tagBlock, Strings.tagAd, Strings.tagElement),
-        version = ModuleVersion(4, "4.0.0", Strings.versionV4Ui),
+        version = ModuleVersion(5, "4.1.0", Strings.versionV4Ui),
         author = ModuleAuthor("WebToApp"),
         builtIn = true,
         enabled = false,
@@ -1539,6 +1539,8 @@ object BuiltInModules {
             selectElement: '选择要屏蔽的元素',
             blockedCount: '已屏蔽 {0} 个元素',
             delete: '删除',
+            copyRule: '复制规则',
+            ruleCopied: '屏蔽规则已复制，可粘贴到去广告自定义规则',
             clearAll: '清除所有屏蔽',
             clickToSelect: '点击上方按钮选择要屏蔽的元素'
         },
@@ -1553,6 +1555,8 @@ object BuiltInModules {
             selectElement: 'Select element to block',
             blockedCount: '{0} elements blocked',
             delete: 'Delete',
+            copyRule: 'Copy rule',
+            ruleCopied: 'Block rule copied; paste it into ad-block custom rules',
             clearAll: 'Clear all blocks',
             clickToSelect: 'Click the button above to select elements'
         },
@@ -1567,6 +1571,8 @@ object BuiltInModules {
             selectElement: 'حدد العنصر للحظر',
             blockedCount: 'تم حظر {0} عنصر',
             delete: 'حذف',
+            copyRule: 'نسخ القاعدة',
+            ruleCopied: 'تم نسخ قاعدة الحظر؛ الصقها في القواعد المخصصة لمنع الإعلانات',
             clearAll: 'مسح جميع الحظر',
             clickToSelect: 'انقر على الزر أعلاه لتحديد العناصر'
         }
@@ -1643,6 +1649,46 @@ object BuiltInModules {
         blockedSelectors.push(selector);
         saveRules();
         __WTA_MODULE_UI__.toast(T.blocked);
+    }
+
+    // Copy屏蔽规则到剪贴板 (issue #765)：拼成“域名##选择器”的去广告
+    // 自定义规则格式，粘贴即用。navigator.clipboard 在非安全上下文不可用
+    // （如 http 页面），此时回退到 textarea + execCommand。
+    function copySelector(index) {
+        const selector = blockedSelectors[index];
+        if (!selector) return;
+        let rule = selector;
+        try {
+            const host = window.location.hostname;
+            if (host) rule = host + '##' + selector;
+        } catch (e) { /* file/blob 页面无 hostname，用裸选择器 */ }
+        function done(ok) {
+            __WTA_MODULE_UI__.toast(ok ? T.ruleCopied : selector);
+        }
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(rule).then(function() { done(true); }, function() { legacyCopy(rule, done); });
+            } else {
+                legacyCopy(rule, done);
+            }
+        } catch (e) {
+            legacyCopy(rule, done);
+        }
+    }
+
+    function legacyCopy(text, done) {
+        try {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
+            document.body.appendChild(ta);
+            ta.select();
+            const ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            done(!!ok);
+        } catch (e) {
+            done(false);
+        }
     }
 
     // Cancel屏蔽
@@ -1746,6 +1792,7 @@ object BuiltInModules {
             blockedSelectors.forEach(function(selector, i) {
                 html += '<div class="wta-blocker-item">' +
                     '<span class="wta-blocker-item-selector">' + selector.replace(/</g, '&lt;') + '</span>' +
+                    '<button class="wta-blocker-item-btn" data-wta-action="copySelector" data-wta-arg="' + i + '" title="' + T.copyRule + '">⧉</button>' +
                     '<button class="wta-blocker-item-btn" data-wta-action="unblock" data-wta-arg="' + i + '">✕</button></div>';
             });
             html += '</div>';
@@ -1759,6 +1806,7 @@ object BuiltInModules {
 
     window.__wta_module_action_enterSelectMode = enterSelectMode;
     window.__wta_module_action_unblock = function(i) { unblockElement(parseInt(i)); };
+    window.__wta_module_action_copySelector = function(i) { copySelector(parseInt(i)); };
     window.__wta_module_action_clearAllBlocks = clearAll;
 
     function register() {


### PR DESCRIPTION
Fixes #765

## Summary
Element-blocker panel list items get a copy button that copies the rule as paste-ready `hostname##selector` ad-block custom-rule text (clipboard API with textarea+execCommand fallback). Built-in blocker bumped to 4.1.0.

## What / Why
- Blocked elements are `display:none`, so there is nothing to long-press and no way to see/copy the full selector; the panel only rendered selector text with no copy affordance.
- Chose panel copy over long-press-on-element: long-press fights WebView text selection, the system context menu, and the app's own long-press menu; the existing `data-wta-action` delegation makes the panel button the natural extension point.
- Rule text is pre-scoped with the page hostname so it pastes straight into AdBlock custom rules (which parse `##`/domain-scoped cosmetic filters).
- Copy uses in-page clipboard with legacy fallback for non-secure contexts (http pages); toast confirms, and shows the raw selector if copying fails.

## Test plan
- [x] Extracted JS passes `node --check`; headless stub harness verified rule assembly (`host##selector` + bare-selector fallback), fallback copy path, and toast
- [x] Full `:app:testStandardDebugUnitTest` green (991)
- [ ] Android CI `check` green
- [ ] On-device: block an element, tap copy in panel, paste into AdBlock custom rules