### PR TITLE
feat(test): shell/host UI parity gate plus media parity fixes and doc refresh

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,11 +62,12 @@ python3 .github/scripts/ci/validate_modules.py
   discussion of the same idea.
 - For non-trivial changes, open an issue first describing the problem and the
   approach you have in mind. This is much cheaper than rewriting after review.
-- **Avoid adding new dependencies.** The list in `app/build.gradle.kts` is
-  intentionally restrained — the project signs and packages APKs in-process,
-  and the shell template pins `targetSdk = 28` on purpose because generated
-  apps rely on fork+exec native runtimes. New dependencies need a strong
-  justification.
+- **Avoid adding new dependencies.** The lists in `app/build.gradle.kts` and
+  `shell/build.gradle.kts` are intentionally restrained — the project signs and
+  packages APKs in-process, and the shell template pins `targetSdk = 28` on
+  purpose because generated apps rely on fork+exec native runtimes. New
+  dependencies need a strong justification, and host-only dependencies must
+  never leak into the shell template.
 
 ### Local setup
 
@@ -83,17 +84,25 @@ cd web-to-app
 ```
 
 The repo has three Gradle modules: **`app`** (the full builder and host),
-**`shell`** (the runtime-only host embedded in generated APKs), and
+**`shell`** (the runtime template embedded in generated APKs), and
 **`clone-host`** (the host code used by app cloning). Shared runtime code is
-authored in `app` and synchronized into `shell`, so changes there usually need
-both `:app` and `:shell` to compile.
+authored **only** under `app/` and synchronized into `shell/` at build time
+(`shell/build/generated/` — never edit `shell/src` by hand; it is
+regenerated and partly git-ignored).
 
 Run the checks before submitting:
 
 ```bash
-./gradlew :app:compileStandardDebugKotlin
-./gradlew :shell:compileDebugKotlin
-./gradlew :app:testStandardDebugUnitTest
+./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache
+./gradlew :app:testStandardDebugUnitTest --no-configuration-cache -PskipShellTemplateSync=true
+./gradlew :app:checkConfigFieldDrift --no-configuration-cache
+```
+
+If you touched shell-synced runtime code or export packaging, also rebuild the
+template you touched:
+
+```bash
+./gradlew :shell:assembleRelease :app:syncShellTemplateApk --no-configuration-cache
 ```
 
 > Native code (`node_launcher`, `go_exec_loader`, the APK optimizer) builds
@@ -108,20 +117,43 @@ Run the checks before submitting:
 | On-device APK builder / signer | `app/src/main/java/com/webtoapp/core/apkbuilder/` |
 | Server runtimes (Node / PHP / Python / Go / WordPress) | `app/src/main/java/com/webtoapp/core/{nodejs,php,python,golang,wordpress}/` |
 | WebView engine, native bridge, fingerprint disguise | `app/src/main/java/com/webtoapp/core/{webview,engine,appearance}/` |
+| Shell config + generated-APK entry points | `app/src/main/java/com/webtoapp/core/shell/` |
+| Preview players (`ui/gallery/`, `ui/media/`) vs packaged players (`ui/shell/`) | `app/src/main/java/com/webtoapp/ui/` |
 | Extension modules, Module Market, Agent | `app/src/main/java/com/webtoapp/core/{extension,market,agent}/` |
 | Compose UI screens & design system | `app/src/main/java/com/webtoapp/ui/` |
 | DI graph (source of truth) | `app/src/main/java/com/webtoapp/di/AppModule.kt` |
+
+### Preview ≠ export: the rule behind most rejections
+
+The host app (preview) and generated APKs (export) run **different code**:
+
+| | Preview (`:app`) | Exported APK |
+| --- | --- | --- |
+| UI | `ui/gallery/`, `ui/media/`, `WebViewManager` live | `ui/shell/*` synced copy |
+| Config | Editor / in-memory models | JSON assets via `ShellModeManager` |
+
+A feature is done only when it works on **both** paths. Concretely, an editor
+setting that must affect generated APKs has to flow through the full chain —
+model → `ApkConfig` JSON → shell config → shell-synced runtime — and a
+player-screen behavior has to be implemented in **both** the preview and the
+shell composable. Three gates enforce this; run them, don't argue with them:
+
+- `checkConfigFieldDrift` — model/JSON/shell field names must match
+  (Gson silently drops mismatches).
+- `WebViewConfigBooleanCoverageTest` — every new `WebViewConfig` Boolean must
+  be listed in `flipAllBooleans()` and survive the export round-trip.
+- `ShellUiParityTest` — every model field read by host player UI must also be
+  read by shell player UI (or carry an explicit `allow` reason). Add your new
+  per-type player pair to it.
 
 ### Coding conventions
 
 WebToApp leans on the Kotlin and Jetpack Compose patterns already in the
 codebase. A few rules worth calling out:
 
-- **This codebase ships without comments.** Source files are kept
-  comment-free by convention — let clear names and small functions carry the
-  intent. Don't add `//`, `/* */`, or KDoc blocks; if a block needs a comment
-  to be understood, prefer rewriting it. (Strings inside code, e.g. URLs, are
-  obviously fine.)
+- **Comments explain *why*, not *what*.** Non-obvious decisions, cross-file
+  contracts, and issue references (`#781`) get a short comment; clear names
+  and small functions carry the rest. Don't narrate readable code.
 - **Build new UI on the Wta design system.** Everything renders through
   `com.webtoapp.ui.design`. The older `Premium*` / `Enhanced*` / `Settings*`
   components are retained as permanent alias layers over the Wta internals —
