### PR TITLE
feat(statusbar): persistent bar split from customize section

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2355,7 +2355,7 @@ object Strings {
     val showNavigationBarHint: String get() = StringsC.showNavigationBarHint
     val fullscreenContentPadding: String get() = StringsC.fullscreenContentPadding
     val fullscreenContentPaddingHint: String get() = StringsC.fullscreenContentPaddingHint
-    val statusBarStyleConfigLabel: String get() = StringsC.statusBarStyleConfigLabel
+    val statusBarCustomizeLabel: String get() = StringsC.statusBarCustomizeLabel
     val statusBarLightModeLabel: String get() = StringsC.statusBarLightModeLabel
     val statusBarDarkModeLabel: String get() = StringsC.statusBarDarkModeLabel
     val statusBarIconsLabel: String get() = StringsC.statusBarIconsLabel
@@ -34312,29 +34312,29 @@ object StringsC {
     }
 
     val showStatusBar: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "显示状态栏"
-        AppLanguage.ENGLISH -> "Show Status Bar"
-        AppLanguage.ARABIC -> "إظهار شريط الحالة"
-        AppLanguage.PORTUGUESE -> "Mostrar Barra de Status"
-        AppLanguage.SPANISH -> "Mostrar Barra de Estado"
-        AppLanguage.FRENCH -> "Afficher la Barre d'État"
-        AppLanguage.GERMAN -> "Statusleiste anzeigen"
-        AppLanguage.RUSSIAN -> "Показывать строку состояния"
-        AppLanguage.JAPANESE -> "ステータスバーを表示"
-        AppLanguage.KOREAN -> "상태 표시줄 표시"
+        AppLanguage.CHINESE -> "状态栏常驻"
+        AppLanguage.ENGLISH -> "Always show status bar"
+        AppLanguage.ARABIC -> "إبقاء شريط الحالة ظاهرًا دائمًا"
+        AppLanguage.PORTUGUESE -> "Manter barra de status sempre visível"
+        AppLanguage.SPANISH -> "Mantener siempre visible la barra de estado"
+        AppLanguage.FRENCH -> "Toujours afficher la barre d'état"
+        AppLanguage.GERMAN -> "Statusleiste immer anzeigen"
+        AppLanguage.RUSSIAN -> "Всегда показывать строку состояния"
+        AppLanguage.JAPANESE -> "ステータスバーを常に表示"
+        AppLanguage.KOREAN -> "상태 표시줄 항상 표시"
     }
 
     val showStatusBarHint: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "全屏时保留顶部状态栏，网页内容从状态栏下方开始排布"
