### PR TITLE
perf(backup): restart only when local files change, throttle progress callbacks

### DIFF
--- a/app/src/main/java/com/webtoapp/core/backup/DataBackupManager.kt
+++ b/app/src/main/java/com/webtoapp/core/backup/DataBackupManager.kt
@@ -26,6 +26,29 @@ import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import kotlin.coroutines.coroutineContext
 
+/**
+ * Time-based gate for high-frequency progress callbacks. A thousand-file backup
+ * must not recompose the progress UI a thousand times; milestones (0/50/60/100)
+ * bypass the gate and always emit. Pure logic, unit-tested on plain JVM.
+ */
+internal class ProgressThrottle(
+    private val minIntervalMs: Long = 150,
+    private val clockMs: () -> Long = System::currentTimeMillis
+) {
+    private var lastEmitMs: Long = -minIntervalMs
+
+    fun shouldEmit(force: Boolean = false): Boolean {
+        if (force) {
+            lastEmitMs = clockMs()
+            return true
+        }
+        val now = clockMs()
+        if (now - lastEmitMs < minIntervalMs) return false
+        lastEmitMs = now
+        return true
+    }
+}
+
 class DataBackupManager(private val context: Context) {
 
     companion object {
@@ -194,10 +217,13 @@ class DataBackupManager(private val context: Context) {
             }
 
             val resourceFiles = mutableMapOf<String, String>()
+            val collectThrottle = ProgressThrottle()
 
             apps.forEachIndexed { index, app ->
                 coroutineContext.ensureActive()
-                onProgress(10 + (index * 30 / apps.size), 100, Strings.backupCollectingResources.format(app.name))
+                if (collectThrottle.shouldEmit()) {
+                    onProgress(10 + (index * 30 / apps.size), 100, Strings.backupCollectingResources.format(app.name))
+                }
                 collectAppResources(app, resourceFiles)
             }
 
@@ -232,6 +258,7 @@ class DataBackupManager(private val context: Context) {
                     val totalFileCount = resourceFiles.size + localFiles.size
                     val writtenZipPaths = HashSet<String>(totalFileCount * 2)
                     var processedFiles = 0
+                    val packThrottle = ProgressThrottle()
 
                     fun writeZipFile(zipPath: String, file: File) {
 
@@ -246,6 +273,7 @@ class DataBackupManager(private val context: Context) {
 
                     fun reportPackaging() {
                         processedFiles++
+                        if (!packThrottle.shouldEmit()) return
                         val pct = if (totalFileCount > 0) {
                             50 + (processedFiles * 45 / totalFileCount)
                         } else 95
@@ -308,11 +336,14 @@ class DataBackupManager(private val context: Context) {
                 ZipInputStream(BufferedInputStream(inputStream, BUFFER_SIZE)).use { zipIn ->
                     var entry = zipIn.nextEntry
                     var totalEntries = 0
+                    val extractThrottle = ProgressThrottle()
 
                     while (entry != null) {
                         coroutineContext.ensureActive()
                         totalEntries++
-                        onProgress(10 + (totalEntries % 40), 100, Strings.backupExtracting.format(entry.name))
+                        if (extractThrottle.shouldEmit()) {
+                            onProgress(10 + (totalEntries % 40), 100, Strings.backupExtracting.format(entry.name))
+                        }
 
                         when {
                             entry.name == APPS_JSON -> {
@@ -358,7 +389,9 @@ class DataBackupManager(private val context: Context) {
             }
 
             // The backup has validated — only now overwrite live local config files.
-            commitPendingLocalEntries(pendingLocalEntries)
+            // Restart is only needed when local files actually changed: Room writes
+            // take effect immediately, so an apps-only restore stays put.
+            val localsRestored = commitPendingLocalEntries(pendingLocalEntries)
 
             onProgress(60, 100, Strings.backupImportingData)
             coroutineContext.ensureActive()
@@ -368,14 +401,17 @@ class DataBackupManager(private val context: Context) {
             val categoryIdMap = restoreCategories(data.categories)
 
             val appIdMap = mutableMapOf<Long, Long>()
+            val importThrottle = ProgressThrottle()
 
             data.apps.forEachIndexed { index, app ->
                 coroutineContext.ensureActive()
-                onProgress(
-                    60 + (index * 35 / data.apps.size),
-                    100,
-                    Strings.backupImportingApp.format(app.name)
-                )
+                if (importThrottle.shouldEmit()) {
+                    onProgress(
+                        60 + (index * 35 / data.apps.size),
+                        100,
+                        Strings.backupImportingApp.format(app.name)
+                    )
+                }
 
                 try {
 
@@ -410,7 +446,8 @@ class DataBackupManager(private val context: Context) {
             Result.success(ImportResult(
                 totalCount = data.appCount,
                 importedCount = importedCount,
-                skippedCount = skippedCount
+                skippedCount = skippedCount,
+                localFilesRestored = localsRestored
             ))
 
         } catch (e: Exception) {
@@ -1037,16 +1074,20 @@ class DataBackupManager(private val context: Context) {
         }
     }
 
-    private fun commitPendingLocalEntries(pending: List<PendingLocalEntry>) {
+    /** Visible for unit tests (commit accounting). */
+    internal fun commitPendingLocalEntries(pending: List<PendingLocalEntry>): Boolean {
+        var committed = false
         pending.forEach { entry ->
             runCatching {
                 entry.targetFile.parentFile?.mkdirs()
                 entry.tempFile.copyTo(entry.targetFile, overwrite = true)
+                committed = true
             }.onFailure { e ->
                 AppLogger.w(TAG, "恢复本地数据失败: ${entry.zipPath}", e)
             }
             entry.tempFile.delete()
         }
+        return committed
     }
 
     private fun discardPendingLocalEntries(pending: List<PendingLocalEntry>) {
@@ -1120,5 +1161,7 @@ data class ExportResult(
 data class ImportResult(
     val totalCount: Int,
     val importedCount: Int,
-    val skippedCount: Int
+    val skippedCount: Int,
+    /** True when any local (prefs/datastore/shared/file) entry was committed. */
+    val localFilesRestored: Boolean = false
 )

--- a/app/src/main/java/com/webtoapp/ui/components/DataBackupCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/DataBackupCard.kt
@@ -117,9 +117,12 @@ fun DataBackupCard() {
                     ).show()
                     // Restored DataStore/SharedPreferences files only take effect
                     // after restart (in-memory caches would otherwise clobber them).
-                    scope.launch {
-                        kotlinx.coroutines.delay(1200)
-                        backupManager.scheduleAppRestart()
+                    // Room-only restores are live already: stay put, don't restart.
+                    if (importResult.localFilesRestored) {
+                        scope.launch {
+                            kotlinx.coroutines.delay(1200)
+                            backupManager.scheduleAppRestart()
+                        }
                     }
                 }.onFailure { e ->
                     errorScope = "Data backup import"

--- a/app/src/test/java/com/webtoapp/core/backup/BackupCommitAccountingTest.kt
+++ b/app/src/test/java/com/webtoapp/core/backup/BackupCommitAccountingTest.kt
@@ -1,0 +1,69 @@
+package com.webtoapp.core.backup
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.io.File
+
+/**
+ * commitPendingLocalEntries reports whether anything was actually committed,
+ * so the UI restarts the app only when restored files need it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class BackupCommitAccountingTest {
+
+    private val manager by lazy {
+        DataBackupManager(RuntimeEnvironment.getApplication())
+    }
+
+    private fun stagedEntry(name: String, content: String): DataBackupManager.PendingLocalEntry {
+        val target = File(RuntimeEnvironment.getApplication().filesDir, "commit_probe/$name")
+        val temp = File.createTempFile("wta_commit_", ".part", RuntimeEnvironment.getApplication().cacheDir)
+        temp.writeText(content)
+        return DataBackupManager.PendingLocalEntry(
+            zipPath = "local/files/commit_probe/$name",
+            targetFile = target,
+            tempFile = temp
+        )
+    }
+
+    @Test
+    fun `empty pending list reports nothing committed`() {
+        assertThat(manager.commitPendingLocalEntries(emptyList())).isFalse()
+    }
+
+    @Test
+    fun `successful commit reports true and lands the file`() {
+        val committed = manager.commitPendingLocalEntries(
+            listOf(stagedEntry("a.txt", "hello"))
+        )
+        assertThat(committed).isTrue()
+        val landed = File(RuntimeEnvironment.getApplication().filesDir, "commit_probe/a.txt")
+        try {
+            assertThat(landed.readText()).isEqualTo("hello")
+        } finally {
+            File(RuntimeEnvironment.getApplication().filesDir, "commit_probe").deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `failed commit reports false`() {
+        // Target inside a regular file: mkdirs + copy cannot succeed.
+        val blocker = File(RuntimeEnvironment.getApplication().filesDir, "commit_blocker")
+        try {
+            blocker.writeText("x")
+            val temp = File.createTempFile("wta_commit_", ".part", RuntimeEnvironment.getApplication().cacheDir)
+            temp.writeText("y")
+            val entry = DataBackupManager.PendingLocalEntry(
+                zipPath = "local/files/commit_blocker/child.txt",
+                targetFile = File(blocker, "child.txt"),
+                tempFile = temp
+            )
+            assertThat(manager.commitPendingLocalEntries(listOf(entry))).isFalse()
+        } finally {
+            blocker.delete()
+        }
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/backup/ProgressThrottleTest.kt
+++ b/app/src/test/java/com/webtoapp/core/backup/ProgressThrottleTest.kt
@@ -1,0 +1,37 @@
+package com.webtoapp.core.backup
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ProgressThrottleTest {
+
+    @Test
+    fun `first call always emits`() {
+        val throttle = ProgressThrottle(minIntervalMs = 150, clockMs = { 1_000L })
+        assertThat(throttle.shouldEmit()).isTrue()
+    }
+
+    @Test
+    fun `calls inside the window are swallowed`() {
+        var now = 0L
+        val throttle = ProgressThrottle(minIntervalMs = 150, clockMs = { now })
+        assertThat(throttle.shouldEmit()).isTrue()
+        now = 100L
+        assertThat(throttle.shouldEmit()).isFalse()
+        assertThat(throttle.shouldEmit()).isFalse()
+        now = 150L
+        assertThat(throttle.shouldEmit()).isTrue()
+    }
+
+    @Test
+    fun `force bypasses the window and resets it`() {
+        var now = 0L
+        val throttle = ProgressThrottle(minIntervalMs = 10_000L, clockMs = { now })
+        assertThat(throttle.shouldEmit()).isTrue()
+        assertThat(throttle.shouldEmit(force = true)).isTrue()
+        // Timer restarted by the forced emit: normal call right after is swallowed.
+        assertThat(throttle.shouldEmit()).isFalse()
+        now = 10_000L
+        assertThat(throttle.shouldEmit()).isTrue()
+    }
+}


### PR DESCRIPTION
Fixes #793

## Summary
Two backup follow-ups: skip the post-import restart when only Room data changed (live already), and stop per-file progress callbacks from recomposing the UI thousands of times.

## What changed
- `commitPendingLocalEntries` returns commit status; `ImportResult.localFilesRestored` (defaulted); UI restarts only then.
- New `ProgressThrottle` wired into export collect/pack and import extract/per-app loops; milestones still direct.

## Test plan
- [x] BackupCommitAccountingTest + ProgressThrottleTest (6 tests)
- [x] full unit suite 1055/1055 green
- [ ] CI `check` job green