@@ -129,30 +161,30 @@ codebase. A few rules worth calling out:
   (`.github/scripts/audit_ui_design_system.py`, wired into `build.gradle.kts`) tracks
   legacy UI debt against `.github/scripts/ui_design_allowlist.txt`.
 - **Reuse the design tokens** in `ui/design/WtaTokens.kt` for spacing, radius,
-  alpha, and elevation. Don't hard-code numbers.
+  alpha, and elevation. Don't hard-code numbers. Editor config cards share one
+  layout grammar (see `AGENTS.md` recipe 12) — copy the neighbouring cards,
+  don't invent your own, and verify on the emulator, not just by compiling.
 - **Strings must cover all 10 supported languages.** UI copy lives in
   `core/i18n/Strings.kt` (facade `object Strings` + in-file `StringsA`…`StringsE`,
   split only for the JVM constant pool). Supported: Chinese, English, Arabic,
   Portuguese, Spanish, French, German, Russian, Japanese, Korean.
-  Every new or changed user-facing `when (Strings.lang)` block **must** have
-  real translations for **all 10** branches — do not leave pt/es/fr/de/ru/ja/ko
-  as English placeholders. Brand names and pure format tokens may match English.
-  If you truly cannot translate one language, use English there and flag it in
-  the PR. `StringsKtTranslationParityTest` currently enforces the core three
-  and forbids hardcoded `else -> "..."`; full 10-way coverage is still required
-  by project convention.
+  Every new or changed user-visible `when (Strings.lang)` block **must** have
+  real translations for **all 10** branches with no `else ->` — do not leave
+  pt/es/fr/de/ru/ja/ko as English placeholders. Brand names and pure format
+  tokens may match English. If you truly cannot translate one language, use
+  English there and flag it in the PR.
+- **Never load user-visible text from `R.string`.** Resource files only cover
+  zh/en/ar, so lookups silently fall back to Chinese for the other 7 locales.
+  `R.string` is reserved for non-localised resources.
 - **No new top-level singletons** unless you discuss it first. The DI graph in
   `di/AppModule.kt` is the source of truth.
 - **The Native Bridge is capability-gated.** Any method exposed to web content
   via `@JavascriptInterface` must be guarded by the per-capability allow-list
   (`NativeBridgeCapabilities`). Never expose a native capability to arbitrary
   pages without a gate. PRs that bypass this will be rejected.
-- **Preview and packaged runtime are two paths.** Bridges and WebView hooks must
-  be registered (and injected, when applicable) both for in-app preview
-  (`WebViewManager` / `WebViewActivity`) and for generated APKs (`ShellActivity`).
-  Shared runtime sources are authored only under `app/` and synced into `shell/`
-  via `./gradlew :shell:syncShellRuntimeSources --rerun-tasks` — do not hand-edit
-  generated `shell/` trees.
+- **Preview and packaged runtime are two paths.** See *Preview ≠ export*
+  above. Shared runtime sources are authored only under `app/` and synced into
+  `shell/` at build time — do not hand-edit anything under `shell/src`.
 - **Avoid catching `Exception` to silence errors.** If recovery is impossible,
   log via `AppLogger` and re-throw or return a failed `Result`.
 
