### PR TITLE
feat(gallery): implement shuffleOnLoop, rememberPosition and overview grid

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/gallery/GalleryPlayerActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/gallery/GalleryPlayerActivity.kt
@@ -23,16 +23,19 @@ class GalleryPlayerActivity : ComponentActivity() {
     companion object {
         private const val EXTRA_CONFIG = "gallery_config"
         private const val EXTRA_START_INDEX = "start_index"
+        private const val EXTRA_GALLERY_ID = "gallery_id"
         private val gson = com.webtoapp.util.GsonProvider.gson
 
         fun launch(
             context: Context,
             config: GalleryConfig,
-            startIndex: Int = 0
+            startIndex: Int = 0,
+            galleryId: Long = 0L
         ) {
             val intent = Intent(context, GalleryPlayerActivity::class.java).apply {
                 putExtra(EXTRA_CONFIG, gson.toJson(config))
                 putExtra(EXTRA_START_INDEX, startIndex)
+                putExtra(EXTRA_GALLERY_ID, galleryId)
             }
             context.startActivity(intent)
         }
@@ -40,6 +43,8 @@ class GalleryPlayerActivity : ComponentActivity() {
 
     private var config: GalleryConfig? = null
     private var startIndex: Int = 0
+    private var positionKey: String? = null
+    private var startInOverview: Boolean = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,6 +63,20 @@ class GalleryPlayerActivity : ComponentActivity() {
         if (galleryConfig == null || galleryConfig.items.isEmpty()) {
             finish()
             return
+        }
+
+        // rememberPosition: resume where the user left off (keyed per gallery).
+        // A restored non-zero position opens the pager directly; otherwise the
+        // overview (grid/list/timeline per defaultView) is the entry.
+        val galleryId = intent.getLongExtra(EXTRA_GALLERY_ID, 0L)
+        if (galleryConfig.rememberPosition && galleryId > 0) {
+            val key = galleryPositionKey(galleryId)
+            val saved = getSharedPreferences(GALLERY_POSITION_PREFS, MODE_PRIVATE).getInt(key, -1)
+            if (saved >= 0) {
+                startIndex = saved.coerceIn(0, galleryConfig.items.size - 1)
+                positionKey = key
+                startInOverview = startIndex > 0
+            }
         }
 
         requestedOrientation = when (galleryConfig.orientation) {
@@ -81,7 +100,9 @@ class GalleryPlayerActivity : ComponentActivity() {
                 GalleryPlayerScreen(
                     config = galleryConfig,
                     startIndex = startIndex.coerceIn(0, galleryConfig.items.size - 1),
-                    onBack = { finish() }
+                    onBack = { finish() },
+                    positionKey = positionKey,
+                    startInOverview = startInOverview
                 )
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/gallery/GalleryPlayerScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/gallery/GalleryPlayerScreen.kt
@@ -7,7 +7,11 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
@@ -43,17 +47,29 @@ import java.io.File
 fun GalleryPlayerScreen(
     config: GalleryConfig,
     startIndex: Int,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    // Persistence key for rememberPosition (e.g. per-app id). Null disables saving.
+    positionKey: String? = null,
+    // Overview (grid/list/timeline) is the entry unless resuming into the pager.
+    startInOverview: Boolean = true
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
-    val items = remember(config) {
+    val positionPrefs = remember(positionKey) {
+        positionKey?.let {
+            context.getSharedPreferences(GALLERY_POSITION_PREFS, android.content.Context.MODE_PRIVATE)
+        }
+    }
+
+    val initialOrder = remember(config) {
         when (config.playMode) {
             GalleryPlayMode.SHUFFLE -> config.getSortedItems().shuffled()
             else -> config.getSortedItems()
         }
     }
+    // Mutable playback order: shuffle-on-loop reshuffles in place on every wrap.
+    var items by remember(config) { mutableStateOf(initialOrder) }
 
     val pagerState = rememberPagerState(
         initialPage = startIndex,
@@ -63,6 +79,46 @@ fun GalleryPlayerScreen(
     val currentIndex by remember { derivedStateOf { pagerState.settledPage } }
     val currentItem = items.getOrNull(currentIndex)
 
+    // rememberPosition: persist the settled page so reopening continues here.
+    LaunchedEffect(currentIndex) {
+        val key = positionKey
+        if (key != null && currentIndex in items.indices) {
+            positionPrefs?.edit()?.putInt(key, currentIndex)?.apply()
+        }
+    }
+
+    var showGrid by remember { mutableStateOf(startInOverview) }
+    // Pager back returns to the overview only when the session started there;
+    // a resume-to-pager session exits directly.
+    val canReturnToGrid = startInOverview
+    androidx.activity.compose.BackHandler(enabled = !showGrid && canReturnToGrid) {
+        showGrid = true
+    }
+
+    val bgColor = remember(config.backgroundColor) {
+        try {
+            Color(android.graphics.Color.parseColor(config.backgroundColor))
+        } catch (e: Exception) {
+            Color.Black
+        }
+    }
+
+    if (showGrid) {
+        GalleryOverview(
+            config = config,
+            items = items,
+            bgColor = bgColor,
+            onBack = onBack,
+            onItemClick = { index ->
+                scope.launch {
+                    showGrid = false
+                    pagerState.scrollToPage(index.coerceIn(0, items.size - 1))
+                }
+            }
+        )
+        return
+    }
+
     var showControls by remember { mutableStateOf(true) }
     var isPlaying by remember { mutableStateOf(config.autoPlay) }
 
@@ -71,10 +127,12 @@ fun GalleryPlayerScreen(
         if (isPlaying && currentItem?.type == GalleryItemType.IMAGE && !pagerState.isScrollInProgress) {
             delay(config.imageInterval * 1000L)
 
-            if (currentIndex < items.size - 1) {
-                pagerState.animateScrollToPage(currentIndex + 1)
-            } else if (config.loop) {
-                pagerState.animateScrollToPage(0)
+            val advance = com.webtoapp.ui.shared.galleryAutoAdvanceTarget(
+                currentIndex, items.size, config.loop, config.shuffleOnLoop
+            )
+            if (advance != null) {
+                if (advance.reshuffle) items = items.shuffled()
+                pagerState.animateScrollToPage(advance.targetIndex)
             } else {
                 isPlaying = false
             }
@@ -85,14 +143,6 @@ fun GalleryPlayerScreen(
         if (showControls) {
             delay(3000)
             showControls = false
-        }
-    }
-
-    val bgColor = remember(config.backgroundColor) {
-        try {
-            Color(android.graphics.Color.parseColor(config.backgroundColor))
-        } catch (e: Exception) {
-            Color.Black
         }
     }
 
@@ -131,10 +181,12 @@ fun GalleryPlayerScreen(
                             onVideoEnded = {
                                 if (config.videoAutoNext) {
                                     scope.launch {
-                                        if (currentIndex < items.size - 1) {
-                                            pagerState.animateScrollToPage(currentIndex + 1)
-                                        } else if (config.loop) {
-                                            pagerState.animateScrollToPage(0)
+                                        val advance = com.webtoapp.ui.shared.galleryAutoAdvanceTarget(
+                                            currentIndex, items.size, config.loop, config.shuffleOnLoop
+                                        )
+                                        if (advance != null) {
+                                            if (advance.reshuffle) items = items.shuffled()
+                                            pagerState.animateScrollToPage(advance.targetIndex)
                                         }
                                     }
                                 }
@@ -157,7 +209,7 @@ fun GalleryPlayerScreen(
                 currentItem = currentItem,
                 currentIndex = currentIndex,
                 totalCount = items.size,
-                onBack = onBack
+                onBack = { if (canReturnToGrid) showGrid = true else onBack() }
             )
         }
 
@@ -771,5 +823,222 @@ private fun formatTime(ms: Long): String {
         String.format(java.util.Locale.getDefault(), "%d:%02d:%02d", hours, minutes, seconds)
     } else {
         String.format(java.util.Locale.getDefault(), "%02d:%02d", minutes, seconds)
+    }
+}
+
+/** SharedPreferences file for gallery resume positions, keyed per gallery. */
+internal const val GALLERY_POSITION_PREFS = "gallery_positions"
+
+internal fun galleryPositionKey(galleryId: Long): String = "pos_$galleryId"
+
+@Composable
+private fun GalleryOverview(
+    config: GalleryConfig,
+    items: List<GalleryItem>,
+    bgColor: Color,
+    onBack: () -> Unit,
+    onItemClick: (Int) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(bgColor)
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = Color.Black.copy(alpha = 0.6f)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 8.dp)
+                    .statusBarsPadding(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = Strings.back,
+                        tint = Color.White
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "${items.size}",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = Color.White
+                )
+            }
+        }
+
+        when (config.defaultView) {
+            GalleryViewMode.LIST -> GalleryListView(items = items, onItemClick = onItemClick)
+            GalleryViewMode.TIMELINE -> GalleryTimelineView(items = items, onItemClick = onItemClick)
+            else -> GalleryGridView(
+                items = items,
+                columns = config.gridColumns.coerceIn(1, 6),
+                onItemClick = onItemClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun GalleryGridView(
+    items: List<GalleryItem>,
+    columns: Int,
+    onItemClick: (Int) -> Unit
+) {
+    val context = LocalContext.current
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(columns),
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        gridItemsIndexed(items, key = { _, item -> item.id }) { index, item ->
+            Box(
+                modifier = Modifier
+                    .aspectRatio(1f)
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable { onItemClick(index) }
+            ) {
+                val imagePath = item.thumbnailPath ?: item.path
+                AsyncImage(
+                    model = ImageRequest.Builder(context)
+                        .data(File(imagePath))
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = item.name,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+                if (item.type == GalleryItemType.VIDEO) {
+                    Icon(
+                        Icons.Default.PlayCircle,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(24.dp)
+                            .align(Alignment.Center),
+                        tint = Color.White.copy(alpha = 0.8f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GalleryListView(
+    items: List<GalleryItem>,
+    onItemClick: (Int) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        itemsIndexed(items, key = { _, item -> item.id }) { index, item ->
+            GalleryOverviewRow(
+                item = item,
+                onClick = { onItemClick(index) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun GalleryTimelineView(
+    items: List<GalleryItem>,
+    onItemClick: (Int) -> Unit
+) {
+    val dateFormat = remember { java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US) }
+    val groups = remember(items) {
+        items.withIndex().groupBy { (_, item) ->
+            if (item.createdAt > 0) dateFormat.format(java.util.Date(item.createdAt)) else ""
+        }
+    }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(vertical = 8.dp)
+    ) {
+        groups.forEach { (date, indexed) ->
+            if (date.isNotEmpty()) {
+                item(key = "header_$date") {
+                    Text(
+                        text = date,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = Color.White.copy(alpha = 0.7f),
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                    )
+                }
+            }
+            itemsIndexed(indexed, key = { _, (_, item) -> item.id }) { _, (index, item) ->
+                GalleryOverviewRow(
+                    item = item,
+                    onClick = { onItemClick(index) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GalleryOverviewRow(
+    item: GalleryItem,
+    onClick: () -> Unit
+) {
+    val context = LocalContext.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(RoundedCornerShape(4.dp))
+        ) {
+            val imagePath = item.thumbnailPath ?: item.path
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(File(imagePath))
+                    .crossfade(true)
+                    .build(),
+                contentDescription = item.name,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+            if (item.type == GalleryItemType.VIDEO) {
+                Icon(
+                    Icons.Default.PlayCircle,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(20.dp)
+                        .align(Alignment.Center),
+                    tint = Color.White.copy(alpha = 0.8f)
+                )
+            }
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = item.name.ifBlank { "Media" },
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (item.type == GalleryItemType.VIDEO && item.formattedDuration.isNotEmpty()) {
+                Text(
+                    text = item.formattedDuration,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.7f)
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/webtoapp/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/webtoapp/ui/navigation/AppNavigation.kt
@@ -805,7 +805,7 @@ fun PreviewScreen(appId: Long, onBack: () -> Unit) {
 
                 com.webtoapp.data.model.AppType.GALLERY -> {
                     app.galleryConfig?.let { config ->
-                        com.webtoapp.ui.gallery.GalleryPlayerActivity.launch(context, config, 0)
+                        com.webtoapp.ui.gallery.GalleryPlayerActivity.launch(context, config, 0, appId)
                     }
                 }
 

--- a/app/src/main/java/com/webtoapp/ui/shared/GalleryPlayback.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/GalleryPlayback.kt
@@ -1,0 +1,28 @@
+package com.webtoapp.ui.shared
+
+/**
+ * Pure playback-advance decision shared by the host gallery player
+ * ([com.webtoapp.ui.gallery.GalleryPlayerScreen]) and the shell player
+ * ([com.webtoapp.ui.shell.ShellGalleryPlayer]) so both wrap — and reshuffle —
+ * identically. Unit-tested on plain JVM.
+ */
+internal data class GalleryAdvance(
+    val targetIndex: Int,
+    /** True when the wrap must reshuffle the order first (shuffle-on-loop). */
+    val reshuffle: Boolean
+)
+
+/**
+ * @return next action, or null when playback should stop (end reached, no loop).
+ */
+internal fun galleryAutoAdvanceTarget(
+    currentIndex: Int,
+    itemCount: Int,
+    loop: Boolean,
+    shuffleOnLoop: Boolean
+): GalleryAdvance? {
+    if (itemCount <= 0) return null
+    if (currentIndex < itemCount - 1) return GalleryAdvance(currentIndex + 1, reshuffle = false)
+    if (!loop) return null
+    return GalleryAdvance(targetIndex = 0, reshuffle = shuffleOnLoop)
+}

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellGallery.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellGallery.kt
@@ -11,7 +11,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -82,16 +86,76 @@ fun ShellGalleryPlayer(
     val currentIndex by remember { derivedStateOf { pagerState.settledPage } }
     val currentItem = effectiveItems.getOrNull(currentIndex)
 
+    // rememberPosition: a generated APK hosts a single gallery, so one fixed key
+    // suffices. Items may resolve asynchronously (derived assets fallback), hence
+    // jump-once-loaded instead of initialPage. A restored non-zero position opens
+    // the pager directly; otherwise the overview is the entry.
+    val positionPrefs = remember {
+        context.getSharedPreferences(SHELL_GALLERY_POSITION_PREFS, android.content.Context.MODE_PRIVATE)
+    }
+    var positionRestored by remember { mutableStateOf(!galleryConfig.rememberPosition) }
+    var showGrid by remember { mutableStateOf(true) }
+    var enteredInPager by remember { mutableStateOf(false) }
+    androidx.activity.compose.BackHandler(enabled = !showGrid && !enteredInPager) {
+        showGrid = true
+    }
+    LaunchedEffect(effectiveItems) {
+        if (!positionRestored && effectiveItems.isNotEmpty()) {
+            positionRestored = true
+            val saved = positionPrefs.getInt(SHELL_GALLERY_POSITION_KEY, 0)
+                .coerceIn(0, effectiveItems.size - 1)
+            if (saved > 0) {
+                pagerState.scrollToPage(saved)
+                showGrid = false
+                enteredInPager = true
+            }
+        }
+    }
+    LaunchedEffect(currentIndex) {
+        if (galleryConfig.rememberPosition && positionRestored && currentIndex in effectiveItems.indices) {
+            positionPrefs.edit().putInt(SHELL_GALLERY_POSITION_KEY, currentIndex).apply()
+        }
+    }
+
+    val bgColor = remember(galleryConfig.backgroundColor) {
+        try {
+            Color(android.graphics.Color.parseColor(galleryConfig.backgroundColor))
+        } catch (e: Exception) {
+            Color.Black
+        }
+    }
+
+        if (showGrid) {
+        ShellGalleryOverview(
+            galleryConfig = galleryConfig,
+            items = effectiveItems,
+            bgColor = bgColor,
+            assetDecryptor = assetDecryptor,
+            onBack = onBack,
+            onItemClick = { index ->
+                scope.launch {
+                    showGrid = false
+                    pagerState.scrollToPage(index.coerceIn(0, effectiveItems.size - 1))
+                }
+            }
+        )
+        return
+    }
+
     var showControls by remember { mutableStateOf(true) }
     var isPlaying by remember { mutableStateOf(galleryConfig.autoPlay) }
 
     LaunchedEffect(currentIndex, isPlaying) {
         if (isPlaying && currentItem?.type == "IMAGE" && !pagerState.isScrollInProgress) {
             kotlinx.coroutines.delay(galleryConfig.imageInterval * 1000L)
-            if (currentIndex < items.size - 1) {
-                pagerState.animateScrollToPage(currentIndex + 1)
-            } else if (galleryConfig.loop) {
-                pagerState.animateScrollToPage(0)
+            // End detection uses the displayed list: config items may be empty with
+            // assets derived as fallback, in which case items.size is 0.
+            val advance = com.webtoapp.ui.shared.galleryAutoAdvanceTarget(
+                currentIndex, effectiveItems.size, galleryConfig.loop, galleryConfig.shuffleOnLoop
+            )
+            if (advance != null) {
+                if (advance.reshuffle) effectiveItems = effectiveItems.shuffled()
+                pagerState.animateScrollToPage(advance.targetIndex)
             } else {
                 isPlaying = false
             }
@@ -102,14 +166,6 @@ fun ShellGalleryPlayer(
         if (showControls) {
             kotlinx.coroutines.delay(3000)
             showControls = false
-        }
-    }
-
-    val bgColor = remember(galleryConfig.backgroundColor) {
-        try {
-            Color(android.graphics.Color.parseColor(galleryConfig.backgroundColor))
-        } catch (e: Exception) {
-            Color.Black
         }
     }
 
@@ -150,10 +206,12 @@ fun ShellGalleryPlayer(
                             onVideoEnded = {
                                 if (galleryConfig.videoAutoNext) {
                                     scope.launch {
-                                        if (currentIndex < effectiveItems.size - 1) {
-                                            pagerState.animateScrollToPage(currentIndex + 1)
-                                        } else if (galleryConfig.loop) {
-                                            pagerState.animateScrollToPage(0)
+                                        val advance = com.webtoapp.ui.shared.galleryAutoAdvanceTarget(
+                                            currentIndex, effectiveItems.size, galleryConfig.loop, galleryConfig.shuffleOnLoop
+                                        )
+                                        if (advance != null) {
+                                            if (advance.reshuffle) effectiveItems = effectiveItems.shuffled()
+                                            pagerState.animateScrollToPage(advance.targetIndex)
                                         }
                                     }
                                 }
@@ -183,7 +241,7 @@ fun ShellGalleryPlayer(
                         .statusBarsPadding(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = { if (!enteredInPager) showGrid = true else onBack() }) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = Strings.cdBack,
@@ -825,6 +883,138 @@ private fun ShellThumbnailCell(
                 tint = Color.White.copy(alpha = 0.7f),
                 modifier = Modifier.size(20.dp)
             )
+        }
+    }
+}
+
+private const val SHELL_GALLERY_POSITION_PREFS = "shell_gallery"
+private const val SHELL_GALLERY_POSITION_KEY = "last_index"
+
+@Composable
+private fun ShellGalleryOverview(
+    galleryConfig: com.webtoapp.core.shell.GalleryShellConfig,
+    items: List<com.webtoapp.core.shell.GalleryShellItem>,
+    bgColor: Color,
+    assetDecryptor: com.webtoapp.core.crypto.AssetDecryptor,
+    onBack: () -> Unit,
+    onItemClick: (Int) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(bgColor)
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = Color.Black.copy(alpha = 0.6f)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 8.dp)
+                    .statusBarsPadding(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = Strings.cdBack,
+                        tint = Color.White
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "${items.size}",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = Color.White
+                )
+            }
+        }
+
+        when (galleryConfig.defaultView.uppercase()) {
+            "LIST" -> ShellGalleryListView(items = items, assetDecryptor = assetDecryptor, onItemClick = onItemClick)
+            // Shell items carry no timestamps, so timeline degrades to a plain
+            // list; host groups by date where available.
+            "TIMELINE" -> ShellGalleryListView(items = items, assetDecryptor = assetDecryptor, onItemClick = onItemClick)
+            else -> ShellGalleryGridView(
+                items = items,
+                columns = galleryConfig.gridColumns.coerceIn(1, 6),
+                assetDecryptor = assetDecryptor,
+                onItemClick = onItemClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun ShellGalleryGridView(
+    items: List<com.webtoapp.core.shell.GalleryShellItem>,
+    columns: Int,
+    assetDecryptor: com.webtoapp.core.crypto.AssetDecryptor,
+    onItemClick: (Int) -> Unit
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(columns),
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        gridItemsIndexed(items, key = { _, item -> item.id }) { index, item ->
+            Box(
+                modifier = Modifier
+                    .aspectRatio(1f)
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable { onItemClick(index) }
+            ) {
+                ShellThumbnailCell(item = item, assetDecryptor = assetDecryptor)
+                if (item.type == "VIDEO") {
+                    Icon(
+                        Icons.Default.PlayCircle,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(24.dp)
+                            .align(Alignment.Center),
+                        tint = Color.White.copy(alpha = 0.8f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShellGalleryListView(
+    items: List<com.webtoapp.core.shell.GalleryShellItem>,
+    assetDecryptor: com.webtoapp.core.crypto.AssetDecryptor,
+    onItemClick: (Int) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        itemsIndexed(items, key = { _, item -> item.id }) { index, item ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onItemClick(index) }
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(modifier = Modifier.size(56.dp)) {
+                    ShellThumbnailCell(item = item, assetDecryptor = assetDecryptor)
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = item.name.ifBlank { "Media" },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+            }
         }
     }
 }

--- a/app/src/test/java/com/webtoapp/ui/shared/GalleryPlaybackTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/shared/GalleryPlaybackTest.kt
@@ -1,0 +1,37 @@
+package com.webtoapp.ui.shared
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class GalleryPlaybackTest {
+
+    @Test
+    fun `advances within list without reshuffle`() {
+        assertThat(galleryAutoAdvanceTarget(0, 4, loop = true, shuffleOnLoop = true))
+            .isEqualTo(GalleryAdvance(1, reshuffle = false))
+    }
+
+    @Test
+    fun `wrap reshuffles only when shuffle on loop`() {
+        assertThat(galleryAutoAdvanceTarget(3, 4, loop = true, shuffleOnLoop = true))
+            .isEqualTo(GalleryAdvance(0, reshuffle = true))
+        assertThat(galleryAutoAdvanceTarget(3, 4, loop = true, shuffleOnLoop = false))
+            .isEqualTo(GalleryAdvance(0, reshuffle = false))
+    }
+
+    @Test
+    fun `end without loop stops playback`() {
+        assertThat(galleryAutoAdvanceTarget(3, 4, loop = false, shuffleOnLoop = true)).isNull()
+    }
+
+    @Test
+    fun `empty list stops playback`() {
+        assertThat(galleryAutoAdvanceTarget(0, 0, loop = true, shuffleOnLoop = true)).isNull()
+    }
+
+    @Test
+    fun `overshot index wraps instead of crashing pager`() {
+        assertThat(galleryAutoAdvanceTarget(9, 4, loop = true, shuffleOnLoop = false))
+            .isEqualTo(GalleryAdvance(0, reshuffle = false))
+    }
+}


### PR DESCRIPTION
Fixes #785

## Summary
Three gallery editor toggles were dead on both sides (found in the #783 parity sweep). This implements all three, mirrored in host preview and shell players.

## What changed
- shuffleOnLoop: reshuffle at loop wrap (image + video ends); shared pure `galleryAutoAdvanceTarget` in shell-synced `ui/shared` + 5 unit tests.
- rememberPosition: host keyed per gallery id (preview entry -> activity -> screen); shell fixed key with jump-once-loaded for async asset resolution.
- Grid/list/timeline overview as entry on both sides (tap to pager, back returns); shell reuses ShellThumbnailCell; shell timeline is a plain list (no timestamps).
- No new user-visible strings, no model/config/export changes.

## Test plan
- [x] GalleryPlaybackTest 5/5, ShellUiParityTest green
- [x] full unit suite 1025/1025 green
- [x] shell template rebuilds + syncs, no omni.ja
- [ ] CI `check` job green