### PR TITLE
fix(apkbuilder): degrade nested multi-web site sources to URL instead of aborting build

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -4409,9 +4409,21 @@ private fun WebApp.buildMultiWebBlock(context: android.content.Context?, package
     val sites = multiWebConfig?.sites?.map { site ->
         val siteShellConfig = if (repo != null && site.sourceAppId > 0) {
             kotlinx.coroutines.runBlocking { repo.getWebApp(site.sourceAppId) }?.let { sourceApp ->
-                buildSiteShellConfig(sourceApp, packageName, site.id, context)
+                val resolved = resolveMultiWebSiteSource(sourceApp, parentAppId = this.id, siteName = site.name)
+                resolved?.let {
+                    runCatching {
+                        buildSiteShellConfig(it, packageName, site.id, context)
+                    }.getOrElse { e ->
+                        AppLogger.w("ApkBuilder", "MultiWeb site \"${site.name}\" config skipped (${e.message}), using its URL")
+                        null
+                    }
+                }
             }
         } else null
+        // A site left without embedded config but still typed MULTI_WEB would hit
+        // the shell's recursive-nesting guard and render blank: normalize it to a
+        // plain URL site, which the shell always knows how to display.
+        val siteAppType = if (siteShellConfig == null && site.appType == "MULTI_WEB") "WEB" else site.appType
         com.webtoapp.core.shell.MultiWebSiteShellConfig(
             id = site.id,
             name = site.name,
@@ -4428,7 +4440,7 @@ private fun WebApp.buildMultiWebBlock(context: android.content.Context?, package
             faviconUrl = site.faviconUrl,
             themeColor = site.themeColor,
             sortIndex = site.sortIndex,
-            appType = site.appType,
+            appType = siteAppType,
             siteProjectId = site.siteProjectId,
             siteShellConfig = siteShellConfig
         )
@@ -4442,8 +4454,39 @@ private fun WebApp.buildMultiWebBlock(context: android.content.Context?, package
     )
 }
 
-internal fun buildSiteShellConfig(
-    sourceWebApp: WebApp,
+/**
+ * Resolves the source app a multi-web site embeds. Returns null (caller falls
+ * back to the site's plain URL) when embedding is impossible or unsafe:
+ * nested multi-web apps, self references, or a deleted source. A null source
+ * (deleted app) was always tolerated; the first two used to abort the whole
+ * build with "MultiWeb site source cannot be MULTI_WEB".
+ */
+internal fun resolveMultiWebSiteSource(
+    sourceApp: WebApp?,
+    parentAppId: Long,
+    siteName: String
+): WebApp? {
+    if (sourceApp == null) return null
+    if (sourceApp.appType == com.webtoapp.data.model.AppType.MULTI_WEB) {
+        AppLogger.w(
+            "ApkBuilder",
+            "MultiWeb site \"$siteName\" points at another multi-web app " +
+                "(id=${sourceApp.id}); nesting is not supported, embedding its URL instead"
+        )
+        return null
+    }
+    if (parentAppId > 0 && sourceApp.id == parentAppId) {
+        AppLogger.w(
+            "ApkBuilder",
+            "MultiWeb site \"$siteName\" points at its own app; self-nesting is not " +
+                "supported, embedding its URL instead"
+        )
+        return null
+    }
+    return sourceApp
+}
+
+internal fun buildSiteShellConfig(    sourceWebApp: WebApp,
     parentPkg: String,
     siteId: String,
     context: android.content.Context?,

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebSiteSourceTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebSiteSourceTest.kt
@@ -1,0 +1,39 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.WebApp
+import org.junit.Test
+
+class MultiWebSiteSourceTest {
+
+    private fun app(id: Long, type: AppType) = WebApp(id = id, name = "app-$id", url = "https://example.com/$id", appType = type)
+
+    @Test
+    fun `normal source resolves`() {
+        val source = app(12, AppType.WEB)
+        assertThat(resolveMultiWebSiteSource(source, parentAppId = 7, siteName = "s")).isEqualTo(source)
+    }
+
+    @Test
+    fun `nested multi-web source degrades to null`() {
+        assertThat(resolveMultiWebSiteSource(app(12, AppType.MULTI_WEB), parentAppId = 7, siteName = "s")).isNull()
+    }
+
+    @Test
+    fun `self reference degrades to null`() {
+        assertThat(resolveMultiWebSiteSource(app(7, AppType.WEB), parentAppId = 7, siteName = "s")).isNull()
+    }
+
+    @Test
+    fun `deleted source degrades to null`() {
+        assertThat(resolveMultiWebSiteSource(null, parentAppId = 7, siteName = "s")).isNull()
+    }
+
+    @Test
+    fun `unsaved parent cannot self reference`() {
+        // id 0 means "not persisted yet": only the type guard applies.
+        val source = app(12, AppType.WEB)
+        assertThat(resolveMultiWebSiteSource(source, parentAppId = 0, siteName = "s")).isEqualTo(source)
+    }
+}


### PR DESCRIPTION
Fixes #791

## Summary
Building a MULTI_WEB app whose site source resolves to another multi-web app aborted the entire build at PREPARE (`MultiWeb site source cannot be MULTI_WEB`). Now such sites degrade to plain-URL rendering with a per-site build-log warning, and the build succeeds.

## What changed
- New `resolveMultiWebSiteSource` (nested/self/missing -> null + warning).
- Sites left without embedded config but typed MULTI_WEB are normalized to WEB so the shell recursion guard doesn't render them blank.
- `require()` kept as an unreachable invariant.

## Test plan
- [x] MultiWebSiteSourceTest 5/5
- [x] full apkbuilder suite 164/164 green
- [ ] CI `check` job green