### PR TITLE
fix(webview): whole-page zoom via initialScale plus auto-reload circuit breaker

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/PageZoomPlan.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/PageZoomPlan.kt
@@ -1,0 +1,26 @@
+package com.webtoapp.core.webview
+
+/**
+ * Whole-page zoom plan for [WebViewManager.configureWebView] (#654).
+ *
+ * `pageZoomPercent` is the build-time per-app zoom (100 = default). It is applied
+ * via [android.webkit.WebView.setInitialScale], which scales the rendered page as
+ * a whole — text AND layout/images/canvas — unlike `textZoom` (text glyphs only,
+ * invisible on dashboard/canvas UIs such as OpenChamber).
+ *
+ * Pure logic, no Android dependencies: unit-tested on plain JVM.
+ */
+internal data class PageZoomPlan(
+    /** True when an explicit non-100 zoom is configured. */
+    val zoomActive: Boolean,
+    /** Value for `setInitialScale`; 0 = auto (default path untouched). */
+    val initialScalePercent: Int
+)
+
+internal fun planPageZoom(pageZoomPercent: Int, initialScaleField: Int): PageZoomPlan {
+    // 0 = legacy data without the field; treat as 100 (default).
+    val zoom = if (pageZoomPercent > 0) pageZoomPercent else 100
+    if (zoom != 100) return PageZoomPlan(zoomActive = true, initialScalePercent = zoom)
+    // Default path preserves the dormant `initialScale` field semantics.
+    return PageZoomPlan(zoomActive = false, initialScalePercent = if (initialScaleField > 0) initialScaleField else 0)
+}

