### PR TITLE
feat(webview): in-app proxy fallback for WebViews without PROXY_OVERRIDE

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/LegacyProxyFetchBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/LegacyProxyFetchBridge.kt
@@ -1,0 +1,389 @@
+package com.webtoapp.core.webview
+
+import android.webkit.CookieManager
+import android.webkit.WebResourceResponse
+import com.webtoapp.core.logging.AppLogger
+import okhttp3.Authenticator
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.Credentials
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.ByteArrayInputStream
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.util.concurrent.TimeUnit
+
+/**
+ * Fallback proxy path for devices whose system WebView predates PROXY_OVERRIDE
+ * (WebView provider < 67, e.g. frozen Android 7.x boxes without Play updates).
+ *
+ * AndroidX WebKit is only a shim: [androidx.webkit.ProxyController] silently does
+ * nothing there, so [PacProxyManager] arms this bridge instead and WebView traffic
+ * is fetched through OkHttp with the same proxy settings. Anything that cannot go
+ * through [shouldInterceptRequest] (WebSocket, WebRTC, plugins) still connects
+ * directly — an documented downgrade, not a full tunnel.
+ *
+ * Fail-closed by design: when a proxy is configured, fetch failures return HTTP
+ * 502 instead of falling back to a direct connection, so a dead proxy can never
+ * silently leak the real IP. Only bypass-listed hosts and non-http(s) schemes
+ * return null (let WebView handle them).
+ *
+ * Runs on Chromium's IO thread; all blocking calls below are safe there.
+ * Shell-synced: used by generated APKs, reads no host-only state.
+ */
+object LegacyProxyFetchBridge {
+
+    private const val TAG = "LegacyProxyFetch"
+
+    private const val CONNECT_TIMEOUT_MS = 15_000L
+    private const val READ_TIMEOUT_MS = 30_000L
+    private const val WRITE_TIMEOUT_MS = 30_000L
+
+    private const val FAIL_LOG_THROTTLE_MS = 10_000L
+
+    enum class Kind { HTTP, SOCKS, BROKEN }
+
+    /**
+     * @param kind HTTP/HTTPS-forward proxy or SOCKS5. BROKEN marks a configured
+     * proxy OkHttp cannot speak (e.g. HTTPS upstream): every request fail-closes.
+     */
+    data class Spec(
+        val kind: Kind,
+        val host: String = "",
+        val port: Int = 0,
+        val username: String = "",
+        val password: String = "",
+        val bypassRules: List<String> = emptyList()
+    )
+
+    /** Hosts that must never be proxied: local runtimes and bridges live here. */
+    private val ALWAYS_BYPASS = setOf("localhost", "127.0.0.1", "[::1]", "::1", "10.0.2.2")
+
+    /** Hop-by-hop / framing headers OkHttp owns; forwarding them corrupts the exchange. */
+    private val STRIP_REQUEST_HEADERS = setOf(
+        "host", "connection", "keep-alive", "proxy-authorization",
+        "transfer-encoding", "content-length", "upgrade", "trailer"
+    )
+
+    @Volatile
+    private var spec: Spec? = null
+
+    private val lock = Any()
+    private var client: OkHttpClient? = null
+    private var clientSpec: Spec? = null
+
+    @Volatile
+    private var lastFailLogAt = 0L
+    @Volatile
+    private var lastPostLogAt = 0L
+
+    fun configure(newSpec: Spec?) {
+        spec = newSpec
+        if (newSpec == null) {
+            synchronized(lock) {
+                client?.dispatcher?.executorService?.shutdown()
+                client?.connectionPool?.evictAll()
+                client = null
+                clientSpec = null
+            }
+            AppLogger.d(TAG, "Legacy proxy fallback cleared")
+        } else {
+            AppLogger.i(TAG, "Legacy proxy fallback armed: ${newSpec.kind} ${newSpec.host}:${newSpec.port}")
+        }
+    }
+
+    fun clear() = configure(null)
+
+    fun isArmed(): Boolean = spec != null
+
+    /**
+     * Resolve STATIC settings to a [Spec]. Returns null when there is nothing to
+     * do (mode NONE / DIRECT intent). HTTPS upstream proxies cannot be spoken by
+     * OkHttp 4 and resolve to [Kind.BROKEN] (fail-closed) instead of null.
+     */
+    fun resolveStatic(
+        mode: String,
+        host: String,
+        port: Int,
+        type: String,
+        bypassRules: List<String>,
+        username: String,
+        password: String
+    ): Spec? {
+        if (mode.equals("NONE", ignoreCase = true)) return null
+        if (!mode.equals("STATIC", ignoreCase = true)) return null
+        if (host.isBlank() || port <= 0) {
+            AppLogger.w(TAG, "Legacy proxy: invalid static endpoint, staying direct")
+            return null
+        }
+        return when (type.uppercase()) {
+            "SOCKS5", "SOCKS" -> Spec(Kind.SOCKS, host, port, username, password, bypassRules)
+            "HTTPS" -> {
+                AppLogger.w(TAG, "Legacy proxy: HTTPS upstream unsupported, failing closed")
+                Spec(Kind.BROKEN, host, port, username, password, bypassRules)
+            }
+            else -> Spec(Kind.HTTP, host, port, username, password, bypassRules)
+        }
+    }
+
+    /**
+     * Resolve already-parsed PAC entries (same extraction as [PacProxyManager])
+     * to a single [Spec]. Only the first usable entry is honored; multi-proxy
+     * PAC failover lists degrade to primary-only on this path.
+     */
+    fun resolvePacEntries(
+        entries: List<String>,
+        bypassRules: List<String>,
+        username: String,
+        password: String
+    ): Spec? {
+        for (entry in entries) {
+            val trimmed = entry.trim()
+            when {
+                trimmed.equals("DIRECT", ignoreCase = true) -> return null
+                trimmed.startsWith("SOCKS5 ", ignoreCase = true) ||
+                    trimmed.startsWith("SOCKS ", ignoreCase = true) -> {
+                    val server = trimmed.substringAfter(" ").trim()
+                    val (h, p) = splitHostPort(server) ?: continue
+                    return Spec(Kind.SOCKS, h, p, username, password, bypassRules)
+                }
+                trimmed.startsWith("HTTPS ", ignoreCase = true) -> {
+                    AppLogger.w(TAG, "Legacy proxy: HTTPS PAC entry unsupported, failing closed")
+                    val server = trimmed.substringAfter(" ").trim()
+                    val (h, p) = splitHostPort(server) ?: return Spec(
+                        Kind.BROKEN, "", 0, username, password, bypassRules
+                    )
+                    return Spec(Kind.BROKEN, h, p, username, password, bypassRules)
+                }
+                trimmed.startsWith("PROXY ", ignoreCase = true) -> {
+                    val server = trimmed.substringAfter(" ").trim()
+                    val (h, p) = splitHostPort(server) ?: continue
+                    return Spec(Kind.HTTP, h, p, username, password, bypassRules)
+                }
+                trimmed.isNotBlank() -> {
+                    val (h, p) = splitHostPort(trimmed) ?: continue
+                    return Spec(Kind.HTTP, h, p, username, password, bypassRules)
+                }
+            }
+        }
+        return null
+    }
+
+    fun splitHostPort(server: String): Pair<String, Int>? {
+        val idx = server.lastIndexOf(':')
+        if (idx <= 0) return null
+        val port = server.substring(idx + 1).toIntOrNull() ?: return null
+        val host = server.substring(0, idx).trim().trim('[', ']')
+        if (host.isEmpty() || port <= 0) return null
+        return host to port
+    }
+
+    fun isBypassed(urlHost: String?, bypassRules: List<String>): Boolean {
+        val host = urlHost?.trim()?.lowercase()?.trim('[', ']') ?: return true
+        if (host.isEmpty()) return true
+        if (host in ALWAYS_BYPASS) return true
+        for (raw in bypassRules) {
+            val rule = raw.trim().lowercase().trim('[', ']')
+            if (rule.isEmpty()) continue
+            if (rule == "*") return true
+            if (rule.startsWith("*.")) {
+                val suffix = rule.removePrefix("*")
+                if (host.endsWith(suffix)) return true
+            } else if (rule.startsWith(".")) {
+                if (host.endsWith(rule)) return true
+            } else if (host == rule) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Fetch [url] through the armed proxy. Returns null when the fallback does
+     * not apply (disarmed, bypassed host, non-http(s) scheme) so the caller falls
+     * through to normal loading; returns a 502 response on fetch failure so a
+     * dead proxy can never silently downgrade to direct.
+     */
+    fun intercept(url: String, method: String?, requestHeaders: Map<String, String>): WebResourceResponse? {
+        val active = spec ?: return null
+        if (!url.startsWith("http://", ignoreCase = true) &&
+            !url.startsWith("https://", ignoreCase = true)
+        ) return null
+
+        val targetHost = try {
+            android.net.Uri.parse(url).host
+        } catch (_: Exception) {
+            null
+        }
+        if (isBypassed(targetHost, active.bypassRules)) return null
+
+        if (active.kind == Kind.BROKEN) {
+            throttledFailLog("proxy type unsupported on this path, failing closed: $url")
+            return errorResponse(502, "Bad Gateway")
+        }
+
+        val httpMethod = (method ?: "GET").uppercase()
+        if (httpMethod == "POST" || httpMethod == "PUT" || httpMethod == "PATCH") {
+            throttledPostLog(url)
+        }
+
+        return try {
+            val httpUrl = url.toHttpUrlOrNull() ?: return null
+            val builder = Request.Builder().url(httpUrl)
+            for ((k, v) in requestHeaders) {
+                if (k.lowercase() in STRIP_REQUEST_HEADERS) continue
+                if (k.equals("cookie", ignoreCase = true)) continue
+                try {
+                    builder.header(k, v)
+                } catch (_: Exception) {
+                }
+            }
+            val body = if (httpMethod == "GET" || httpMethod == "HEAD") {
+                null
+            } else {
+                // shouldInterceptRequest exposes no request body; forward the
+                // method/headers/cookies without one (privacy over fidelity).
+                ByteArray(0).toRequestBody(null)
+            }
+            builder.method(httpMethod, body)
+
+            val okClient = clientFor(active)
+            val response = okClient.newCall(builder.build()).execute()
+            // NOTE: no .use{} here — the body stream is handed to WebView, which
+            // owns (and closes) it. Closing the response here would close the
+            // stream out from under the renderer.
+            try {
+                val code = response.code
+                val message = response.message.ifBlank { if (code < 400) "OK" else "Error" }
+                val respHeaders = LinkedHashMap<String, String>()
+                for (name in response.headers.names()) {
+                    // OkHttp already consumed chunk framing; forwarding it would corrupt the body.
+                    if (name.equals("transfer-encoding", ignoreCase = true)) continue
+                    respHeaders[name] = response.headers.values(name).joinToString(", ")
+                }
+                val contentType = response.header("Content-Type") ?: "text/plain"
+                val mime = contentType.substringBefore(";").trim().ifEmpty { "text/plain" }
+                val charset = Regex("charset=([^;]+)", RegexOption.IGNORE_CASE)
+                    .find(contentType)?.groupValues?.get(1)?.trim()?.ifEmpty { null } ?: "utf-8"
+                val stream = try {
+                    response.body?.byteStream()
+                } catch (_: Exception) {
+                    null
+                } ?: ByteArrayInputStream(ByteArray(0))
+                WebResourceResponse(mime, charset, code, message, respHeaders, stream)
+            } catch (e: Exception) {
+                try {
+                    response.close()
+                } catch (_: Exception) {
+                }
+                throttledFailLog("response mapping failed, failing closed: ${url.take(120)} (${e.message})")
+                errorResponse(502, "Bad Gateway")
+            }
+        } catch (e: Exception) {
+            throttledFailLog("fetch failed, failing closed: ${url.take(120)} (${e.message})")
+            errorResponse(502, "Bad Gateway")
+        }
+    }
+
+    private fun errorResponse(code: Int, reason: String): WebResourceResponse {
+        return WebResourceResponse("text/plain", "UTF-8", code, reason, emptyMap(), ByteArrayInputStream(ByteArray(0)))
+    }
+
+    private fun clientFor(active: Spec): OkHttpClient {
+        synchronized(lock) {
+            val cached = client
+            if (cached != null && clientSpec == active) return cached
+            val proxyType = if (active.kind == Kind.SOCKS) Proxy.Type.SOCKS else Proxy.Type.HTTP
+            val proxyAddress = InetSocketAddress(active.host, active.port)
+            val user = active.username
+            val pass = active.password
+            val built = OkHttpClient.Builder()
+                .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .readTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .writeTimeout(WRITE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .proxy(Proxy(proxyType, proxyAddress))
+                .proxyAuthenticator(
+                    if (user.isNotBlank()) {
+                        Authenticator { _, response ->
+                            if (response.request.header("Proxy-Authorization") != null) {
+                                return@Authenticator null
+                            }
+                            response.request.newBuilder()
+                                .header("Proxy-Authorization", Credentials.basic(user, pass))
+                                .build()
+                        }
+                    } else {
+                        Authenticator.NONE
+                    }
+                )
+                .cookieJar(WebViewCookieJar())
+                .build()
+            client = built
+            clientSpec = active
+            return built
+        }
+    }
+
+    private fun throttledFailLog(msg: String) {
+        val now = System.currentTimeMillis()
+        if (now - lastFailLogAt >= FAIL_LOG_THROTTLE_MS) {
+            lastFailLogAt = now
+            AppLogger.w(TAG, msg)
+        } else {
+            AppLogger.d(TAG, msg)
+        }
+    }
+
+    private fun throttledPostLog(url: String) {
+        val now = System.currentTimeMillis()
+        if (now - lastPostLogAt >= FAIL_LOG_THROTTLE_MS) {
+            lastPostLogAt = now
+            AppLogger.w(TAG, "Forwarding $url without body (unavailable on this path)")
+        }
+    }
+
+    /**
+     * Bridges OkHttp's cookie jar to the WebView store so sessions survive
+     * redirects and subresource hops exactly as with direct loading.
+     */
+    internal class WebViewCookieJar : CookieJar {
+        override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+            val cm = try {
+                CookieManager.getInstance()
+            } catch (_: Exception) {
+                return
+            }
+            for (c in cookies) {
+                try {
+                    cm.setCookie(url.toString(), c.toString())
+                } catch (_: Exception) {
+                }
+            }
+            try {
+                cm.flush()
+            } catch (_: Exception) {
+            }
+        }
+
+        override fun loadForRequest(url: HttpUrl): List<Cookie> {
+            val header = try {
+                CookieManager.getInstance().getCookie(url.toString())
+            } catch (_: Exception) {
+                null
+            } ?: return emptyList()
+            return header.split(";").mapNotNull { part ->
+                val kv = part.trim()
+                if (kv.isEmpty() || !kv.contains("=")) return@mapNotNull null
+                try {
+                    Cookie.parse(url, kv)
+                } catch (_: Exception) {
+                    null
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/PacProxyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/PacProxyManager.kt
@@ -52,9 +52,13 @@ class PacProxyManager(private val context: Context) {
         password: String = ""
     ) {
         if (!isProxyOverrideSupported()) {
-            AppLogger.w(TAG, "PROXY_OVERRIDE not supported on this WebView version")
+            // Pre-67 WebView: ProxyController is a no-op. Arm the in-app fetch
+            // fallback (same settings) instead of silently doing nothing.
+            AppLogger.w(TAG, "PROXY_OVERRIDE not supported, arming legacy fetch fallback")
+            applyLegacyFallback(proxyMode, staticProxyHost, staticProxyPort, staticProxyType, pacUrl, bypassRules, username, password)
             return
         }
+        LegacyProxyFetchBridge.clear()
 
         currentProxyUsername = username
         currentProxyPassword = password
@@ -77,6 +81,7 @@ class PacProxyManager(private val context: Context) {
     }
 
     fun clearProxy() {
+        LegacyProxyFetchBridge.clear()
         if (!isProxyOverrideSupported()) return
 
         try {
@@ -261,6 +266,59 @@ class PacProxyManager(private val context: Context) {
             )
         } catch (e: Exception) {
             AppLogger.e(TAG, "Failed to apply PAC proxy", e)
+        }
+    }
+
+    /**
+     * Same settings as [applyProxy], routed to [LegacyProxyFetchBridge] for
+     * WebViews without PROXY_OVERRIDE. Reuses the PAC download/parse below so
+     * both paths resolve identical upstreams.
+     */
+    private suspend fun applyLegacyFallback(
+        proxyMode: String,
+        staticProxyHost: String,
+        staticProxyPort: Int,
+        staticProxyType: String,
+        pacUrl: String,
+        bypassRules: List<String>,
+        username: String,
+        password: String
+    ) {
+        when (proxyMode.uppercase()) {
+            "NONE" -> LegacyProxyFetchBridge.clear()
+            "STATIC" -> {
+                val spec = LegacyProxyFetchBridge.resolveStatic(
+                    mode = proxyMode,
+                    host = staticProxyHost,
+                    port = staticProxyPort,
+                    type = staticProxyType,
+                    bypassRules = bypassRules,
+                    username = username,
+                    password = password
+                )
+                LegacyProxyFetchBridge.configure(spec)
+            }
+            "PAC" -> {
+                if (pacUrl.isBlank()) {
+                    AppLogger.w(TAG, "Empty PAC URL")
+                    LegacyProxyFetchBridge.clear()
+                    return
+                }
+                val pacScript = downloadPacScript(pacUrl)
+                if (pacScript.isNullOrBlank()) {
+                    AppLogger.e(TAG, "Failed to download PAC script from: $pacUrl")
+                    LegacyProxyFetchBridge.clear()
+                    return
+                }
+                val entries = parsePacScript(pacScript)
+                LegacyProxyFetchBridge.configure(
+                    LegacyProxyFetchBridge.resolvePacEntries(entries, bypassRules, username, password)
+                )
+            }
+            else -> {
+                AppLogger.w(TAG, "Unknown proxy mode: $proxyMode, clearing proxy")
+                LegacyProxyFetchBridge.clear()
+            }
         }
     }
 

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1964,6 +1964,16 @@ class WebViewManager(
                             return adBlocker.createEmptyResponse(adResType)
                         }
                     }
+
+                    // Legacy proxy fallback for pre-PROXY_OVERRIDE WebViews: fetch via
+                    // the configured proxy in-app. Null when disarmed/bypassed/scheme
+                    // mismatch (normal loading continues); 502 on fetch failure so a
+                    // dead proxy fails closed instead of leaking direct.
+                    LegacyProxyFetchBridge.intercept(
+                        url = url,
+                        method = it.method,
+                        requestHeaders = it.requestHeaders ?: emptyMap()
+                    )?.let { proxied -> return proxied }
                 }
 
                 return super.shouldInterceptRequest(view, request)

--- a/app/src/test/java/com/webtoapp/core/webview/LegacyProxyFetchBridgeTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/LegacyProxyFetchBridgeTest.kt
@@ -1,0 +1,376 @@
+package com.webtoapp.core.webview
+
+import android.webkit.CookieManager
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayOutputStream
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+
+/**
+ * LegacyProxyFetchBridge: proves subresource traffic actually traverses the
+ * configured proxy on the fallback path (pre-PROXY_OVERRIDE WebViews).
+ */
+@RunWith(RobolectricTestRunner::class)
+class LegacyProxyFetchBridgeTest {
+
+    private var origin: ServerSocket? = null
+    private var originPort: Int = 0
+    private var originThread: Thread? = null
+
+    private var proxy: ServerSocket? = null
+    private var proxyPort: Int = 0
+    private var proxyThread: Thread? = null
+    private val lastProxyRequest = AtomicReference<ProxyCapture?>()
+    @Volatile
+    private var challengeAuth = false
+
+    data class ProxyCapture(
+        val method: String,
+        val uri: String,
+        val headers: Map<String, String>,
+        val body: ByteArray
+    )
+
+    @Before
+    fun setUp() {
+        LegacyProxyFetchBridge.clear()
+
+        origin = ServerSocket().also {
+            it.bind(InetSocketAddress("127.0.0.1", 0))
+            originPort = it.localPort
+        }
+        originThread = thread(isDaemon = true, name = "test-origin") {
+            try {
+                while (origin?.isClosed == false) {
+                    val sock = origin!!.accept()
+                    try {
+                        handleOriginConnection(sock)
+                    } catch (_: Exception) {
+                    } finally {
+                        try {
+                            sock.close()
+                        } catch (_: Exception) {
+                        }
+                    }
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        proxy = ServerSocket().also {
+            it.bind(InetSocketAddress("127.0.0.1", 0))
+            proxyPort = it.localPort
+        }
+        proxyThread = thread(isDaemon = true, name = "test-forward-proxy") {
+            try {
+                while (proxy?.isClosed == false) {
+                    val sock = proxy!!.accept()
+                    try {
+                        handleProxyConnection(sock)
+                    } catch (_: Exception) {
+                    } finally {
+                        try {
+                            sock.close()
+                        } catch (_: Exception) {
+                        }
+                    }
+                }
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        LegacyProxyFetchBridge.clear()
+        try {
+            proxy?.close()
+        } catch (_: Exception) {
+        }
+        try {
+            origin?.close()
+        } catch (_: Exception) {
+        }
+        proxyThread?.join(2000)
+        originThread?.join(2000)
+    }
+
+    private fun readHttpMessage(input: java.io.InputStream): Triple<String, Map<String, String>, ByteArray> {
+        val head = ByteArrayOutputStream()
+        var matched = 0
+        val crlfcrlf = byteArrayOf(13, 10, 13, 10)
+        while (true) {
+            val b = input.read()
+            if (b < 0) break
+            head.write(b)
+            matched = if (b == crlfcrlf[matched].toInt()) matched + 1 else 0
+            if (matched == 4) break
+            if (head.size() > 65536) break
+        }
+        val headText = head.toString(StandardCharsets.ISO_8859_1.name())
+        val lines = headText.split("\r\n")
+        val headers = LinkedHashMap<String, String>()
+        for (line in lines.drop(1)) {
+            if (line.isEmpty()) continue
+            val idx = line.indexOf(':')
+            if (idx > 0) headers[line.substring(0, idx).trim().lowercase()] = line.substring(idx + 1).trim()
+        }
+        val contentLength = headers["content-length"]?.toIntOrNull() ?: 0
+        val body = if (contentLength > 0) input.readNBytes(contentLength) else ByteArray(0)
+        return Triple(lines.firstOrNull() ?: "", headers, body)
+    }
+
+    private fun handleOriginConnection(sock: Socket) {
+        sock.soTimeout = 15000
+        val (requestLine, headers, body) = readHttpMessage(sock.getInputStream())
+        val parts = requestLine.split(" ")
+        val method = parts.getOrElse(0) { "" }
+        val path = parts.getOrElse(1) { "/" }.substringBefore("?")
+        val (statusExtra, respBody) = when (path) {
+            "/hello" -> listOf("X-Test: yes", "Set-Cookie: sess=abc123; Path=/") to "hello-world".toByteArray()
+            "/echo-cookie" -> emptyList<String>() to (headers["cookie"] ?: "none").toByteArray()
+            "/post" -> emptyList<String>() to "method=$method len=${body.size}".toByteArray()
+            else -> emptyList<String>() to "not-found".toByteArray()
+        }
+        val status = if (path == "/hello" || path == "/echo-cookie" || path == "/post") 200 else 404
+        val out = StringBuilder()
+        out.append("HTTP/1.1 $status ${if (status == 200) "OK" else "Not Found"}\r\n")
+        out.append("Content-Type: text/plain\r\n")
+        for (h in statusExtra) out.append("$h\r\n")
+        out.append("Content-Length: ${respBody.size}\r\nConnection: close\r\n\r\n")
+        sock.getOutputStream().write(out.toString().toByteArray(StandardCharsets.ISO_8859_1))
+        sock.getOutputStream().write(respBody)
+        sock.getOutputStream().flush()
+    }
+
+    private fun handleProxyConnection(sock: Socket) {
+        sock.soTimeout = 15000
+        val input = sock.getInputStream()
+        val (requestLine, headers, body) = readHttpMessage(input)
+        val parts = requestLine.split(" ")
+        val method = parts.getOrElse(0) { "" }
+        val uri = parts.getOrElse(1) { "" }
+        lastProxyRequest.set(ProxyCapture(method, uri, headers, body))
+
+        if (challengeAuth && !headers.containsKey("proxy-authorization")) {
+            // Real proxies challenge once with 407; OkHttp answers on retry.
+            val challenge = "HTTP/1.1 407 Proxy Authentication Required\r\n" +
+                "Proxy-Authenticate: Basic realm=\"test\"\r\n" +
+                "Content-Length: 0\r\nConnection: close\r\n\r\n"
+            sock.getOutputStream().write(challenge.toByteArray(StandardCharsets.ISO_8859_1))
+            sock.getOutputStream().flush()
+            return
+        }
+
+        // Forward absolute-form URI to the origin over a raw socket, relay raw bytes.
+        // Pseudo-host test.local routes to the loopback origin (which itself is
+        // always bypassed, so e2e tests address it through this alias).
+        val target = java.net.URI(uri)
+        val relayHost = if (target.host == "test.local") "127.0.0.1" else target.host
+        val targetPort = if (target.port > 0) target.port else 80
+        val path = (target.rawPath?.ifEmpty { "/" } ?: "/") +
+            (target.rawQuery?.let { "?$it" } ?: "")
+        Socket().use { upstream ->
+            upstream.connect(InetSocketAddress(relayHost, targetPort), 10000)
+            upstream.soTimeout = 15000
+            val out = StringBuilder()
+            out.append("$method $path HTTP/1.1\r\n")
+            out.append("Host: ${target.host}\r\n")
+            for ((k, v) in headers) {
+                if (k == "proxy-authorization" || k == "proxy-connection") continue
+                out.append("$k: $v\r\n")
+            }
+            out.append("Connection: close\r\n\r\n")
+            upstream.getOutputStream().write(out.toString().toByteArray(StandardCharsets.ISO_8859_1))
+            if (body.isNotEmpty()) upstream.getOutputStream().write(body)
+            upstream.getOutputStream().flush()
+            upstream.shutdownOutput()
+            upstream.getInputStream().copyTo(sock.getOutputStream())
+        }
+    }
+
+    private fun armHttp(
+        bypass: List<String> = emptyList(),
+        username: String = "",
+        password: String = ""
+    ) {
+        LegacyProxyFetchBridge.configure(
+            LegacyProxyFetchBridge.Spec(
+                kind = LegacyProxyFetchBridge.Kind.HTTP,
+                host = "127.0.0.1",
+                port = proxyPort,
+                username = username,
+                password = password,
+                bypassRules = bypass
+            )
+        )
+    }
+
+    private fun originUrl(path: String) = "http://127.0.0.1:$originPort$path"
+
+    /** E2E tests address the loopback origin through this alias (see proxy relay). */
+    private fun proxyTestUrl(path: String) = "http://test.local:$originPort$path"
+
+    @Test(timeout = 30000)
+    fun `disarmed bridge returns null`() {
+        assertThat(LegacyProxyFetchBridge.intercept(originUrl("/hello"), "GET", emptyMap())).isNull()
+    }
+
+    @Test(timeout = 30000)
+    fun `bypassed loopback target returns null even when armed`() {
+        armHttp()
+        // Origin itself is loopback: always bypassed, never proxied.
+        assertThat(LegacyProxyFetchBridge.intercept(originUrl("/hello"), "GET", emptyMap())).isNull()
+        assertThat(lastProxyRequest.get()).isNull()
+    }
+
+    @Test(timeout = 30000)
+    fun `non-http scheme returns null`() {
+        armHttp()
+        assertThat(LegacyProxyFetchBridge.intercept("file:///android_asset/x.html", "GET", emptyMap())).isNull()
+    }
+
+    @Test(timeout = 30000)
+    fun `custom bypass rules match exact and suffix`() {
+        assertThat(LegacyProxyFetchBridge.isBypassed("example.com", listOf("example.com"))).isTrue()
+        assertThat(LegacyProxyFetchBridge.isBypassed("a.example.com", listOf(".example.com"))).isTrue()
+        assertThat(LegacyProxyFetchBridge.isBypassed("a.example.com", listOf("*.example.com"))).isTrue()
+        assertThat(LegacyProxyFetchBridge.isBypassed("other.com", listOf(".example.com"))).isFalse()
+        assertThat(LegacyProxyFetchBridge.isBypassed("anything.io", listOf("*"))).isTrue()
+        assertThat(LegacyProxyFetchBridge.isBypassed("127.0.0.1", emptyList())).isTrue()
+        assertThat(LegacyProxyFetchBridge.isBypassed(null, emptyList())).isTrue()
+    }
+
+    @Test(timeout = 30000)
+    fun `static resolve picks kind and rejects bad input`() {
+        val http = LegacyProxyFetchBridge.resolveStatic("STATIC", "p.example.com", 8080, "HTTP", emptyList(), "", "")
+        assertThat(http?.kind).isEqualTo(LegacyProxyFetchBridge.Kind.HTTP)
+        val socks = LegacyProxyFetchBridge.resolveStatic("STATIC", "p.example.com", 1080, "SOCKS5", emptyList(), "", "")
+        assertThat(socks?.kind).isEqualTo(LegacyProxyFetchBridge.Kind.SOCKS)
+        val broken = LegacyProxyFetchBridge.resolveStatic("STATIC", "p.example.com", 443, "HTTPS", emptyList(), "", "")
+        assertThat(broken?.kind).isEqualTo(LegacyProxyFetchBridge.Kind.BROKEN)
+        assertThat(LegacyProxyFetchBridge.resolveStatic("NONE", "", 0, "HTTP", emptyList(), "", "")).isNull()
+        assertThat(LegacyProxyFetchBridge.resolveStatic("STATIC", "", 0, "HTTP", emptyList(), "", "")).isNull()
+    }
+
+    @Test(timeout = 30000)
+    fun `unreachable proxy fail-closes with 502`() {
+        // Bind then release a loopback port: connect refused immediately, no real DNS.
+        val probe = ServerSocket(0)
+        val closedPort = probe.localPort
+        probe.close()
+        LegacyProxyFetchBridge.configure(
+            LegacyProxyFetchBridge.Spec(
+                kind = LegacyProxyFetchBridge.Kind.HTTP,
+                host = "127.0.0.1",
+                port = closedPort,
+                bypassRules = emptyList()
+            )
+        )
+        val resp = LegacyProxyFetchBridge.intercept("http://example.com/", "GET", emptyMap())
+        assertThat(resp).isNotNull()
+        assertThat(resp!!.statusCode).isEqualTo(502)
+    }
+
+    @Test(timeout = 30000)
+    fun `pac resolve picks first usable entry`() {
+        // Entries arrive pre-split on ';' (same contract as PacProxyManager).
+        val spec = LegacyProxyFetchBridge.resolvePacEntries(
+            listOf("PROXY p1.example.com:8080", "PROXY p2.example.com:8080"),
+            emptyList(), "", ""
+        )
+        assertThat(spec?.kind).isEqualTo(LegacyProxyFetchBridge.Kind.HTTP)
+        assertThat(spec?.host).isEqualTo("p1.example.com")
+        assertThat(spec?.port).isEqualTo(8080)
+        assertThat(
+            LegacyProxyFetchBridge.resolvePacEntries(listOf("DIRECT"), emptyList(), "", "")
+        ).isNull()
+        assertThat(
+            LegacyProxyFetchBridge.resolvePacEntries(listOf("SOCKS5 s.example.com:1080"), emptyList(), "", "")?.kind
+        ).isEqualTo(LegacyProxyFetchBridge.Kind.SOCKS)
+    }
+
+    @Test(timeout = 30000)
+    fun `broken kind fail-closes with 502`() {
+        LegacyProxyFetchBridge.configure(
+            LegacyProxyFetchBridge.Spec(kind = LegacyProxyFetchBridge.Kind.BROKEN, bypassRules = emptyList())
+        )
+        val resp = LegacyProxyFetchBridge.intercept("http://example.com/", "GET", emptyMap())
+        assertThat(resp).isNotNull()
+        assertThat(resp!!.statusCode).isEqualTo(502)
+    }
+
+    @Test(timeout = 30000)
+    fun `end to end through proxy maps body headers and cookies`() {
+        // Bypass only a sentinel host so the origin alias is fetched VIA proxy.
+        armHttp(bypass = listOf("bypassed.invalid"))
+        val resp = LegacyProxyFetchBridge.intercept(proxyTestUrl("/hello"), "GET", emptyMap())
+        assertThat(resp).isNotNull()
+        val capture = lastProxyRequest.get()
+        assertThat(capture).isNotNull()
+        checkNotNull(capture)
+        assertThat(capture.method).isEqualTo("GET")
+        assertThat(capture.uri).isEqualTo(proxyTestUrl("/hello"))
+        assertThat(resp!!.statusCode).isEqualTo(200)
+        assertThat(resp.responseHeaders["X-Test"]).isEqualTo("yes")
+        assertThat(resp.mimeType).isEqualTo("text/plain")
+        val body = resp.data?.bufferedReader()?.use { it.readText() }
+        assertThat(body).isEqualTo("hello-world")
+
+        // Set-Cookie bridged into the WebView store...
+        val stored = try {
+            CookieManager.getInstance().getCookie(proxyTestUrl("/hello"))
+        } catch (_: Exception) {
+            null
+        }
+        assertThat(stored).contains("sess=abc123")
+
+        // ...and sent back on the next hop.
+        lastProxyRequest.set(null)
+        val resp2 = LegacyProxyFetchBridge.intercept(proxyTestUrl("/echo-cookie"), "GET", emptyMap())
+        assertThat(resp2).isNotNull()
+        val body2 = resp2!!.data?.bufferedReader()?.use { it.readText() }
+        assertThat(body2).contains("sess=abc123")
+        assertThat(lastProxyRequest.get()?.headers?.get("cookie")).contains("sess=abc123")
+    }
+
+    @Test(timeout = 30000)
+    fun `proxy auth header is sent and post goes without body`() {
+        challengeAuth = true
+        try {
+            armHttp(bypass = listOf("bypassed.invalid"), username = "alice", password = "s3cret")
+            val resp = LegacyProxyFetchBridge.intercept(proxyTestUrl("/post"), "POST", mapOf("X-Custom" to "1"))
+            assertThat(resp).isNotNull()
+            val capture = lastProxyRequest.get()
+            assertThat(capture).isNotNull()
+            checkNotNull(capture)
+            assertThat(capture.method).isEqualTo("POST")
+            assertThat(capture.body.size).isEqualTo(0)
+            assertThat(capture.headers["proxy-authorization"]).startsWith("Basic ")
+            assertThat(capture.headers["x-custom"]).isEqualTo("1")
+            val body = resp!!.data?.bufferedReader()?.use { it.readText() }
+            assertThat(body).isEqualTo("method=POST len=0")
+        } finally {
+            challengeAuth = false
+        }
+    }
+
+    @Test(timeout = 30000)
+    fun `splitHostPort parses and rejects`() {
+        assertThat(LegacyProxyFetchBridge.splitHostPort("p.example.com:8080"))
+            .isEqualTo(Pair("p.example.com", 8080))
+        assertThat(LegacyProxyFetchBridge.splitHostPort("[::1]:1080"))
+            .isEqualTo(Pair("::1", 1080))
+        assertThat(LegacyProxyFetchBridge.splitHostPort("noport")).isNull()
+        assertThat(LegacyProxyFetchBridge.splitHostPort("h:0")).isNull()
+    }
+}


### PR DESCRIPTION
Fixes #777

## Summary
On devices with a frozen system WebView (provider < 67, e.g. Android 7.x boxes without Play updates), `ProxyController` is a no-op and the configured proxy was silently ignored — traffic went direct while the UI claimed protection. This adds an automatic in-app fallback: subresource traffic is fetched through OkHttp with the same proxy settings.

## What changed
- New `core/webview/LegacyProxyFetchBridge` (shell-synced, no new deps, no user-visible strings): STATIC/PAC/SOCKS resolution, proxy auth, bypass rules with mandatory loopback bypass, WebView-cookie bridging across redirects, throttled logging.
- `PacProxyManager`: unsupported path arms the fallback (reusing PAC download/parse); `clearProxy` always disarms it.
- `WebViewManager.shouldInterceptRequest`: fallback hooked at the main fall-through, after extension/DNR/adblock/local handling.
- Fail-closed by design: dead/unsupported proxy returns 502, never direct. Documented limits: WebSocket/WebRTC bypass interception, POST without body, HTTPS upstream unsupported, PAC primary-only.

## Test plan
- [x] New `LegacyProxyFetchBridgeTest` 11/11 (live forward-proxy harness: traversal, auth challenge, cookie round-trip, bypass, POST, fail-closed)
- [x] webview/adblock/apkbuilder/port/engine suites 336/336 green
- [x] `check_config_field_drift` OK
- [x] `:shell:assembleRelease` + template sync succeed, bridge present in template, no omni.ja
- [ ] CI `check` job green