-        AppLanguage.ENGLISH -> "Keep the status bar visible in fullscreen; page content starts below it"
-        AppLanguage.ARABIC -> "إبقاء شريط الحالة مرئيًا في ملء الشاشة؛ يبدأ محتوى الصفحة أسفله"
-        AppLanguage.PORTUGUESE -> "Manter a barra de status visível em tela cheia; o conteúdo começa abaixo dela"
-        AppLanguage.SPANISH -> "Mantener visible la barra de estado en pantalla completa; el contenido empieza debajo"
-        AppLanguage.FRENCH -> "Garder la barre d'état visible en plein écran ; le contenu commence en dessous"
-        AppLanguage.GERMAN -> "Statusleiste im Vollbildmodus behalten; der Inhalt beginnt darunter"
-        AppLanguage.RUSSIAN -> "Оставлять строку состояния видимой в полноэкранном режиме; контент начинается под ней"
-        AppLanguage.JAPANESE -> "全画面でもステータスバーを表示し、ページ内容はその下から配置"
-        AppLanguage.KOREAN -> "전체 화면에서도 상태 표시줄을 유지하고 페이지 콘텐츠는 그 아래부터 배치"
+        AppLanguage.CHINESE -> "全屏时状态栏始终显示，不会自动隐藏"
+        AppLanguage.ENGLISH -> "Status bar stays visible in fullscreen and never auto-hides"
+        AppLanguage.ARABIC -> "يبقى شريط الحالة ظاهرًا في ملء الشاشة ولا يختفي تلقائيًا"
+        AppLanguage.PORTUGUESE -> "A barra de status permanece visível em tela cheia e nunca se oculta sozinha"
+        AppLanguage.SPANISH -> "La barra de estado permanece visible en pantalla completa y nunca se oculta sola"
+        AppLanguage.FRENCH -> "La barre d'état reste visible en plein écran et ne se masque jamais toute seule"
+        AppLanguage.GERMAN -> "Die Statusleiste bleibt im Vollbildmodus sichtbar und blendet sich nie automatisch aus"
+        AppLanguage.RUSSIAN -> "Строка состояния остаётся видимой в полноэкранном режиме и никогда не скрывается сама"
+        AppLanguage.JAPANESE -> "全画面でもステータスバーは表示されたままになり、自動では隠れません"
+        AppLanguage.KOREAN -> "전체 화면에서도 상태 표시줄이 계속 표시되며 자동으로 숨겨지지 않습니다"
     }
 
     val showNavigationBar: String get() = when (Strings.lang) {
@@ -34389,17 +34389,17 @@ object StringsC {
         AppLanguage.KOREAN -> "전체 화면 여백: 모서리 버튼이 쉬워지고 가장자리 제스처 충돌 감소"
     }
 
-    val statusBarStyleConfigLabel: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "状态栏样式配置"
-        AppLanguage.ENGLISH -> "Status Bar Style Config"
-        AppLanguage.ARABIC -> "إعدادات نمط شريط الحالة"
-        AppLanguage.PORTUGUESE -> "Configuração de Estilo da Barra de Status"
-        AppLanguage.SPANISH -> "Configuración de Estilo de la Barra de Estado"
-        AppLanguage.FRENCH -> "Configuration du Style de la Barre d'État"
-        AppLanguage.GERMAN -> "Konfiguration des Statusleistenstils"
-        AppLanguage.RUSSIAN -> "Настройка стиля строки состояния"
-        AppLanguage.JAPANESE -> "ステータスバースタイル設定"
-        AppLanguage.KOREAN -> "상태 표시줄 스타일 설정"
+    val statusBarCustomizeLabel: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "状态栏自定义"
+        AppLanguage.ENGLISH -> "Customize status bar"
+        AppLanguage.ARABIC -> "تخصيص شريط الحالة"
+        AppLanguage.PORTUGUESE -> "Personalizar barra de status"
+        AppLanguage.SPANISH -> "Personalizar barra de estado"
+        AppLanguage.FRENCH -> "Personnaliser la barre d'état"
+        AppLanguage.GERMAN -> "Statusleiste anpassen"
+        AppLanguage.RUSSIAN -> "Настроить строку состояния"
+        AppLanguage.JAPANESE -> "ステータスバーをカスタマイズ"
+        AppLanguage.KOREAN -> "상태 표시줄 사용자 설정"
     }
 
     val statusBarLightModeLabel: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -2314,7 +2314,7 @@ fun FullscreenModeCard(
                         WtaSectionDivider()
 
                         WtaChoiceRow(
-                            title = Strings.statusBarStyleConfigLabel,
+                            title = Strings.statusBarCustomizeLabel,
                             icon = Icons.Outlined.Tune,
                             value = if (statusBarConfigExpanded) Strings.collapse else Strings.expand,
                             isExpanded = statusBarConfigExpanded,

--- a/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
@@ -182,21 +182,30 @@ object WindowHelper {
                         controller.hide(WindowInsetsCompat.Type.statusBars())
                     }
 
+                    // Issue #771: a shown status bar must stay (BEHAVIOR_DEFAULT).
+                    // Transient bars auto-hide seconds after appearing, which is
+                    // why "show status bar" never stayed until swiped back.
+                    // Hidden paths keep the transient swipe-to-peek behavior.
+                    val barsBehavior = if (shouldShowStatusBar) {
+                        WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+                    } else {
+                        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                    }
+
                     if (hideNavBar) {
                         controller.hide(WindowInsetsCompat.Type.navigationBars())
-                        controller.systemBarsBehavior =
-                            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                     } else {
                         controller.show(WindowInsetsCompat.Type.navigationBars())
-                        controller.systemBarsBehavior =
-                            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                     }
+                    controller.systemBarsBehavior = barsBehavior
                 } else {
                     decorFitsSystemWindows = classicKeyboardResize
                     WindowCompat.setDecorFitsSystemWindows(activity.window, classicKeyboardResize)
                     controller.show(WindowInsetsCompat.Type.systemBars())
+                    // Non-fullscreen bars are permanently shown chrome: default
+                    // behavior, never transient auto-hide (issue #771).
                     controller.systemBarsBehavior =
-                        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                        WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
                     if (!classicKeyboardResize) {
                         activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
                     }

--- a/app/src/main/java/com/webtoapp/ui/shell/MultiWebShellMode.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/MultiWebShellMode.kt
@@ -230,9 +230,16 @@ private fun TabsMode(
     ) { padding ->
         // 全屏模式下可选的内容内边距，与单站点 ShellScaffoldLayout 行为一致：
         // 把网页交互区从屏幕边缘内移，让角落按钮易于点按，并缓解与系统返回手势边缘带的冲突。
+        // Issue #771: transparent/image 状态栏覆盖在内容上（常驻微信式），顶部不预留；
+        // 实色栏保留预留，避免遮挡页面顶部控件。
         val contentPad = webViewConfig.fullscreenContentPaddingDp.dp
+        val multiDark = androidx.compose.foundation.isSystemInDarkTheme()
+        val multiBgType = if (multiDark) webViewConfig.statusBarBackgroundTypeDark else webViewConfig.statusBarBackgroundType
+        val multiMode = if (multiDark) webViewConfig.statusBarColorModeDark else webViewConfig.statusBarColorMode
+        val multiOverlaysContent = multiBgType == com.webtoapp.data.model.StatusBarBackgroundType.IMAGE ||
+            multiMode == com.webtoapp.data.model.StatusBarColorMode.TRANSPARENT
         val topPad = if (webViewConfig.hideToolbar && webViewConfig.showStatusBarInFullscreen) {
-            WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+            if (multiOverlaysContent) 0.dp else WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
         } else {
             contentPad
         }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -191,6 +191,15 @@ fun BoxScope.ShellScaffoldLayout(
         // 同时缓解与系统返回手势边缘带的冲突。默认 0 → 向后兼容旧行为。
         val contentPad = config.webViewConfig.fullscreenContentPaddingDp.dp
 
+        // Issue #771: transparent/image bars overlay the content (persistent
+        // WeChat-style bar) instead of reserving a strip; solid bars keep the
+        // reservation so page controls stay clear of the status icons.
+        val shellDark = androidx.compose.foundation.isSystemInDarkTheme()
+        val shellBgType = if (shellDark) config.webViewConfig.statusBarBackgroundTypeDark else config.webViewConfig.statusBarBackgroundType
+        val shellMode = if (shellDark) config.webViewConfig.statusBarColorModeDark else config.webViewConfig.statusBarColorMode
+        val shellOverlaysContent = shellBgType == "IMAGE" ||
+            shellMode == com.webtoapp.data.model.StatusBarColorMode.TRANSPARENT.name
+
         val contentModifier = when {
             hideToolbar && showToolbar -> {
 
@@ -199,7 +208,7 @@ fun BoxScope.ShellScaffoldLayout(
             hideToolbar && config.webViewConfig.showStatusBarInFullscreen -> {
 
                 Modifier.fillMaxSize().padding(
-                    top = actualStatusBarPadding,
+                    top = if (shellOverlaysContent) 0.dp else actualStatusBarPadding,
                     start = contentPad,
                     end = contentPad,
                     bottom = contentPad

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -3009,6 +3009,15 @@ fun WebViewScreen(
 
         val actualStatusBarPadding = if (statusBarHeightDp >= 0) statusBarHeightDp.dp else systemStatusBarHeightDp
 
+        // Issue #771: transparent/image bars overlay the content instead of
+        // reserving a strip (WeChat-style persistent bar); solid bars keep the
+        // reservation so page controls stay clear of the status icons.
+        val previewDark = com.webtoapp.ui.theme.LocalIsDarkTheme.current
+        val effBgType = if (previewDark) statusBarBackgroundTypeDarkLocal else statusBarBackgroundType
+        val effMode = if (previewDark) webApp?.webViewConfig?.statusBarColorModeDark else webApp?.webViewConfig?.statusBarColorMode
+        val barOverlaysContent = effBgType == "IMAGE" ||
+            effMode == com.webtoapp.data.model.StatusBarColorMode.TRANSPARENT
+
         // Fullscreen content padding mirrors the exported shell (ShellScaffoldLayout):
         // reserve the status-bar height on top when the bar is shown, pad the
         // remaining edges so corner controls stay tappable. Preview used to ignore
@@ -3023,7 +3032,7 @@ fun WebViewScreen(
             hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true -> {
 
                 Modifier.fillMaxSize().padding(
-                    top = actualStatusBarPadding,
+                    top = if (barOverlaysContent) 0.dp else actualStatusBarPadding,
                     start = contentPad,
                     end = contentPad,
                     bottom = contentPad


### PR DESCRIPTION
Fixes #771

## Summary
Splits the conflated Show-status-bar toggle into Persistent (lifecycle) + Customize (appearance), makes the shown bar actually stay, and lets transparent/image bars overlay content WeChat-style. Field names untouched (zero migration); UI text-only rename.

## What / Why
- UI: Show status bar -> Always-show/persistent wording (10 locales); style section -> Customize status bar; old style-config label key removed.
- Behavior (`WindowHelper`): fullscreen + bar shown -> `BEHAVIOR_DEFAULT` (persistent; transient auto-hide was why the bar vanished seconds after appearing). Hidden paths keep transient swipe-to-peek; non-fullscreen (permanently shown chrome) also DEFAULT.
- Layout (preview + single/multi-web shell, kept in parity): TRANSPARENT/IMAGE bars draw content underneath (overlay look); solid bars keep reserving the height so page controls stay clear.
- Known accepted trade-off: with the bar persistent, a hidden nav bar revealed by swipe stays until next apply (single controller-level behavior).

## Test plan
- [x] Host + shell compile green; full unit suite green (991); config drift green
- [ ] Android CI `check` green
- [ ] Emulator: fullscreen+persistent on TRANSPARENT (content under bar, stays) and CUSTOM solid (reserved strip, stays)