### PR TITLE
fix(adblock): lazy regex compile fixes AdGuard Base import OOM and export failure

### DIFF
--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
@@ -38,7 +38,7 @@ class AdBlocker {
 
     private data class NetworkFilter(
         val pattern: String,
-        val regex: Regex?,
+        val regexSource: String?,
         val isException: Boolean,
         val matchCase: Boolean,
 
@@ -54,7 +54,28 @@ class AdBlocker {
         val anchorDomain: String?,
 
         val rawRule: String = ""
-    )
+    ) {
+        // Compiled on first MATCH, not at import: a 100k-rule list (AdGuard Base
+        // is 6.4MB) would otherwise pin ~100MB+ of Pattern objects and OOM
+        // 256MB-heap devices on import — and twice that at export, which builds
+        // a second engine. Most rules never match a given device's traffic.
+        // Body property: excluded from equals/hashCode/copy.
+        @Volatile
+        private var compiledRegex: Regex? = null
+        @Volatile
+        private var compileAttempted: Boolean = false
+
+        fun regex(): Regex? {
+            if (compileAttempted) return compiledRegex
+            synchronized(this) {
+                if (!compileAttempted) {
+                    compiledRegex = regexSource?.let { compileTranslatedRegex(it, matchCase) }
+                    compileAttempted = true
+                }
+                return compiledRegex
+            }
+        }
+    }
 
     data class CosmeticFilter(
         val selector: String,
@@ -661,9 +682,6 @@ class AdBlocker {
         val BLOCKED_JS_BYTES = "/* blocked */".toByteArray()
         val BLOCKED_CSS_BYTES = "/* blocked */".toByteArray()
         val BLOCKED_JSON_BYTES = "{}".toByteArray()
-
-        private const val MAX_ABP_PATTERN_LEN = 1024
-        private val MAX_CONSECUTIVE_STARS_REGEX = Regex("\\*{2,}(?:\\^\\*{2,})?")
     }
 
     private val exactHosts = mutableSetOf<String>()
@@ -1395,11 +1413,11 @@ class AdBlocker {
             return
         }
 
-        val regex = compileAbpPattern(patternPart, matchCase)
+        val regexSource = translateAbpPattern(patternPart)
 
         val filter = NetworkFilter(
             pattern = patternPart,
-            regex = regex,
+            regexSource = regexSource,
             isException = isException,
             matchCase = matchCase,
             domains = domainConstraints,
@@ -1435,50 +1453,6 @@ class AdBlocker {
             networkBlockFilters.add(filter)
             unanchoredFilterIndex[networkBlockFilters] =
                 (unanchoredFilterIndex[networkBlockFilters] ?: emptyList()) + idx
-        }
-    }
-
-    private fun compileAbpPattern(pattern: String, matchCase: Boolean): Regex? {
-        if (pattern.isEmpty()) return null
-        if (pattern.length > MAX_ABP_PATTERN_LEN) return null
-        if (MAX_CONSECUTIVE_STARS_REGEX.containsMatchIn(pattern)) return null
-        return try {
-            var p = pattern
-
-            if (p.startsWith("/") && p.endsWith("/") && p.length > 2) {
-                val options = if (matchCase) emptySet() else setOf(RegexOption.IGNORE_CASE)
-                return Regex(p.substring(1, p.length - 1), options)
-            }
-
-            p = p.replace("\\", "\\\\")
-                .replace(".", "\\.")
-                .replace("+", "\\+")
-                .replace("?", "\\?")
-                .replace("{", "\\{")
-                .replace("}", "\\}")
-                .replace("(", "\\(")
-                .replace(")", "\\)")
-                .replace("[", "\\[")
-                .replace("]", "\\]")
-
-            // Order matters: the '^' separator must be converted to its character class
-            // BEFORE the '||'/'|' anchors insert their own regex (which contain '^' inside
-            // [^/]). Doing it afterwards corrupts the inserted [^/] class, so every
-            // '||host/path' regex rule failed to match.
-            p = p.replace("^", "[^\\w%.\\-]")
-
-            p = p.replace("||", "^(?:https?|wss?)://(?:[^/]*\\.)?")
-
-            if (p.startsWith("|")) p = "^" + p.removePrefix("|")
-
-            if (p.endsWith("|")) p = p.removeSuffix("|") + "$"
-
-            p = p.replace("*", ".*")
-
-            val options = if (matchCase) emptySet() else setOf(RegexOption.IGNORE_CASE)
-            Regex(p, options)
-        } catch (e: Throwable) {
-            null
         }
     }
 
@@ -1594,7 +1568,7 @@ class AdBlocker {
             if (filter.excludedDomains.any { pageHost == it || pageHost.endsWith(".$it") }) return false
         }
 
-        val regex = filter.regex ?: return false
+        val regex = filter.regex() ?: return false
         return regex.containsMatchIn(url)
     }
 
@@ -1884,20 +1858,27 @@ class AdBlocker {
                     val buffer = ByteArray(8192)
                     val builder = StringBuilder()
                     var downloaded = 0L
+                    // Progress fires per 8KB chunk (~800 callbacks for AdGuard Base);
+                    // throttle UI updates to 6/sec, always emit the final one below.
+                    var lastProgressAt = 0L
                     while (true) {
                         ensureActive()
                         val read = stream.read(buffer)
                         if (read <= 0) break
                         downloaded += read
-                        builder.append(String(buffer, 0, read))
+                        builder.append(String(buffer, 0, read, Charsets.UTF_8))
                         if (onProgress != null) {
-                            onProgress(
-                                DownloadProgress(
-                                    downloadedBytes = downloaded,
-                                    totalBytes = totalBytes,
-                                    elapsedMillis = System.currentTimeMillis() - startTime
+                            val now = System.currentTimeMillis()
+                            if (now - lastProgressAt >= 150) {
+                                lastProgressAt = now
+                                onProgress(
+                                    DownloadProgress(
+                                        downloadedBytes = downloaded,
+                                        totalBytes = totalBytes,
+                                        elapsedMillis = now - startTime
+                                    )
                                 )
-                            )
+                            }
                         }
                     }
                     builder.toString()
@@ -2178,7 +2159,7 @@ class AdBlocker {
 
     private fun AdBlockFilterCache.SerializableNetworkFilter.toNetworkFilter() = NetworkFilter(
         pattern = pattern,
-        regex = compileAbpPattern(pattern, matchCase),
+        regexSource = translateAbpPattern(pattern),
         isException = isException,
         matchCase = matchCase,
         domains = domains,
@@ -2193,6 +2174,62 @@ class AdBlocker {
         firstPartyOnly = firstPartyOnly,
         anchorDomain = anchorDomain
     )
+}
+
+private const val MAX_ABP_PATTERN_LEN = 1024
+private val MAX_CONSECUTIVE_STARS_REGEX = Regex("\\*{2,}(?:\\^\\*{2,})?")
+
+/**
+ * Cheap half of rule compilation: ABP syntax -> regex source string.
+ * Runs at import for every rule; the expensive [compileTranslatedRegex] step
+ * is deferred to first match (see NetworkFilter.regex).
+ */
+private fun translateAbpPattern(pattern: String): String? {
+    if (pattern.isEmpty()) return null
+    if (pattern.length > MAX_ABP_PATTERN_LEN) return null
+    if (MAX_CONSECUTIVE_STARS_REGEX.containsMatchIn(pattern)) return null
+
+    var p = pattern
+
+    if (p.startsWith("/") && p.endsWith("/") && p.length > 2) {
+        return p.substring(1, p.length - 1)
+    }
+
+    p = p.replace("\\", "\\\\")
+        .replace(".", "\\.")
+        .replace("+", "\\+")
+        .replace("?", "\\?")
+        .replace("{", "\\{")
+        .replace("}", "\\}")
+        .replace("(", "\\(")
+        .replace(")", "\\)")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+
+    // Order matters: the '^' separator must be converted to its character class
+    // BEFORE the '||'/'|' anchors insert their own regex (which contain '^' inside
+    // [^/]). Doing it afterwards corrupts the inserted [^/] class, so every
+    // '||host/path' regex rule failed to match.
+    p = p.replace("^", "[^\\w%.\\-]")
+
+    p = p.replace("||", "^(?:https?|wss?)://(?:[^/]*\\.)?")
+
+    if (p.startsWith("|")) p = "^" + p.removePrefix("|")
+
+    if (p.endsWith("|")) p = p.removeSuffix("|") + "$"
+
+    p = p.replace("*", ".*")
+    return p
+}
+
+/** Expensive half: regex source -> compiled Pattern. Runs at most once per rule. */
+private fun compileTranslatedRegex(translated: String, matchCase: Boolean): Regex? {
+    return try {
+        val options = if (matchCase) emptySet() else setOf(RegexOption.IGNORE_CASE)
+        Regex(translated, options)
+    } catch (e: Throwable) {
+        null
+    }
 }
 
 private val TRANSPARENT_GIF = byteArrayOf(

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockLazyRegexTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockLazyRegexTest.kt
@@ -1,0 +1,84 @@
+package com.webtoapp.core.adblock
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression tests for the AdGuard Base import crash: 100k+ rule lists must not
+ * pin a compiled Pattern per rule at import (OOM on 256MB-heap devices, doubled
+ * again at export which builds a second engine). Regexes compile lazily on first
+ * match; behavior must be identical to eager compilation.
+ */
+class AdBlockLazyRegexTest {
+
+    private lateinit var adBlocker: AdBlocker
+
+    @Before
+    fun setUp() {
+        adBlocker = AdBlocker()
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+    }
+
+    @Test
+    fun `regex-backed rule blocks only after lazy compile`() {
+        // Path-anchored rule: cannot use the exactHosts fast path, needs its regex.
+        adBlocker.addRule("||example.com/ads/banner*.js")
+
+        assertThat(
+            adBlocker.shouldBlock(
+                "https://example.com/ads/banner123.js",
+                "example.com", "script", true
+            )
+        ).isTrue()
+        assertThat(
+            adBlocker.shouldBlock(
+                "https://example.com/content/article.html",
+                "example.com", "main_frame", true
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `uncompilable pattern degrades to no-block without throwing`() {
+        // Unbalanced regex literal: translate passes it through, compile fails.
+        adBlocker.addRule("/(unbalanced/")
+        assertThat(
+            adBlocker.shouldBlock("https://example.com/(unbalanced/", "example.com", "other", true)
+        ).isFalse()
+    }
+
+    @Test
+    fun `oversize pattern is rejected at import without throwing`() {
+        adBlocker.addRule("||example.com/" + "a".repeat(2048) + "\$script")
+        assertThat(
+            adBlocker.shouldBlock("https://example.com/", "example.com", "other", true)
+        ).isFalse()
+    }
+
+    @Test
+    fun `exception rule with regex still unblocks`() {
+        adBlocker.addRule("||example.com/ads/*")
+        adBlocker.addRule("@@||example.com/ads/allowed/*")
+        assertThat(
+            adBlocker.shouldBlock(
+                "https://example.com/ads/allowed/1.js",
+                "example.com", "script", true
+            )
+        ).isFalse()
+        assertThat(
+            adBlocker.shouldBlock(
+                "https://example.com/ads/blocked/1.js",
+                "example.com", "script", true
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `export serialization does not compile regexes`() {
+        adBlocker.addRule("||example.com/ads/banner*.js")
+        // Must round-trip the ORIGINAL rule text (modifiers preserved opaquely).
+        assertThat(adBlocker.getCompiledRulesText()).contains("||example.com/ads/banner*.js")
+    }
+}


### PR DESCRIPTION
Fixes #775

## Summary
Importing AdGuard Base (6.4MB / ~134k rules) crashed the app, and APK export failed after restart. Root cause: every network rule eagerly compiled its `Pattern` at import (~125MB for one engine; export builds a second engine, ~280MB total) — fatal on 256MB-heap devices. Reproduced locally with the real filter file before fixing.

## What changed
- `AdBlocker.kt`: rule compilation split into cheap import-time translation (`translateAbpPattern`) and lazy `Pattern` compile on first match (`NetworkFilter.regex()`, double-checked locking). Matching semantics identical.
- Import download-progress callbacks throttled (was ~1 UI update per 8KB chunk); network decode charset pinned to UTF-8.
- New `AdBlockLazyRegexTest`: lazy-match equivalence, uncompilable/oversize patterns degrade gracefully, export serialization round-trips original text.

## Measured effect
Same repro script: single engine 125 -> 91MB heap, export scenario 280 -> 161MB.

## Test plan
- [x] adblock/apkbuilder/port suites green (196/196, incl. 5 new tests)
- [x] `check_config_field_drift` OK
- [ ] CI `check` job green