--- a/app/src/main/java/com/webtoapp/core/webview/ReloadCircuitBreaker.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/ReloadCircuitBreaker.kt
@@ -1,0 +1,52 @@
+package com.webtoapp.core.webview
+
+/**
+ * Safety net against app-initiated auto-reload storms (#654 follow-up).
+ *
+ * Every individual auto-reload path is bounded (loopback/file retries, exhaustible
+ * failover cursor), but their counters reset when the URL changes — a login <->
+ * dashboard cycle (or any error-navigation-error cycle) can otherwise reload
+ * forever while each single path believes it is within budget. This breaker counts
+ * app-initiated reloads per host in a sliding window; once tripped, callers must
+ * fall through to the error UI instead of scheduling another reload.
+ *
+ * Only auto-reload entry points consult it — user gestures (pull-to-refresh, back,
+ * address-bar loads) are never gated.
+ *
+ * Pure logic, no Android dependencies: unit-tested on plain JVM.
+ */
+internal class ReloadCircuitBreaker(
+    private val maxReloads: Int = 6,
+    private val windowMs: Long = 10_000L,
+    private val clockMs: () -> Long = System::currentTimeMillis
+) {
+    private val lock = Any()
+    private val hits = ArrayDeque<Pair<String, Long>>()
+
+    /**
+     * Records an app-initiated reload of [url]. Returns true when the reload may
+     * proceed, false when the breaker tripped (caller must show error UI instead).
+     * Unparseable URLs are always allowed — never break what we cannot attribute.
+     */
+    fun noteAutoReload(url: String?): Boolean {
+        val host = hostOf(url) ?: return true
+        val now = clockMs()
+        synchronized(lock) {
+            while (hits.isNotEmpty() && now - hits.first().second > windowMs) {
+                hits.removeFirst()
+            }
+            if (hits.count { it.first == host } >= maxReloads) return false
+            hits.addLast(host to now)
+            return true
+        }
+    }
+
+    internal fun hostOf(url: String?): String? {
+        if (url.isNullOrBlank()) return null
+        return try {
+            java.net.URI(url).host?.lowercase()?.takeIf { it.isNotBlank() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1123,6 +1123,11 @@ class WebViewManager(
     private val LOOPBACK_MAIN_FRAME_MAX_RETRIES = 3
     private val LOOPBACK_MAIN_FRAME_RETRY_DELAY_MS = 150L
 
+    // Cross-URL budget over all app-initiated auto-reloads (#654): per-path counters
+    // reset when the URL changes, so only this breaker can stop error-navigation
+    // cycles (e.g. login redirect loops) from reloading forever.
+    private val reloadBreaker = ReloadCircuitBreaker()
+
     // A download-intercepted navigation surfaces as an aborted main-frame load; remember
     // the URL so the loopback auto-retry does not re-navigate into the same download.
     private var lastDownloadInterceptedUrl: String? = null
@@ -1172,6 +1177,13 @@ class WebViewManager(
             return false
         }
         val nextUrl = urls[current]
+        // Circuit breaker (#654): error-navigation-error cycles reset the per-URL
+        // counters above, so only a cross-URL budget can stop a reload storm.
+        // Tripping falls through to the error UI instead of another loadUrl.
+        if (!reloadBreaker.noteAutoReload(nextUrl)) {
+            AppLogger.w("WebViewManager", "Failover circuit breaker tripped, showing error instead: $nextUrl reason=$reason")
+            return false
+        }
         failoverCursor[view] = current + 1
         AppLogger.i(
             "WebViewManager",
@@ -1422,6 +1434,8 @@ class WebViewManager(
 
         val preferLandscapeEmbeddedViewport = config.landscapeMode && !isDesktopModeRequested
 
+        val zoomPlan = planPageZoom(config.pageZoomPercent, config.initialScale)
+
         webView.apply {
             settings.apply {
 
@@ -1450,7 +1464,14 @@ class WebViewManager(
                 displayZoomControls = false
 
                 useWideViewPort = true
-                loadWithOverviewMode = !preferLandscapeEmbeddedViewport
+                // Whole-page zoom (initialScale) is overridden by overview fit, so
+                // overview must stay off while an explicit zoom is active. Default
+                // path (zoom 100) keeps the historical behavior.
+                loadWithOverviewMode = if (zoomPlan.zoomActive) {
+                    false
+                } else {
+                    !preferLandscapeEmbeddedViewport
+                }
 
                 if (config.viewportMode == com.webtoapp.data.model.ViewportMode.FIT_SCREEN) {
                     useWideViewPort = true
@@ -1549,17 +1570,17 @@ class WebViewManager(
 
             com.webtoapp.core.perf.NativePerfEngine.optimizeWebViewSettings(this)
 
-            // Per-app page zoom (textZoom) configured in the editor's Advanced Settings (#654).
-            // The tool was transferred from the runtime hidden toolbar into the build-time
-            // config — the config value is the single source of truth, applied on every run.
-            // Applied AFTER the viewport/dark-mode settings above (which may pin textZoom to
-            // 100 in DESKTOP mode) so zoom wins. 0 (legacy data) is treated as 100.
-            if (config.pageZoomPercent > 0 && config.pageZoomPercent != 100) {
-                settings.textZoom = config.pageZoomPercent
-                AppLogger.d("WebViewManager", "Applied page zoom: textZoom=${config.pageZoomPercent}%")
-            }
-
-            if (config.initialScale > 0) {
+            // Per-app page zoom (#654): whole-page scaling via initialScale — text
+            // AND layout/images/canvas, unlike textZoom (glyphs only, invisible on
+            // dashboard/canvas UIs). Runs AFTER the viewport block above so an
+            // explicit zoom wins over FIT_SCREEN/CUSTOM scale-1 forcing; textZoom
+            // stays pinned at 100 so text is never scaled twice. Default (100)
+            // leaves everything untouched; pooled instances are reset to auto.
+            if (zoomPlan.zoomActive) {
+                settings.textZoom = 100
+                setInitialScale(zoomPlan.initialScalePercent)
+                AppLogger.d("WebViewManager", "Applied page zoom: initialScale=${zoomPlan.initialScalePercent}% (overview off)")
+            } else if (config.initialScale > 0) {
                 setInitialScale(config.initialScale)
                 AppLogger.d("WebViewManager", "Set initial scale: ${config.initialScale}%")
             } else if (config.viewportMode == com.webtoapp.data.model.ViewportMode.FIT_SCREEN) {
@@ -1570,6 +1591,9 @@ class WebViewManager(
 
                 setInitialScale(1)
                 AppLogger.d("WebViewManager", "ViewportMode.CUSTOM: forced initial scale to 1 (custom width=${config.customViewportWidth})")
+            } else {
+                // DEFAULT mode, no zoom: clear any scale a pooled WebView may carry.
+                setInitialScale(0)
             }
 
             settings.setSupportMultipleWindows(config.newWindowBehavior != NewWindowBehavior.SAME_WINDOW)
@@ -2458,34 +2482,40 @@ class WebViewManager(
                         val isSameRetry = failedUrl == loopbackMainFrameRetryUrl
                         val currentRetry = if (isSameRetry) loopbackMainFrameRetryCount else 0
                         if (currentRetry < LOOPBACK_MAIN_FRAME_MAX_RETRIES) {
+                            if (!reloadBreaker.noteAutoReload(failedUrl)) {
+                                AppLogger.w(
+                                    "WebViewManager",
+                                    "Loopback auto-retry circuit breaker tripped, showing error instead: $failedUrl"
+                                )
+                            } else {
+                                loopbackMainFrameRetryRunnable?.let { view.removeCallbacks(it) }
 
-                            loopbackMainFrameRetryRunnable?.let { view.removeCallbacks(it) }
+                                loopbackMainFrameRetryUrl = failedUrl
+                                loopbackMainFrameRetryCount = currentRetry + 1
+                                loopbackMainFrameRetryPending = true
+                                loopbackMainFrameRetryView = view
+                                AppLogger.i(
+                                    "WebViewManager",
+                                    "Loopback main-frame load failed (code=$errorCode, desc=$rawDescription), auto-retry ${loopbackMainFrameRetryCount}/$LOOPBACK_MAIN_FRAME_MAX_RETRIES after ${LOOPBACK_MAIN_FRAME_RETRY_DELAY_MS}ms: $failedUrl"
+                                )
+                                val retryRunnable = Runnable {
+                                    val currentUrl = view.url
+                                    if (currentUrl == null || currentUrl == "about:blank" || currentUrl == failedUrl || currentMainFrameUrl == failedUrl) {
+                                        AppLogger.d("WebViewManager", "Retrying loopback main-frame request: $failedUrl")
+                                        view.loadUrl(failedUrl)
+                                    } else {
+                                        AppLogger.d(
+                                            "WebViewManager",
+                                            "Skip loopback auto-retry because WebView navigated away: current=$currentUrl, failed=$failedUrl"
+                                        )
+                                    }
 
-                            loopbackMainFrameRetryUrl = failedUrl
-                            loopbackMainFrameRetryCount = currentRetry + 1
-                            loopbackMainFrameRetryPending = true
-                            loopbackMainFrameRetryView = view
-                            AppLogger.i(
-                                "WebViewManager",
-                                "Loopback main-frame load failed (code=$errorCode, desc=$rawDescription), auto-retry ${loopbackMainFrameRetryCount}/$LOOPBACK_MAIN_FRAME_MAX_RETRIES after ${LOOPBACK_MAIN_FRAME_RETRY_DELAY_MS}ms: $failedUrl"
-                            )
-                            val retryRunnable = Runnable {
-                                val currentUrl = view.url
-                                if (currentUrl == null || currentUrl == "about:blank" || currentUrl == failedUrl || currentMainFrameUrl == failedUrl) {
-                                    AppLogger.d("WebViewManager", "Retrying loopback main-frame request: $failedUrl")
-                                    view.loadUrl(failedUrl)
-                                } else {
-                                    AppLogger.d(
-                                        "WebViewManager",
-                                        "Skip loopback auto-retry because WebView navigated away: current=$currentUrl, failed=$failedUrl"
-                                    )
+                                    loopbackMainFrameRetryRunnable = null
                                 }
-
-                                loopbackMainFrameRetryRunnable = null
+                                loopbackMainFrameRetryRunnable = retryRunnable
+                                view.postDelayed(retryRunnable, LOOPBACK_MAIN_FRAME_RETRY_DELAY_MS)
+                                return
                             }
-                            loopbackMainFrameRetryRunnable = retryRunnable
-                            view.postDelayed(retryRunnable, LOOPBACK_MAIN_FRAME_RETRY_DELAY_MS)
-                            return
                         } else {
                             AppLogger.w(
                                 "WebViewManager",
@@ -2507,16 +2537,23 @@ class WebViewManager(
                         val isSameRetry = failedUrl == fileRetryUrl
                         val currentRetry = if (isSameRetry) fileRetryCount else 0
                         if (currentRetry < FILE_MAX_RETRIES) {
-                            fileRetryUrl = failedUrl
-                            fileRetryCount = currentRetry + 1
-                            AppLogger.d(
-                                "WebViewManager",
-                                "file:// load failed (code=$errorCode, desc=$rawDescription), auto-retry ${fileRetryCount}/$FILE_MAX_RETRIES after ${FILE_RETRY_DELAY_MS}ms: $failedUrl"
-                            )
-                            view.postDelayed({
-                                view.loadUrl(failedUrl)
-                            }, FILE_RETRY_DELAY_MS)
-                            return
+                            if (!reloadBreaker.noteAutoReload(failedUrl)) {
+                                AppLogger.w(
+                                    "WebViewManager",
+                                    "file:// auto-retry circuit breaker tripped, showing error instead: $failedUrl"
+                                )
+                            } else {
+                                fileRetryUrl = failedUrl
+                                fileRetryCount = currentRetry + 1
+                                AppLogger.d(
+                                    "WebViewManager",
+                                    "file:// load failed (code=$errorCode, desc=$rawDescription), auto-retry ${fileRetryCount}/$FILE_MAX_RETRIES after ${FILE_RETRY_DELAY_MS}ms: $failedUrl"
+                                )
+                                view.postDelayed({
+                                    view.loadUrl(failedUrl)
+                                }, FILE_RETRY_DELAY_MS)
+                                return
+                            }
                         } else {
                             AppLogger.w(
                                 "WebViewManager",

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -333,10 +333,11 @@ data class WebViewConfig(
     val popupBlockerToggleEnabled: Boolean = false,
 
     val initialScale: Int = 0,
-    // Build-time per-app page zoom in percent (100 = default), applied via textZoom on
-    // every run (#654). This is THE page zoom for the app — the tool was transferred from
-    // the runtime hidden toolbar into the editor's Advanced Settings, so there is no
-    // runtime override layer anymore. 0 (legacy data) is treated as 100.
+    // Build-time per-app page zoom in percent (100 = default), applied via initialScale
+    // (whole-page scaling: text AND layout/images) on every run (#654). This is THE page
+    // zoom for the app — the tool was transferred from the runtime hidden toolbar into
+    // the editor's Advanced Settings, so there is no runtime override layer anymore.
+    // 0 (legacy data) is treated as 100.
     val pageZoomPercent: Int = 100,
     val viewportMode: ViewportMode = ViewportMode.DEFAULT,
     val customViewportWidth: Int = 0,

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -996,7 +996,7 @@ fun BrowserAdvancedConfigCard(
                             WtaSectionDivider()
                             // Per-app page zoom (#654): transferred from the runtime hidden
                             // toolbar into Advanced Settings — this is THE zoom for the app,
-                            // applied via textZoom on every run. Same Chrome-style presets.
+                            // applied via initialScale (whole page) on every run. Same Chrome-style presets.
                             var pageZoomDialogOpen by remember { mutableStateOf(false) }
                             WtaChoiceRow(
                                 title = Strings.pageZoomSettingLabel,

--- a/app/src/test/java/com/webtoapp/core/webview/PageZoomPlanTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/PageZoomPlanTest.kt
@@ -1,0 +1,49 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PageZoomPlanTest {
+
+    @Test
+    fun `zoom out activates whole-page scale`() {
+        val plan = planPageZoom(pageZoomPercent = 75, initialScaleField = 0)
+        assertThat(plan.zoomActive).isTrue()
+        assertThat(plan.initialScalePercent).isEqualTo(75)
+    }
+
+    @Test
+    fun `zoom in activates whole-page scale`() {
+        val plan = planPageZoom(pageZoomPercent = 125, initialScaleField = 0)
+        assertThat(plan.zoomActive).isTrue()
+        assertThat(plan.initialScalePercent).isEqualTo(125)
+    }
+
+    @Test
+    fun `default leaves everything untouched`() {
+        val plan = planPageZoom(pageZoomPercent = 100, initialScaleField = 0)
+        assertThat(plan.zoomActive).isFalse()
+        assertThat(plan.initialScalePercent).isEqualTo(0)
+    }
+
+    @Test
+    fun `legacy zero treated as default`() {
+        val plan = planPageZoom(pageZoomPercent = 0, initialScaleField = 0)
+        assertThat(plan.zoomActive).isFalse()
+        assertThat(plan.initialScalePercent).isEqualTo(0)
+    }
+
+    @Test
+    fun `explicit zoom wins over dormant initialScale field`() {
+        val plan = planPageZoom(pageZoomPercent = 75, initialScaleField = 80)
+        assertThat(plan.zoomActive).isTrue()
+        assertThat(plan.initialScalePercent).isEqualTo(75)
+    }
+
+    @Test
+    fun `dormant initialScale field preserved on default path`() {
+        val plan = planPageZoom(pageZoomPercent = 100, initialScaleField = 80)
+        assertThat(plan.zoomActive).isFalse()
+        assertThat(plan.initialScalePercent).isEqualTo(80)
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/webview/ReloadCircuitBreakerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/ReloadCircuitBreakerTest.kt
@@ -1,0 +1,58 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ReloadCircuitBreakerTest {
+
+    @Test
+    fun `allows budget then trips`() {
+        val breaker = ReloadCircuitBreaker(maxReloads = 3, windowMs = 10_000L, clockMs = { 0L })
+        assertThat(breaker.noteAutoReload("http://192.168.1.10/login")).isTrue()
+        assertThat(breaker.noteAutoReload("http://192.168.1.10/login")).isTrue()
+        assertThat(breaker.noteAutoReload("http://192.168.1.10/login")).isTrue()
+        assertThat(breaker.noteAutoReload("http://192.168.1.10/login")).isFalse()
+    }
+
+    @Test
+    fun `window expiry resets budget`() {
+        var now = 0L
+        val breaker = ReloadCircuitBreaker(maxReloads = 1, windowMs = 1_000L, clockMs = { now })
+        assertThat(breaker.noteAutoReload("http://example.com/a")).isTrue()
+        assertThat(breaker.noteAutoReload("http://example.com/a")).isFalse()
+        now = 1_001L
+        assertThat(breaker.noteAutoReload("http://example.com/a")).isTrue()
+    }
+
+    @Test
+    fun `budgets are per host across url cycles`() {
+        val breaker = ReloadCircuitBreaker(maxReloads = 2, windowMs = 10_000L, clockMs = { 0L })
+        // Login <-> dashboard cycle on one host shares a single budget.
+        assertThat(breaker.noteAutoReload("http://192.168.1.10/login")).isTrue()
+        assertThat(breaker.noteAutoReload("http://192.168.1.10/dashboard")).isTrue()
+        assertThat(breaker.noteAutoReload("http://192.168.1.10/login")).isFalse()
+    }
+
+    @Test
+    fun `different hosts do not share budget`() {
+        val breaker = ReloadCircuitBreaker(maxReloads = 1, windowMs = 10_000L, clockMs = { 0L })
+        assertThat(breaker.noteAutoReload("http://a.example.com/")).isTrue()
+        assertThat(breaker.noteAutoReload("http://b.example.com/")).isTrue()
+    }
+
+    @Test
+    fun `unparseable urls are never blocked`() {
+        val breaker = ReloadCircuitBreaker(maxReloads = 1, windowMs = 10_000L, clockMs = { 0L })
+        assertThat(breaker.noteAutoReload(null)).isTrue()
+        assertThat(breaker.noteAutoReload("")).isTrue()
+        assertThat(breaker.noteAutoReload("not a url [[[")).isTrue()
+        assertThat(breaker.noteAutoReload("not a url [[[")).isTrue()
+    }
+
+    @Test
+    fun `host matching is case-insensitive`() {
+        val breaker = ReloadCircuitBreaker(maxReloads = 1, windowMs = 10_000L, clockMs = { 0L })
+        assertThat(breaker.noteAutoReload("http://Example.COM/a")).isTrue()
+        assertThat(breaker.noteAutoReload("http://example.com/b")).isFalse()
+    }
+}


### PR DESCRIPTION
Fixes #654

## Summary
Follow-up on the #654 reports: per-app zoom had no visible effect on dashboard/canvas UIs (OpenChamber), and the login page could refresh in a loop.

## What changed
- pageZoomPercent now drives setInitialScale (whole page: text + layout/images/canvas) instead of textZoom (glyphs only). Overview mode is disabled while zoom is active so fit logic cannot override it; textZoom stays pinned at 100; explicit zoom wins over FIT_SCREEN/CUSTOM scale-1; pooled instances reset on the default path. No model/config/export changes.
- New ReloadCircuitBreaker: per-host sliding-window budget (6/10s) over all app-initiated auto-reloads (loopback/file/failover), whose per-URL counters reset across navigations. Tripping falls through to the error UI instead of another loadUrl.
- New PageZoomPlanTest + ReloadCircuitBreakerTest (12 tests, plain JVM).

## Test plan
- [x] New tests 12/12 green
- [x] webview/adblock/apkbuilder/port/engine suites 348/348 green
- [x] check_config_field_drift OK
- [x] shell assembleRelease + template sync succeed, no omni.ja
- [ ] CI check job green