@@ -185,21 +217,28 @@ an hour as authoritative; the refresh button always bypasses the cache.
 ### Pull requests
 
 - Branch from `main`. Keep PRs focused — one logical change per PR.
+- **Write Issues and PRs in English** — titles, bodies, and review threads.
 - Describe the user-visible effect in the PR body, not just the code change.
+- The standard loop is Issue → branch → PR (`Fixes #N`) → green CI → merge.
+  Issues close on merge, never on PR open or red CI.
 - If your PR touches the build system, native code, or APK packaging, attach
-  the output of `./gradlew :app:assembleStandardDebug` (or note the failure if it
-  fails on your machine).
+  the output of the template rebuild above (or note the failure if it fails
+  on your machine).
 - CI runs on every PR. A green CI is required before merge.
+- Never commit secrets, keystores, `local.properties`, or IDE/cache junk.
 
 ### Reviewer expectations
 
 Maintainer reviews look for:
 
-- **Correctness.** Does the change do what the PR description says?
+- **Correctness.** Does the change do what the PR description says? Was it
+  verified by execution (tests, build output), not just by reading?
 - **Safety.** See *Security* above.
 - **Scope discipline.** Drive-by refactors expand the review surface. Land
   them in a separate PR.
 - **Style fit.** See *Coding conventions* above.
+- **Both paths.** Preview-only features and export-only wiring are the two
+  classic failure modes — see *Preview ≠ export* above.
 
 ---
 
