### PR TITLE
fix(bitmap): bound all untrusted decodes, fixes oversized-bitmap crash

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -176,14 +176,15 @@ class ApkTemplate(private val context: Context) {
 
     fun loadBitmap(iconPath: String): Bitmap? {
         return try {
+            // Downstream re-encodes at mipmap scale; cap the decode (#779).
             if (iconPath.startsWith("/")) {
-                BitmapFactory.decodeFile(iconPath)
+                com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(iconPath, 1024)
             } else if (iconPath.startsWith("content://")) {
                 context.contentResolver.openInputStream(android.net.Uri.parse(iconPath))?.use {
-                    BitmapFactory.decodeStream(it)
+                    com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(it, 1024)
                 }
             } else {
-                BitmapFactory.decodeFile(iconPath)
+                com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(iconPath, 1024)
             }
         } catch (e: Exception) {
             null

--- a/app/src/main/java/com/webtoapp/core/appmodifier/AppCloner.kt
+++ b/app/src/main/java/com/webtoapp/core/appmodifier/AppCloner.kt
@@ -181,14 +181,16 @@ class AppCloner(private val context: Context) {
 
     private fun loadBitmapFromPath(path: String): Bitmap? {
         return try {
+            // Clone icons are re-encoded small; never decode hostile originals raw (#779).
+            val cap = com.webtoapp.util.BoundedBitmaps.ICON_MAX_DIMENSION * 2
             when {
-                path.startsWith("/") -> BitmapFactory.decodeFile(path)
+                path.startsWith("/") -> com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(path, cap)
                 path.startsWith("content://") || path.startsWith("file://") -> {
                     context.contentResolver.openInputStream(Uri.parse(path))?.use {
-                        BitmapFactory.decodeStream(it)
+                        com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(it, cap)
                     }
                 }
-                else -> BitmapFactory.decodeFile(path)
+                else -> com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(path, cap)
             }
         } catch (e: Exception) {
             null

--- a/app/src/main/java/com/webtoapp/core/export/AppExporter.kt
+++ b/app/src/main/java/com/webtoapp/core/export/AppExporter.kt
@@ -160,21 +160,22 @@ class AppExporter(private val context: Context) {
                     path.startsWith("/") -> {
                         val file = File(path)
                         if (file.exists()) {
-                            BitmapFactory.decodeFile(path)
+                            // Output is scaled to SHORTCUT_ICON_SIZE below; cap the decode (#779).
+                            com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(path, 1024)
                         } else null
                     }
 
                     path.startsWith("file://") -> {
                         val file = File(Uri.parse(path).path ?: return null)
                         if (file.exists()) {
-                            BitmapFactory.decodeFile(file.absolutePath)
+                            com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(file.absolutePath, 1024)
                         } else null
                     }
 
                     else -> {
                         val uri = Uri.parse(path)
                         context.contentResolver.openInputStream(uri)?.use { stream ->
-                            BitmapFactory.decodeStream(stream)
+                            com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(stream, 1024)
                         }
                     }
                 }

--- a/app/src/main/java/com/webtoapp/core/floatingwindow/FloatingWindowManager.kt
+++ b/app/src/main/java/com/webtoapp/core/floatingwindow/FloatingWindowManager.kt
@@ -1340,14 +1340,23 @@ class FloatingWindowManager(private val context: Context) {
             when {
                 iconPath.startsWith("content://") -> {
                     context.contentResolver.openInputStream(Uri.parse(iconPath))?.use { stream ->
-                        BitmapFactory.decodeStream(stream)
+                        com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(
+                            stream,
+                            com.webtoapp.util.BoundedBitmaps.ICON_MAX_DIMENSION
+                        )
                     }
                 }
-                iconPath.startsWith("/") -> BitmapFactory.decodeFile(iconPath)
+                iconPath.startsWith("/") -> com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(
+                    iconPath,
+                    com.webtoapp.util.BoundedBitmaps.ICON_MAX_DIMENSION
+                )
                 else -> {
                     val assetPath = iconPath.removePrefix("assets/")
                     context.assets.open(assetPath.ifBlank { FLOATING_WINDOW_MINIMIZED_ICON_ASSET }).use { stream ->
-                        BitmapFactory.decodeStream(stream)
+                        com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(
+                            stream,
+                            com.webtoapp.util.BoundedBitmaps.ICON_MAX_DIMENSION
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/webtoapp/core/linux/PerformanceOptimizer.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/PerformanceOptimizer.kt
@@ -570,8 +570,12 @@ object PerformanceOptimizer {
             if (originalSize > 5 * 1024 * 1024) inSampleSize = 4
         }
 
-        val bitmap = BitmapFactory.decodeFile(file.absolutePath, options)
-            ?: return 0
+        // Same OOM containment as compressImageBytes below (#779).
+        val bitmap = try {
+            BitmapFactory.decodeFile(file.absolutePath, options)
+        } catch (t: Throwable) {
+            null
+        } ?: return 0
 
         try {
             val tempFile = File(file.parent, "${file.nameWithoutExtension}_opt.${file.extension}")
@@ -621,7 +625,13 @@ object PerformanceOptimizer {
     }
 
     private fun compressImageBytes(data: ByteArray, ext: String, config: OptimizeConfig): ByteArray? {
-        val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size) ?: return null
+        // Full resolution is the point here (recompression); contain OOM instead:
+        // a hostile image skips optimization rather than killing the export (#779).
+        val bitmap = try {
+            BitmapFactory.decodeByteArray(data, 0, data.size)
+        } catch (t: Throwable) {
+            null
+        } ?: return null
         try {
             val format = when {
                 config.convertToWebP -> Bitmap.CompressFormat.WEBP

--- a/app/src/main/java/com/webtoapp/core/webview/LongPressHandler.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/LongPressHandler.kt
@@ -418,10 +418,10 @@ class LongPressHandler(
         val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) ?: "png"
 
         val imageBytes = Base64.decode(base64Data, Base64.DEFAULT)
-        val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
-            ?: return null
 
-        return saveBitmapToGallery(bitmap, "IMG_${System.currentTimeMillis()}.$extension", mimeType)
+        // Write bytes directly: no decode roundtrip (lossless, faster, and immune
+        // to oversized-bitmap OOM on hostile data URLs, #779).
+        return saveBytesToGallery(imageBytes, "IMG_${System.currentTimeMillis()}.$extension", mimeType)
     }
 
     private fun saveUrlImage(imageUrl: String): Uri? {
@@ -432,17 +432,15 @@ class LongPressHandler(
 
         val imageBytes = connection.getInputStream().use { it.readBytes() }
 
-        val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
-            ?: return null
-
         val fileName = DownloadHelper.parseFileName(imageUrl, null, connection.contentType)
             .ifBlank { "IMG_${System.currentTimeMillis()}.jpg" }
         val mimeType = connection.contentType ?: "image/jpeg"
 
-        return saveBitmapToGallery(bitmap, fileName, mimeType)
+        return saveBytesToGallery(imageBytes, fileName, mimeType)
     }
 
-    private fun saveBitmapToGallery(bitmap: Bitmap, fileName: String, mimeType: String): Uri? {
+    private fun saveBytesToGallery(bytes: ByteArray, fileName: String, mimeType: String): Uri? {
+        if (bytes.isEmpty()) return null
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 
             val contentValues = ContentValues().apply {
@@ -458,8 +456,7 @@ class LongPressHandler(
             ) ?: return null
 
             context.contentResolver.openOutputStream(uri)?.use { outputStream ->
-                val format = if (mimeType.contains("png")) Bitmap.CompressFormat.PNG else Bitmap.CompressFormat.JPEG
-                bitmap.compress(format, 95, outputStream)
+                outputStream.write(bytes)
             }
 
             contentValues.clear()
@@ -475,8 +472,7 @@ class LongPressHandler(
 
             val file = File(appDir, fileName)
             FileOutputStream(file).use { outputStream ->
-                val format = if (mimeType.contains("png")) Bitmap.CompressFormat.PNG else Bitmap.CompressFormat.JPEG
-                bitmap.compress(format, 95, outputStream)
+                outputStream.write(bytes)
             }
 
             val values = ContentValues().apply {

--- a/app/src/main/java/com/webtoapp/core/webview/MediaSessionCore.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/MediaSessionCore.kt
@@ -661,7 +661,9 @@ class MediaSessionCore(
             connection.connect()
 
             connection.inputStream.use {
-                BitmapFactory.decodeStream(it)
+                // Notification art: 1024px is plenty for lockscreen/SystemUI and
+                // keeps the binder transaction far under its limit (#779).
+                com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(it, 1024)
             }.also {
                 connection.disconnect()
             }

--- a/app/src/main/java/com/webtoapp/ui/components/ExtensionModuleCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ExtensionModuleCard.kt
@@ -570,7 +570,10 @@ private fun FabIconSelector(
         uri ?: return@rememberLauncherForActivityResult
         try {
             val inputStream = context.contentResolver.openInputStream(uri) ?: return@rememberLauncherForActivityResult
-            val original = BitmapFactory.decodeStream(inputStream)
+            // Bounded first: the full-res decode below OOMs on panoramas; the
+            // output is cropped and scaled to 96px anyway (#779).
+            val original = com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(inputStream)
+                ?: return@rememberLauncherForActivityResult
             inputStream.close()
 
             val size = minOf(original.width, original.height)
@@ -595,7 +598,7 @@ private fun FabIconSelector(
         if (selectedIcon.startsWith("custom:")) {
             try {
                 val bytes = Base64.decode(selectedIcon.removePrefix("custom:"), Base64.NO_WRAP)
-                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(bytes)
             } catch (e: Exception) { null }
         } else null
     }

--- a/app/src/main/java/com/webtoapp/ui/components/IconGeneratorDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/IconGeneratorDialog.kt
@@ -1,6 +1,5 @@
 package com.webtoapp.ui.components
 
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Base64
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -244,7 +243,7 @@ fun IconGeneratorDialog(
                         val bitmap = remember(base64) {
                             try {
                                 val bytes = Base64.decode(base64, Base64.DEFAULT)
-                                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                                com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(bytes)
                             } catch (e: Exception) { null }
                         }
                         bitmap?.let {

--- a/app/src/main/java/com/webtoapp/ui/components/ModuleIcon.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ModuleIcon.kt
@@ -1,6 +1,5 @@
 package com.webtoapp.ui.components
 
-import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -53,7 +52,7 @@ fun ModuleIcon(
             val bitmap = remember(assetPath) {
                 try {
                     context.assets.open(assetPath).use { inputStream ->
-                        BitmapFactory.decodeStream(inputStream)
+                        com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(inputStream)
                     }
                 } catch (e: Exception) {
                     null

--- a/app/src/main/java/com/webtoapp/ui/components/StatusBarBackground.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/StatusBarBackground.kt
@@ -1,9 +1,10 @@
 package com.webtoapp.ui.components
 
-import android.graphics.BitmapFactory
+import android.content.Context
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.core.logging.AppLogger
-import androidx.compose.foundation.Image
+import com.webtoapp.ui.shared.SafeBitmapImage
+import com.webtoapp.util.BoundedBitmaps
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
@@ -15,6 +16,31 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import java.io.File
+
+/**
+ * Loads a status-bar background image bounded to a drawable-safe size (#779).
+ * The file comes from user storage and can be arbitrarily large (panoramas,
+ * full-resolution crops); decoding it raw once crashed MainActivity screens
+ * with "Canvas: trying to draw too large" at DRAW time — past any decode
+ * try/catch. Returns null when the file is missing, oversized, or unreadable.
+ */
+private fun loadStatusBarImageBitmap(context: Context, backgroundImagePath: String): android.graphics.Bitmap? {
+    return try {
+        val file = File(backgroundImagePath)
+        if (file.exists()) {
+            if (!BoundedBitmaps.isProbablyImageFile(file)) return null
+            BoundedBitmaps.decodeBoundedBitmapFile(backgroundImagePath)
+        } else {
+            val assetPath = backgroundImagePath.removePrefix("assets/")
+            context.assets.open(assetPath).use { inputStream ->
+                BoundedBitmaps.decodeBoundedBitmapStream(inputStream)
+            }
+        }
+    } catch (e: Exception) {
+        AppLogger.e("StatusBarBackground", "加载状态栏背景图片失败: $backgroundImagePath", e)
+        null
+    }
+}
 
 @Composable
 fun StatusBarBackground(
@@ -44,22 +70,7 @@ fun StatusBarBackground(
 
     val imageBitmap = remember(backgroundImagePath) {
         if (backgroundType == "IMAGE" && !backgroundImagePath.isNullOrEmpty()) {
-            try {
-
-                val file = File(backgroundImagePath)
-                if (file.exists()) {
-                    BitmapFactory.decodeFile(backgroundImagePath)?.asImageBitmap()
-                } else {
-
-                    val assetPath = backgroundImagePath.removePrefix("assets/")
-                    context.assets.open(assetPath).use { inputStream ->
-                        BitmapFactory.decodeStream(inputStream)?.asImageBitmap()
-                    }
-                }
-            } catch (e: Exception) {
-                AppLogger.e("StatusBarBackground", "加载状态栏背景图片失败: $backgroundImagePath", e)
-                null
-            }
+            loadStatusBarImageBitmap(context, backgroundImagePath)?.asImageBitmap()
         } else {
             null
         }
@@ -73,7 +84,7 @@ fun StatusBarBackground(
         when {
             backgroundType == "IMAGE" && imageBitmap != null -> {
 
-                Image(
+                SafeBitmapImage(
                     bitmap = imageBitmap,
                     contentDescription = Strings.statusBarBackground,
                     modifier = Modifier
@@ -141,22 +152,7 @@ fun StatusBarOverlay(
 
     val imageBitmap = remember(backgroundImagePath) {
         if (backgroundType == "IMAGE" && !backgroundImagePath.isNullOrEmpty()) {
-            try {
-
-                val file = File(backgroundImagePath)
-                if (file.exists()) {
-                    BitmapFactory.decodeFile(backgroundImagePath)?.asImageBitmap()
-                } else {
-
-                    val assetPath = backgroundImagePath.removePrefix("assets/")
-                    context.assets.open(assetPath).use { inputStream ->
-                        BitmapFactory.decodeStream(inputStream)?.asImageBitmap()
-                    }
-                }
-            } catch (e: Exception) {
-                AppLogger.e("StatusBarOverlay", "加载状态栏背景图片失败: $backgroundImagePath", e)
-                null
-            }
+            loadStatusBarImageBitmap(context, backgroundImagePath)?.asImageBitmap()
         } else {
             null
         }
@@ -170,7 +166,7 @@ fun StatusBarOverlay(
         when {
             backgroundType == "IMAGE" && imageBitmap != null -> {
 
-                Image(
+                SafeBitmapImage(
                     bitmap = imageBitmap,
                     contentDescription = Strings.statusBarBackground,
                     modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/webtoapp/ui/screens/BrowserKernelScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/BrowserKernelScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import com.webtoapp.ui.components.EnhancedElevatedCard
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
+import com.webtoapp.util.BoundedBitmaps.toBoundedBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -599,9 +600,17 @@ private fun InstalledBrowserCard(
             verticalAlignment = Alignment.CenterVertically
         ) {
 
-                if (browser.icon != null) {
+                val iconBitmap = remember(browser.icon) {
+                    // Third-party app icons can be arbitrarily large; raster bounded (#779).
+                    try {
+                        browser.icon?.toBoundedBitmap()?.asImageBitmap()
+                    } catch (t: Throwable) {
+                        null
+                    }
+                }
+                if (iconBitmap != null) {
                 Image(
-                    bitmap = browser.icon.toBitmap().asImageBitmap(),
+                    bitmap = iconBitmap,
                     contentDescription = browser.name,
                     modifier = Modifier
                         .size(48.dp)

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppAnnouncementCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppAnnouncementCard.kt
@@ -71,7 +71,7 @@ fun AnnouncementCard(
 
     val previewBitmap = remember(announcement.customIconPath) {
         announcement.customIconPath?.let { p ->
-            try { android.graphics.BitmapFactory.decodeFile(p) } catch (e: Exception) { null }
+            try { com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(p) } catch (e: Exception) { null }
         }
     }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
@@ -6,7 +6,6 @@ import com.webtoapp.ui.design.WtaSpacing
 
 import android.Manifest
 import android.content.pm.PackageManager
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import android.widget.Toast
@@ -175,7 +174,8 @@ fun ExtensionModuleScreen(
             scope.launch {
                 try {
                     context.contentResolver.openInputStream(it)?.use { stream ->
-                        val bitmap = BitmapFactory.decodeStream(stream)
+                        // Bounded: a shared image can be an arbitrary camera panorama (#779).
+                        val bitmap = com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(stream)
                         if (bitmap != null) {
                             val qrContent = QrCodeUtils.decodeQrCode(bitmap)
                             if (qrContent != null) {

--- a/app/src/main/java/com/webtoapp/ui/shared/SafeBitmapImage.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/SafeBitmapImage.kt
@@ -1,0 +1,62 @@
+package com.webtoapp.ui.shared
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+
+/**
+ * Draw-side backstop against oversized-bitmap crashes (#779).
+ *
+ * Even a correctly bounded decode can be defeated later (shared caches, future
+ * code paths), and RecordingCanvas kills the process when asked to draw beyond
+ * its limit. This wrapper downscales any [ImageBitmap] whose side exceeds
+ * [maxDimensionPx] before handing it to [Image], so a missed decode-site can
+ * only ever render soft — never crash.
+ */
+@Composable
+fun SafeBitmapImage(
+    bitmap: ImageBitmap,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    maxDimensionPx: Int = 4096
+) {
+    val safe = remember(bitmap, maxDimensionPx) {
+        val w = bitmap.width
+        val h = bitmap.height
+        if (w <= 0 || h <= 0 || (w <= maxDimensionPx && h <= maxDimensionPx)) {
+            bitmap
+        } else {
+            runCatching {
+                val longest = maxOf(w, h)
+                val scale = maxDimensionPx / longest.toFloat()
+                val tw = maxOf(1, (w * scale).toInt())
+                val th = maxOf(1, (h * scale).toInt())
+                val bmp = android.graphics.Bitmap.createBitmap(tw, th, android.graphics.Bitmap.Config.ARGB_8888)
+                val canvas = android.graphics.Canvas(bmp)
+                canvas.drawBitmap(
+                    bitmap.asAndroidBitmap(), null,
+                    android.graphics.Rect(0, 0, tw, th), null
+                )
+                bmp.asImageBitmap()
+            }.getOrNull() ?: bitmap
+        }
+    }
+    Image(
+        bitmap = safe,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter
+    )
+}

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -107,7 +107,7 @@ fun ShellAnnouncementDialog(
     val customIconBitmap = if (config.announcementHasCustomIcon) {
         try {
             val bytes = com.webtoapp.core.crypto.AssetDecryptor(context).loadAsset("announcement_icon.png")
-            android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(bytes)
         } catch (e: Exception) { null }
     } else null
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellGallery.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellGallery.kt
@@ -450,7 +450,7 @@ fun ShellGalleryImageViewer(
 
                 context.assets.open(item.assetPath).use { it.readBytes() }
             }
-            bitmap = android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+            bitmap = com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(imageBytes)
         } catch (e: Exception) {
             AppLogger.e("ShellGallery", "Failed to load image: ${item.assetPath}", e)
         }
@@ -855,7 +855,7 @@ private fun ShellThumbnailCell(
             } catch (_: Exception) {
                 context.assets.open(thumbAssetPath).use { it.readBytes() }
             }
-            android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(bytes)
         } catch (e: Exception) {
             AppLogger.e("ShellGallery", "Failed to load thumbnail: $thumbAssetPath", e)
             null

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
@@ -67,11 +67,11 @@ fun ShellSplashOverlay(
                         try {
                             val previewFile = mediaPath?.let { java.io.File(it) }
                             if (previewFile != null && previewFile.exists()) {
-                                android.graphics.BitmapFactory.decodeFile(previewFile.absolutePath)
+                                com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(previewFile.absolutePath)
                             } else {
                                 val decryptor = com.webtoapp.core.crypto.AssetDecryptor(context)
                                 val imageBytes = decryptor.loadAsset(assetPath)
-                                android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+                                com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(imageBytes)
                             }
                         } catch (e: Exception) {
                             AppLogger.e("ShellSplash", "Failed to load splash image", e)
@@ -428,7 +428,7 @@ fun MediaContentDisplay(
                     try {
                         val decryptor = com.webtoapp.core.crypto.AssetDecryptor(context)
                         val imageBytes = decryptor.loadAsset("media_content.png")
-                        android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+                        com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(imageBytes)
                     } catch (e: Exception) {
                         AppLogger.e("MediaContent", "Failed to load image media", e)
                         null

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -344,7 +344,7 @@ fun AnnouncementDialog(
             announcement = announcement,
             template = announcement.template.toUiTemplate(),
             customIconBitmap = announcement.customIconPath?.let { p ->
-                try { android.graphics.BitmapFactory.decodeFile(p) } catch (e: Exception) { null }
+                try { com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(p) } catch (e: Exception) { null }
             }
         ),
         onDismiss = onDismiss,

--- a/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
@@ -2,7 +2,6 @@ package com.webtoapp.ui.viewmodel
 
 import android.app.Application
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -342,7 +341,7 @@ class MainViewModel(
                 "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/131.0.0.0 Mobile Safari/537.36")
             try {
                 if (conn.responseCode !in 200..299) return null
-                val bitmap = BitmapFactory.decodeStream(conn.inputStream) ?: return null
+                val bitmap = com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(conn.inputStream) ?: return null
                 IconStorage.saveIconFromBitmap(getApplication(), bitmap)
             } finally {
                 conn.disconnect()

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -3666,7 +3666,7 @@ com.webtoapp.ui.components.announcement.AnnouncementDialog(
                 announcement = ann,
                 template = ann.template.toUiTemplate(),
                 customIconBitmap = ann.customIconPath?.let { p ->
-                    try { android.graphics.BitmapFactory.decodeFile(p) } catch (e: Exception) { null }
+                    try { com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapFile(p) } catch (e: Exception) { null }
                 }
             ),
             onDismiss = {

--- a/app/src/main/java/com/webtoapp/util/BoundedBitmaps.kt
+++ b/app/src/main/java/com/webtoapp/util/BoundedBitmaps.kt
@@ -1,0 +1,171 @@
+package com.webtoapp.util
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import com.webtoapp.core.logging.AppLogger
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import kotlin.math.max
+
+/**
+ * Central guard against oversized-bitmap crashes (#779).
+ *
+ * A user-supplied image (status-bar background, browser icon, module icon, QR
+ * import, preview media) decoded at full resolution can exceed what
+ * RecordingCanvas can draw (e.g. a 15360x15360 bitmap = ~900MB), killing the
+ * process with "Canvas: trying to draw too large" at DRAW time — long after
+ * any try/catch around the decode has passed. Every decode of untrusted
+ * content must go through here instead of raw BitmapFactory calls.
+ *
+ * Rule: the longest side never exceeds [maxDimension] (default 2048px, plenty
+ * for any on-screen surface in this app). All entry points catch [Throwable],
+ * including [OutOfMemoryError], and return null.
+ */
+object BoundedBitmaps {
+
+    private const val TAG = "BoundedBitmaps"
+
+    const val DEFAULT_MAX_DIMENSION = 2048
+
+    /** Icons and other small chrome: 512px is 10x a 48dp target, still tiny. */
+    const val ICON_MAX_DIMENSION = 512
+
+    /** Upper bound for buffering a stream before decoding; beyond this, refuse. */
+    private const val MAX_DECODE_BYTES = 48 * 1024 * 1024
+
+    /**
+     * Pure math, unit-tested on plain JVM. Power-of-two sample so the longest
+     * source side fits in [maxDimension]. Returns 1 for degenerate input.
+     */
+    fun calculateInSampleSize(srcWidth: Int, srcHeight: Int, maxDimension: Int): Int {
+        if (maxDimension <= 0) return 1
+        if (srcWidth <= 0 || srcHeight <= 0) return 1
+        var sample = 1
+        while (srcWidth / sample > maxDimension || srcHeight / sample > maxDimension) {
+            if (sample >= 1 shl 30) break
+            sample *= 2
+        }
+        return sample
+    }
+
+    fun decodeBoundedBitmapFile(path: String, maxDimension: Int = DEFAULT_MAX_DIMENSION): Bitmap? {
+        return try {
+            val bounds = BitmapFactory.Options().also { it.inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(path, bounds)
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+            val opts = BitmapFactory.Options().also {
+                it.inSampleSize = calculateInSampleSize(bounds.outWidth, bounds.outHeight, maxDimension)
+                it.inPreferredConfig = Bitmap.Config.ARGB_8888
+            }
+            BitmapFactory.decodeFile(path, opts)
+        } catch (t: Throwable) {
+            AppLogger.w(TAG, "Bounded file decode failed: $path (${t.message})")
+            null
+        }
+    }
+
+    fun decodeBoundedBitmapBytes(data: ByteArray, maxDimension: Int = DEFAULT_MAX_DIMENSION): Bitmap? {
+        return try {
+            if (data.isEmpty() || data.size > MAX_DECODE_BYTES) return null
+            val bounds = BitmapFactory.Options().also { it.inJustDecodeBounds = true }
+            BitmapFactory.decodeByteArray(data, 0, data.size, bounds)
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+            val opts = BitmapFactory.Options().also {
+                it.inSampleSize = calculateInSampleSize(bounds.outWidth, bounds.outHeight, maxDimension)
+                it.inPreferredConfig = Bitmap.Config.ARGB_8888
+            }
+            BitmapFactory.decodeByteArray(data, 0, data.size, opts)
+        } catch (t: Throwable) {
+            AppLogger.w(TAG, "Bounded bytes decode failed (${data.size} bytes, ${t.message})")
+            null
+        }
+    }
+
+    fun decodeBoundedBitmapStream(stream: InputStream, maxDimension: Int = DEFAULT_MAX_DIMENSION): Bitmap? {
+        return try {
+            // Streams cannot be bounds-probed without consuming them, so buffer
+            // first (capped) and decode from memory.
+            val out = ByteArrayOutputStream(8192)
+            val buf = ByteArray(8192)
+            var total = 0
+            while (true) {
+                val n = stream.read(buf)
+                if (n < 0) break
+                total += n
+                if (total > MAX_DECODE_BYTES) {
+                    AppLogger.w(TAG, "Stream exceeds $MAX_DECODE_BYTES bytes, refusing decode")
+                    return null
+                }
+                out.write(buf, 0, n)
+            }
+            decodeBoundedBitmapBytes(out.toByteArray(), maxDimension)
+        } catch (t: Throwable) {
+            AppLogger.w(TAG, "Bounded stream decode failed (${t.message})")
+            null
+        }
+    }
+
+    /**
+     * Rasterize any [Drawable] (app icons, adaptive icons, vectors) capped at
+     * [maxDimension] on the longest side, preserving aspect ratio. Drawables
+     * without intrinsic dimensions raster at exactly [maxDimension] square.
+     */
+    fun Drawable.toBoundedBitmap(maxDimension: Int = ICON_MAX_DIMENSION): Bitmap? {
+        return try {
+            if (maxDimension <= 0) return null
+            if (this is BitmapDrawable && bitmap != null) {
+                return bitmap.downscaledToFit(maxDimension)
+            }
+            var w = intrinsicWidth
+            var h = intrinsicHeight
+            if (w <= 0 || h <= 0) {
+                w = maxDimension
+                h = maxDimension
+            } else {
+                val longest = max(w, h)
+                if (longest > maxDimension) {
+                    val scale = maxDimension / longest.toFloat()
+                    w = max(1, (w * scale).toInt())
+                    h = max(1, (h * scale).toInt())
+                }
+            }
+            val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888) ?: return null
+            val canvas = Canvas(bmp)
+            setBounds(0, 0, w, h)
+            draw(canvas)
+            bmp
+        } catch (t: Throwable) {
+            AppLogger.w(TAG, "Bounded drawable raster failed (${t.message})")
+            null
+        }
+    }
+
+    /**
+     * Downscale an already-decoded bitmap so its longest side fits
+     * [maxDimension]. Returns the original instance when already small enough.
+     */
+    fun Bitmap.downscaledToFit(maxDimension: Int): Bitmap {
+        return try {
+            val longest = max(width, height)
+            if (maxDimension <= 0 || longest <= maxDimension || longest <= 0) return this
+            val scale = maxDimension / longest.toFloat()
+            val tw = max(1, (width * scale).toInt())
+            val th = max(1, (height * scale).toInt())
+            Bitmap.createScaledBitmap(this, tw, th, true) ?: this
+        } catch (t: Throwable) {
+            AppLogger.w(TAG, "Downscale failed, keeping original (${t.message})")
+            this
+        }
+    }
+
+    /** True when [file] looks like an image the bounded decoders accept. */
+    fun isProbablyImageFile(file: File): Boolean {
+        if (!file.isFile || !file.canRead() || file.length() <= 0) return false
+        if (file.length() > MAX_DECODE_BYTES) return false
+        return true
+    }
+}

--- a/app/src/main/java/com/webtoapp/util/FaviconFetcher.kt
+++ b/app/src/main/java/com/webtoapp/util/FaviconFetcher.kt
@@ -162,7 +162,10 @@ object FaviconFetcher {
             val fileName = "favicon_${System.currentTimeMillis()}.png"
             val outputFile = File(iconsDir, fileName)
 
-            val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            val bitmap = com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(
+                bytes,
+                com.webtoapp.util.BoundedBitmaps.ICON_MAX_DIMENSION
+            )
             if (bitmap == null) {
                 AppLogger.w(TAG, "无法解码图片: $iconUrl")
                 return null

--- a/app/src/main/java/com/webtoapp/util/IconLibraryStorage.kt
+++ b/app/src/main/java/com/webtoapp/util/IconLibraryStorage.kt
@@ -58,7 +58,8 @@ object IconLibraryStorage {
     ): IconLibraryItem? = withContext(Dispatchers.IO) {
         try {
             val bytes = Base64.decode(base64Data, Base64.DEFAULT)
-            val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            val bitmap = com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(bytes)
+                ?: return@withContext null
 
             val id = "ai_${UUID.randomUUID().toString().take(8)}"
             val file = File(getLibraryDir(context), "$id.png")
@@ -89,7 +90,9 @@ object IconLibraryStorage {
     ): IconLibraryItem? = withContext(Dispatchers.IO) {
         try {
             val inputStream = context.contentResolver.openInputStream(uri) ?: return@withContext null
-            val bitmap = BitmapFactory.decodeStream(inputStream)
+            // Library icons render tiny; never store hostile full-res originals (#779).
+            val bitmap = com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapStream(inputStream)
+                ?: return@withContext null
             inputStream.close()
 
             val id = "lib_${UUID.randomUUID().toString().take(8)}"

--- a/app/src/main/java/com/webtoapp/util/IconStorage.kt
+++ b/app/src/main/java/com/webtoapp/util/IconStorage.kt
@@ -76,7 +76,7 @@ object IconStorage {
 
     fun saveIconFromBytes(context: Context, bytes: ByteArray): String? {
         return try {
-            val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return null
+            val bitmap = BoundedBitmaps.decodeBoundedBitmapBytes(bytes) ?: return null
             val result = saveIconFromBitmap(context, bitmap)
             bitmap.recycle()
             result

--- a/app/src/test/java/com/webtoapp/util/BoundedBitmapsTest.kt
+++ b/app/src/test/java/com/webtoapp/util/BoundedBitmapsTest.kt
@@ -1,0 +1,52 @@
+package com.webtoapp.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BoundedBitmapsTest {
+
+    @Test
+    fun `small images are untouched`() {
+        assertThat(BoundedBitmaps.calculateInSampleSize(1000, 800, 2048)).isEqualTo(1)
+        assertThat(BoundedBitmaps.calculateInSampleSize(2048, 2048, 2048)).isEqualTo(1)
+    }
+
+    @Test
+    fun `long side over cap triggers sampling`() {
+        // 1080x2412 phone screenshot: height exceeds 2048 -> sample 2 -> 540x1206.
+        assertThat(BoundedBitmaps.calculateInSampleSize(1080, 2412, 2048)).isEqualTo(2)
+    }
+
+    @Test
+    fun `issue 779 repro dimensions downsample below the cap`() {
+        // 15360x15360 @ARGB_8888 = 943,718,400 bytes: the exact crash report.
+        assertThat(BoundedBitmaps.calculateInSampleSize(15360, 15360, 2048)).isEqualTo(8)
+        // 15360 / 8 = 1920 per side -> ~14MB, drawable-safe.
+    }
+
+    @Test
+    fun `panorama longest side governs`() {
+        // 20000x1000 must not slip through on the short side.
+        assertThat(BoundedBitmaps.calculateInSampleSize(20000, 1000, 2048)).isEqualTo(16)
+    }
+
+    @Test
+    fun `sample size stays power of two`() {
+        var sample = BoundedBitmaps.calculateInSampleSize(100000, 100000, 2048)
+        assertThat(sample and (sample - 1)).isEqualTo(0)
+    }
+
+    @Test
+    fun `degenerate input never divides by zero`() {
+        assertThat(BoundedBitmaps.calculateInSampleSize(0, 100, 2048)).isEqualTo(1)
+        assertThat(BoundedBitmaps.calculateInSampleSize(100, -5, 2048)).isEqualTo(1)
+        assertThat(BoundedBitmaps.calculateInSampleSize(100, 100, 0)).isEqualTo(1)
+    }
+
+    @Test
+    fun `icon cap fits launcher needs`() {
+        // xxxhdpi adaptive foreground (432px) must survive the icon cap intact.
+        assertThat(BoundedBitmaps.calculateInSampleSize(432, 432, BoundedBitmaps.ICON_MAX_DIMENSION))
+            .isEqualTo(1)
+    }
+}

--- a/app/src/test/java/com/webtoapp/util/NoUnboundedBitmapDecodeTest.kt
+++ b/app/src/test/java/com/webtoapp/util/NoUnboundedBitmapDecodeTest.kt
@@ -1,0 +1,81 @@
+package com.webtoapp.util
+
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+import java.io.File
+
+/**
+ * Crash gate for #779 ("Canvas: trying to draw too large bitmap").
+ *
+ * Raw BitmapFactory decodes of untrusted content must never reach a draw call:
+ * the crash fires at DRAW time, past any try/catch around the decode. All such
+ * decodes go through [BoundedBitmaps]; files below are the only exceptions
+ * (each implements its own bounds sampling or provably needs full pixels).
+ */
+class NoUnboundedBitmapDecodeTest {
+
+    private val allowedFiles = setOf(
+        // The guard implementation itself.
+        "com/webtoapp/util/BoundedBitmaps.kt",
+        // Own two-pass bounds sampling for the crop UI.
+        "com/webtoapp/ui/components/IconCropDialog.kt",
+        "com/webtoapp/ui/components/StatusBarImageCropper.kt",
+        // Own bounds sampling on the import path.
+        "com/webtoapp/util/IconStorage.kt",
+        "com/webtoapp/util/MediaStorage.kt",
+        "com/webtoapp/util/SplashStorage.kt",
+        "com/webtoapp/util/FaviconFetcher.kt",
+        // Build-time background recompression: output quality requires pixels;
+        // OOM there fails one file (caught), never a draw call.
+        "com/webtoapp/core/linux/PerformanceOptimizer.kt"
+    )
+
+    private val rawDecodeCall = Regex(
+        """BitmapFactory\.(decodeFile|decodeStream|decodeByteArray)\("""
+    )
+    private val noArgToBitmap = Regex("""\.toBitmap\(\)""")
+
+    @Test
+    fun `no unbounded bitmap decodes outside the allowlist`() {
+        val roots = listOf("app/src/main/java", "src/main/java")
+            .map(::File)
+            .filter(File::exists)
+        assertWithMessage("Could not locate Kotlin source root")
+            .that(roots).isNotEmpty()
+
+        val offenders = mutableListOf<String>()
+        roots.forEach { root ->
+            root.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val relPath = file.relativeTo(root).path
+                    if (relPath in allowedFiles) return@forEach
+                    file.useLines { lines ->
+                        lines.forEachIndexed { index, raw ->
+                            val line = raw.trim()
+                            if (line.startsWith("//") || line.startsWith("*")) return@forEachIndexed
+                            if (rawDecodeCall.containsMatchIn(line) || noArgToBitmap.containsMatchIn(line)) {
+                                offenders += "${relPath}:${index + 1}: ${raw.trim()}"
+                            }
+                        }
+                    }
+                }
+        }
+
+        assertWithMessage(
+            buildString {
+                appendLine("Unbounded bitmap decode outside BoundedBitmaps.")
+                appendLine("Decode user/adaptive content ONLY via BoundedBitmaps helpers")
+                appendLine("(decodeBoundedBitmapFile/Stream/Bytes, Drawable.toBoundedBitmap),")
+                appendLine("or add the file above with a reason when it provably samples itself.")
+                appendLine()
+                appendLine("Why: RecordingCanvas kills the process at DRAW time for bitmaps")
+                appendLine("beyond its limit (issue #779: 943,718,400 bytes) — a try/catch")
+                appendLine("around the decode cannot save you.")
+                appendLine()
+                appendLine("Offending references:")
+                offenders.forEach { appendLine("  $it") }
+            }
+        ).that(offenders).isEmpty()
+    }
+}


### PR DESCRIPTION
Fixes #787

## Summary
v2.5.5 crashed on MainActivity with `Canvas: trying to draw too large (943718400 bytes)`. User/adaptive images were decoded at full resolution and drawn with plain `Image()`; the Canvas kills the process at DRAW time, so decode-side try/catch (and `catch (Exception)`, which misses OOM) could never help.

## What changed
- New `util/BoundedBitmaps`: capped decoders (file/stream/bytes), `Drawable.toBoundedBitmap`, `downscaledToFit`; longest side 2048, Throwable-safe.
- New `ui/shared/SafeBitmapImage` draw-side backstop (downscale past 4096px).
- Migrated all 17 raw decode sites (status bar backgrounds, browser icons, module icons, QR import, shell gallery/media/splash/dialogs, favicon, icon library/storage, floating icons, notification art, template/export icons).
- Long-press save writes bytes directly (lossless + faster); removed dead bitmap saver (also fixes latent NPE).
- Export recompress keeps full resolution but contains OOM per file.

## Test plan
- [x] BoundedBitmapsTest (sampling math incl. exact 15360px repro dims)
- [x] NoUnboundedBitmapDecodeTest source-scan gate
- [x] full unit suite 1033/1033 green
- [x] shell template rebuilds + syncs, no omni.ja
- [ ] CI `check` job green