@@ -264,9 +303,10 @@ python3 .github/scripts/ci/validate_modules.py
 - 在 [issues](https://github.com/shiaho777/web-to-app/issues) 里先搜一下
   类似讨论
 - 较大的改动请先开 issue 说明要解决的问题和方案
-- **谨慎引入新依赖**。`app/build.gradle.kts` 的依赖列表刻意保持精简——本项目
-  全程在设备内签名打包 APK，shell 模板也特意把 `targetSdk` 锁在 28，因为
-  生成应用依赖 `fork`、`exec` 原生运行时。新依赖需要充分理由。
+- **谨慎引入新依赖**。`app/build.gradle.kts` 与 `shell/build.gradle.kts` 的依
+  赖列表刻意保持精简——本项目全程在设备内签名打包 APK，shell 模板也特意把
+  `targetSdk` 锁在 28，因为生成应用依赖 `fork`、`exec` 原生运行时。新依赖需
+  要充分理由，且宿主专用依赖绝不能漏进 shell 模板。
 
 **本地环境**
 
@@ -281,16 +321,22 @@ cd web-to-app
 ```
 
 仓库有三个 Gradle 模块：**`app`**（完整构建器和宿主）、**`shell`**（嵌入生
-成 APK 的运行时宿主）和 **`clone-host`**（应用克隆使用的宿主代码）。共享运
-行时代码以 `app` 为唯一事实来源，再同步到 `shell`，所以改动这部分通常至少
-要保证 `:app` 和 `:shell` 都能编译。
+成 APK 的运行时模板）和 **`clone-host`**（应用克隆使用的宿主代码）。共享运
+行时代码以 `app/` 为唯一事实来源，构建时同步到 `shell/`（`shell/build/` 下，
+不要手改 `shell/src`——它是再生成的产物，部分被 git 忽略）。
 
 提交前请跑通：
 
 ```bash
-./gradlew :app:compileStandardDebugKotlin
-./gradlew :shell:compileDebugKotlin
-./gradlew :app:testStandardDebugUnitTest
+./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache
+./gradlew :app:testStandardDebugUnitTest --no-configuration-cache -PskipShellTemplateSync=true
+./gradlew :app:checkConfigFieldDrift --no-configuration-cache
+```
+
+动到 shell 同步的运行时代码或导出打包，还要重建你碰过的模板：
+
+```bash
+./gradlew :shell:assembleRelease :app:syncShellTemplateApk --no-configuration-cache
 ```
 
 > 原生代码（`node_launcher`、`go_exec_loader`、APK 优化器）按 ABI 经 CMake
@@ -305,39 +351,60 @@ cd web-to-app
 | 设备端 APK 打包 / 签名 | `app/src/main/java/com/webtoapp/core/apkbuilder/` |
 | 服务端运行时（Node / PHP / Python / Go / WordPress） | `app/src/main/java/com/webtoapp/core/{nodejs,php,python,golang,wordpress}/` |
 | WebView 引擎、原生桥、指纹伪装 | `app/src/main/java/com/webtoapp/core/{webview,engine,appearance}/` |
+| Shell 配置与生成 APK 入口 | `app/src/main/java/com/webtoapp/core/shell/` |
+| 预览播放器（`ui/gallery/`、`ui/media/`）vs 打包播放器（`ui/shell/`） | `app/src/main/java/com/webtoapp/ui/` |
 | 扩展模块、模块市场、Agent | `app/src/main/java/com/webtoapp/core/{extension,market,agent}/` |
 | Compose UI 与设计系统 | `app/src/main/java/com/webtoapp/ui/` |
 | DI 依赖图（单一事实来源） | `app/src/main/java/com/webtoapp/di/AppModule.kt` |
 
+**预览 ≠ 导出：大多数打回的原因**
+
+宿主应用（预览）和生成的 APK（导出）跑的是**两套代码**：
+
+| | 预览（`:app`） | 导出的 APK |
+| --- | --- | --- |
+| 界面 | `ui/gallery/`、`ui/media/`、实时 `WebViewManager` | `ui/shell/*` 的同步副本 |
+| 配置 | 编辑器 / 内存模型 | 经 `ShellModeManager` 读取的 JSON 资源 |
+
+一个功能只有两边都通才算做完。编辑器开关要影响生成 APK，必须走完整条
+链——模型 → `ApkConfig` JSON → shell 配置 → shell 同步的运行时代码；而播放
+器界面的行为要在预览和壳两套 composable 里各实现一遍。三道门禁负责兜底，
+跑过它们，别跟它们争：
+
+- `checkConfigFieldDrift`——模型 / JSON / shell 字段名必须一致（Gson 会静默
+  丢掉对不上的字段）。
+- `WebViewConfigBooleanCoverageTest`——`WebViewConfig` 每新增一个 Boolean 都
+  必须进 `flipAllBooleans()` 并走完导出往返。
+- `ShellUiParityTest`——宿主播放器读的每个模型字段，壳播放器也必须读（或写
+  明 `allow` 理由）。新增每类播放器时照样子扩展。
+
 **代码风格**
 
-- **本仓库不写注释。** 源码按约定保持无注释——用清晰的命名和小函数表达意图。
-  不要加 `//`、`/* */` 或 KDoc；如果某段代码非得靠注释才能看懂，优先重写它。
-  （代码里字符串内的内容，比如 URL，当然不受此限。）
+- **注释解释 *为什么*，不复述 *干了什么*。** 反直觉的决策、跨文件约定、
+  issue 引用（`#781`）值得一句短注释；命名清晰的小函数不需要解说。不要给
+  易读的代码写旁白。
 - **新 UI 一律构建在 Wta 设计系统之上**——所有界面通过 `com.webtoapp.ui.design`
   渲染。旧的 `Premium*` / `Enhanced*` / `Settings*` 组件作为 Wta 内部实现的
   永久别名层保留——不要再新增，也无需强行替换。构建期有一个审计脚本
   （`.github/scripts/audit_ui_design_system.py`，接进 `build.gradle.kts`）按
   `.github/scripts/ui_design_allowlist.txt` 跟踪历史 UI 债务。
 - 复用 `ui/design/WtaTokens.kt` 里的设计 token（间距、圆角、透明度、高度），
-  别硬编码数字
+  别硬编码数字。编辑器配置卡片共用一套排版语法（见 `AGENTS.md` recipe 12）——
+  照抄相邻卡片，不要自创，跑模拟器验效果，不要只编译。
 - **字符串必须覆盖全部 10 种已支持语言**：文案在 `core/i18n/Strings.kt`
   （facade `object Strings` + 同文件 `StringsA`…`StringsE`，拆分只为常量池）。
   已支持：中 / 英 / 阿 / 葡 / 西 / 法 / 德 / 俄 / 日 / 韩。
   新增或修改面向用户的 `when (Strings.lang)` **必须**为 10 个分支写真实翻译，
-  禁止把 pt/es/fr/de/ru/ja/ko 继续当英文占位。品牌名、纯格式符可与英文相同。
-  某语实在不会翻可暂填英文并在 PR 标明。
-  `StringsKtTranslationParityTest` 目前强制三核心 + 禁止硬编码 `else -> "..."`；
-  项目约定仍要求 10 语全覆盖
+  且不许写 `else ->`；禁止把 pt/es/fr/de/ru/ja/ko 继续当英文占位。品牌名、
+  纯格式符可与英文相同。某语实在不会翻可暂填英文并在 PR 标明。
+- **面向用户的文案绝不用 `R.string`。** 资源文件只有 zh/en/ar 三套，其他 7
+  语会静默回落到中文。`R.string` 只保留给无需本地化的资源。
 - 引入新的全局单例前请先讨论；`di/AppModule.kt` 是单一事实来源
 - **原生桥是按能力门禁的**：任何通过 `@JavascriptInterface` 暴露给网页的方法，
   都必须经过逐能力白名单（`NativeBridgeCapabilities`）。绝不要在没有门禁的
   情况下把原生能力暴露给任意页面。绕过门禁的 PR 会被拒
-- **预览和打包运行时是两条路径**：桥接类 / WebView hook 要在预览
-  （`WebViewManager` / `WebViewActivity`）和生成 APK（`ShellActivity`）两侧都
-  注册（需要 hook 网页 API 的还要注入脚本）。共享运行时代码只改 `app/`，
-  改完跑 `./gradlew :shell:syncShellRuntimeSources --rerun-tasks`；不要手改
-  `shell/` 下的同步产物
+- **预览和打包运行时是两条路径**：见上文《预览 ≠ 导出》。共享运行时代码只改
+  `app/`，构建时同步进 `shell/`；不要手改 `shell/src` 下的任何东西
 - 不要 catch 然后吞掉异常；用 `AppLogger` 记录后重新抛出或返回失败的 `Result`
 
 **安全**
@@ -357,17 +424,23 @@ cd web-to-app
 **Pull Request**
 
 - 从 `main` 分出分支，每个 PR 只解决一件事
+- **Issue 与 PR 请用英文写**——标题、正文、评审讨论
 - PR 描述写"用户看得到的效果"，不只是代码 diff
-- 改动涉及构建系统、原生代码或 APK 打包时，附上 `./gradlew :app:assembleStandardDebug`
-  的结果
+- 标准流程是 Issue → 分支 → PR（`Fixes #N`）→ CI 变绿 → 合并。
+  Issue 只在合并时关闭，开 PR 时不关、CI 红时不关
+- 改动涉及构建系统、原生代码或 APK 打包时，附上上面模板重建命令的结果
 - CI 必须绿色才会合并
+- 不要提交密钥、keystore、`local.properties` 或 IDE / 缓存垃圾
 
 **Review 标准**
 
-- **正确性**——是否真的做了 PR 描述里写的事
+- **正确性**——是否真的做了 PR 描述里写的事；是否经过执行验证（测试、
+  构建产物），而不只是"读起来对"
 - **安全**——见上面《安全》小节
 - **聚焦**——顺手做的重构请单独发 PR
 - **风格**——参考上面那条
+- **两条路径**——只在预览生效的功能和只在导出接线的配置是两类经典翻车——见
+  上文《预览 ≠ 导出》
 
 ### 行为准则
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,16 @@ Trace and update **all** of:
    a spot-check to `key non-Boolean WebViewConfig fields survive the export
    round-trip`. This is the safety net that catches "preview works, export
    broken" before it ships.
+7. **Shell UI parity (REQUIRED for per-type player screens).** Gallery / media /
+   splash-style app types render through DIFFERENT composables in preview
+   (`ui/gallery/`, `ui/media/`) vs generated APKs (`ui/shell/`). A flag that flows
+   end-to-end still does nothing if the shell screen never reads it (gallery
+   thumbnail bar shipped config + assets correctly and still rendered nothing,
+   #781). `ShellUiParityTest.kt` enforces this: every model field read by host
+   runtime UI must also be read by shell runtime UI. If you add a field and read
+   it in a host player, the test fails naming the field until you port the
+   behavior to shell or add an explicit `allow` entry with a reason. When adding
+   a new per-type player pair, extend its `pairs` list the same way.
 
 Missing any step usually yields: editor shows the switch, export ignores it, or export embeds config the runtime never reads.
 
@@ -291,6 +301,7 @@ The editor screens have an established card language. **Find the neighboring car
 - **Adblock is wired for preview + export.** Do not wipe host filter state during export; the host AdBlocker serves preview and the compiled rule set ships in the APK.
 - **Runtime permissions are feature-driven.** `RuntimePermissionSync` derives the permission list from enabled features; do not revert to a static template.
 - **Splash preview media path.** Preview reads splash media from the host filesystem (`splashMediaPath`); export packages it into assets. Do not hardcode `assets/splash_media.*` as the only source.
+- **Host player UI ≠ shell player UI.** Preview players (`ui/gallery/`, `ui/media/`) and generated-APK players (`ui/shell/`) are separate composables sharing only the config. Port every visible behavior across (thumbnail bar, background, keep-screen-on, orientation) and let `ShellUiParityTest` verify the flags; config flowing end-to-end is necessary but not sufficient.
 - **Port conflict policy.** Local server runtimes must allocate through `PortManager` and clean up on stop; do not bind ports directly.
 - **Agent tool ↔ service drift.** When a service class API changes, the corresponding Agent tool in `core/agent/tool/builtin/` must be updated in the same PR. A stale tool either fails to compile or silently passes wrong arguments at runtime. Check `ToolRegistryFactory.baseTools()` for the full tool list.
 - **Editor card UI grammar.** Config-screen cards share one layout grammar (recipe 12): rows are full-bleed, non-row content sits in 16dp-padded zones, expansion never toggles the feature, and card UI is verified on the emulator — not just compiled.
@@ -308,6 +319,7 @@ The editor screens have an established card language. **Find the neighboring car
 - Crashing FGS when notification channel creation fails
 - Committing secrets, keystores, or local machine config
 - Regressing HTML/FRONTEND file access in packaged shells
+- Shipping a host player-screen feature without its shell counterpart (preview-only UI)
 - Shipping NODEJS_APP without `libnode_bridge.so` / `libnode.so` / `libc++_shared.so`
 - Skipping 16KB alignment for large ELF natives
 - Inventing editor card layout/spacing/animations instead of copying the neighbouring cards' patterns, or shipping card UI verified only by compilation

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -4172,7 +4172,8 @@ private fun WebApp.buildMediaBlock(): MediaBlock = MediaBlock(
     autoPlay = mediaConfig?.autoPlay ?: true,
     fillScreen = mediaConfig?.fillScreen ?: true,
     landscape = mediaConfig?.orientation == com.webtoapp.data.model.SplashOrientation.LANDSCAPE,
-    keepScreenOn = mediaConfig?.keepScreenOn ?: true
+    keepScreenOn = mediaConfig?.keepScreenOn ?: true,
+    backgroundColor = mediaConfig?.backgroundColor ?: "#000000"
 )
 
 private fun com.webtoapp.data.model.HtmlConfig?.toHtmlBlock(): HtmlBlock = HtmlBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -711,7 +711,8 @@ data class MediaBlock(
     val autoPlay: Boolean = true,
     val fillScreen: Boolean = true,
     val landscape: Boolean = false,
-    val keepScreenOn: Boolean = true
+    val keepScreenOn: Boolean = true,
+    val backgroundColor: String = "#000000"
 )
 
 data class HtmlBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -384,7 +384,8 @@ internal object ApkConfigJsonFactory {
         "autoPlay" to media.autoPlay,
         "fillScreen" to media.fillScreen,
         "landscape" to media.landscape,
-        "keepScreenOn" to media.keepScreenOn
+        "keepScreenOn" to media.keepScreenOn,
+        "backgroundColor" to media.backgroundColor
     )
 
     private fun ApkConfig.htmlConfigPayload(): Map<String, Any?> = linkedMapOf(

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -810,7 +810,10 @@ data class MediaShellConfig(
     val landscape: Boolean = false,
 
     @SerializedName("keepScreenOn")
-    val keepScreenOn: Boolean = true
+    val keepScreenOn: Boolean = true,
+
+    @SerializedName("backgroundColor")
+    val backgroundColor: String = "#000000"
 )
 
 data class WordPressShellConfig(

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
@@ -304,10 +304,32 @@ fun MediaContentDisplay(
 ) {
     val context = LocalContext.current
 
+    val bgColor = remember(mediaConfig.backgroundColor) {
+        try {
+            Color(android.graphics.Color.parseColor(mediaConfig.backgroundColor))
+        } catch (e: Exception) {
+            Color.Black
+        }
+    }
+
+    // Mirror host MediaAppActivity: keep the screen awake for the lifetime of
+    // this screen when configured. Add-only like the host (no explicit clear).
+    LaunchedEffect(mediaConfig.keepScreenOn) {
+        if (mediaConfig.keepScreenOn) {
+            try {
+                (context as? android.app.Activity)?.window?.addFlags(
+                    android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+                )
+            } catch (e: Exception) {
+                AppLogger.w("ShellMedia", "Failed to set keep-screen-on: ${e.message}")
+            }
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Black),
+            .background(bgColor),
         contentAlignment = Alignment.Center
     ) {
         if (isVideo) {

--- a/app/src/test/java/com/webtoapp/core/shell/ShellUiParityTest.kt
+++ b/app/src/test/java/com/webtoapp/core/shell/ShellUiParityTest.kt
@@ -1,0 +1,152 @@
+package com.webtoapp.core.shell
+
+import com.google.common.truth.Truth.assertWithMessage
+import com.webtoapp.data.model.GalleryConfig
+import com.webtoapp.data.model.MediaConfig
+import org.junit.Test
+import java.io.File
+
+/**
+ * Preview/export UI parity gate (incident: gallery thumbnail bar, #781).
+ *
+ * Rule: every field of a per-type host model that host runtime code reads must
+ * also be read by shell runtime code. Otherwise the editor shows a switch, the
+ * preview honors it, and the exported APK silently ignores it.
+ *
+ * When you add a field to a covered model AND read it in host runtime UI, this
+ * test fails naming the field until you either port the behavior to shell or
+ * add an explicit allow entry with a reason. When you genuinely consume a new
+ * flag in shell, nothing needs to change here.
+ *
+ * Covered pairs (extend by adding a [ShellUiParityPair], not by editing logic):
+ * - Gallery: GalleryPlayerScreen/Activity vs ShellGallery/ShellScreen
+ * - Media: MediaAppActivity vs ShellMediaContent/ShellScreen
+ */
+class ShellUiParityTest {
+
+    data class ShellUiParityPair(
+        val name: String,
+        val modelClass: Class<*>,
+        val hostFiles: List<String>,
+        val hostQualifiers: List<String>,
+        val shellFiles: List<String>,
+        val shellQualifiers: List<String>,
+        /** Host field name -> shell-side name when they differ (media orientation -> landscape). */
+        val renames: Map<String, String> = emptyMap(),
+        /** Host field name -> reason it needs no shell consumer. */
+        val allow: Map<String, String> = emptyMap()
+    )
+
+    private val pairs = listOf(
+        ShellUiParityPair(
+            name = "gallery",
+            modelClass = GalleryConfig::class.java,
+            hostFiles = listOf(
+                "com/webtoapp/ui/gallery/GalleryPlayerScreen.kt",
+                "com/webtoapp/ui/gallery/GalleryPlayerActivity.kt"
+            ),
+            hostQualifiers = listOf("config.", "galleryConfig."),
+            shellFiles = listOf(
+                "com/webtoapp/ui/shell/ShellGallery.kt",
+                "com/webtoapp/ui/shell/ShellScreen.kt"
+            ),
+            shellQualifiers = listOf("galleryConfig.")
+        ),
+        ShellUiParityPair(
+            name = "media",
+            modelClass = MediaConfig::class.java,
+            hostFiles = listOf(
+                "com/webtoapp/ui/media/MediaAppActivity.kt"
+            ),
+            hostQualifiers = listOf("mediaConfig.", "config."),
+            shellFiles = listOf(
+                "com/webtoapp/ui/shell/ShellMediaContent.kt",
+                "com/webtoapp/ui/shell/ShellScreen.kt"
+            ),
+            shellQualifiers = listOf("mediaConfig."),
+            renames = mapOf(
+                // Export flattens SplashOrientation to a boolean (buildMediaBlock).
+                "orientation" to "landscape"
+            ),
+            allow = mapOf(
+                // Asset path is fixed at export (media_content.*); the shell
+                // mediaPath parameter is host-preview-only.
+                "mediaPath" to "fixed asset path, preview-only parameter"
+            )
+        )
+    )
+
+    @Test
+    fun `shell consumes every host-consumed model field`() {
+        val javaRoot = resolveExistingDir("app/src/main/java", "src/main/java")
+        val failures = mutableListOf<String>()
+        for (pair in pairs) {
+            val modelFields = pair.modelClass.declaredFields
+                .filter { !it.isSynthetic && it.name != "Companion" }
+                .map { it.name }
+                .toSet()
+
+            val staleAllow = pair.allow.keys - modelFields
+            if (staleAllow.isNotEmpty()) {
+                failures += "[${pair.name}] stale allow entries (field gone from ${pair.modelClass.simpleName}): $staleAllow"
+            }
+
+            val hostSources = pair.hostFiles.associateWith { readSanitized(javaRoot, it) }
+            val shellSources = pair.shellFiles.associateWith { readSanitized(javaRoot, it) }
+
+            val required = modelFields.filter { field ->
+                pair.hostQualifiers.any { q ->
+                    hostSources.values.any { src -> containsRef(src, q, field) }
+                }
+            }
+            for (field in required) {
+                if (field in pair.allow) continue
+                val shellField = pair.renames[field] ?: field
+                val covered = pair.shellQualifiers.any { q ->
+                    shellSources.values.any { src -> containsRef(src, q, shellField) }
+                }
+                if (!covered) {
+                    val hostHits = hostSources.filter { (_, src) ->
+                        pair.hostQualifiers.any { q -> containsRef(src, q, field) }
+                    }.keys
+                    failures += "[${pair.name}] '${pair.modelClass.simpleName}.$field' read by host $hostHits " +
+                        "but not by shell ${pair.shellFiles}. Port the behavior to shell " +
+                        "(see thumbnail bar, #781) or add an allow entry with a reason."
+                }
+            }
+        }
+        assertWithMessage(
+            "Shell/host UI parity violations:\n" + failures.joinToString("\n")
+        ).that(failures).isEmpty()
+    }
+
+    private fun readSanitized(javaRoot: File, relativePath: String): String {
+        val file = File(javaRoot, relativePath)
+        assertWithMessage("Parity harness cannot find source file: $relativePath")
+            .that(file.isFile).isTrue()
+        return stripCodeNoise(file.readText())
+    }
+
+    private fun containsRef(sanitized: String, qualifier: String, field: String): Boolean {
+        // qualifier + field as one token reference, e.g. "galleryConfig.showThumbnailBar".
+        val pattern = Regex("(?<![A-Za-z0-9_$])" + Regex.escape(qualifier + field) + "(?![A-Za-z0-9_])")
+        return pattern.containsMatchIn(sanitized)
+    }
+
+    private fun stripCodeNoise(source: String): String {
+        var s = source
+        // Triple-quoted strings first (may contain // or /* */).
+        s = Regex("\"\"\".*?\"\"\"", RegexOption.DOT_MATCHES_ALL).replace(s, "\"\"")
+        // Double-quoted strings (log lines must not count as code refs).
+        s = Regex("\"(?:\\\\.|[^\"\\\\])*\"").replace(s, "\"\"")
+        // Block comments, then line comments.
+        s = Regex("/\\*.*?\\*/", RegexOption.DOT_MATCHES_ALL).replace(s, " ")
+        s = s.lines().joinToString("\n") { it.substringBefore("//") }
+        return s
+    }
+
+    private fun resolveExistingDir(vararg candidates: String): File {
+        return candidates.asSequence().map(::File).firstOrNull(File::exists)
+            ?: error("Cannot locate java directory from: ${candidates.joinToString()}")
+    }
+}


### PR DESCRIPTION
Fixes #783

## Summary
Makes the gallery-thumbnail-bar incident class (#781) CI-catchable, sweeps the other per-type players for the same divergence, and refreshes the contributor docs.

## What changed
- New `ShellUiParityTest` (gallery + media pairs, allowlist-with-reason): host-player-consumed model fields must be shell-consumed. Proven to flag the pre-fix tree.
- Media gaps fixed end to end: `backgroundColor` (MediaBlock -> JSON -> MediaShellConfig -> UI) and `keepScreenOn` (window flag, host parity).
- AGENTS.md: parity step + easy-to-miss + forbidden entries.
- CONTRIBUTING.md rewritten (EN+ZH): Preview-vs-export gates, current verify commands, Issue-PR-CI-merge loop, realistic comment policy.

## Test plan
- [x] full unit suite 1020/1020 green (incl. new gate)
- [x] `check_config_field_drift` OK
- [x] shell template rebuilds + syncs, no omni.ja
- [ ] CI `check` job green