### PR TITLE
fix(multiweb): embed gallery/media site files and resolve them at runtime

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
@@ -109,7 +109,9 @@ class ApkBuildCache(private val context: Context) {
         errorPageMediaPath: String?,
         nativeLibsFingerprint: String? = null,
         hostVersionCode: Int = 0,
-        forceFullRebuild: Boolean
+        forceFullRebuild: Boolean,
+        multiWebSiteGalleryItems: List<com.webtoapp.data.model.GalleryItem> = emptyList(),
+        multiWebSiteMediaPaths: List<String> = emptyList()
     ): IncrementalPlan {
         val shellId = shellTemplateId(templateApk)
         val identity = identityFingerprint(
@@ -132,7 +134,9 @@ class ApkBuildCache(private val context: Context) {
             errorPageMediaPath = errorPageMediaPath,
             statusBarImage = config.statusBarBackgroundImage,
             statusBarImageDark = config.statusBarBackgroundImageDark,
-            floatingIcon = config.floatingWindowMinimizedIconPath
+            floatingIcon = config.floatingWindowMinimizedIconPath,
+            multiWebSiteGalleryItems = multiWebSiteGalleryItems,
+            multiWebSiteMediaPaths = multiWebSiteMediaPaths
         )
 
         if (forceFullRebuild) {
@@ -391,7 +395,9 @@ class ApkBuildCache(private val context: Context) {
         errorPageMediaPath: String?,
         statusBarImage: String?,
         statusBarImageDark: String?,
-        floatingIcon: String?
+        floatingIcon: String?,
+        multiWebSiteGalleryItems: List<com.webtoapp.data.model.GalleryItem> = emptyList(),
+        multiWebSiteMediaPaths: List<String> = emptyList()
     ): String {
         val parts = mutableListOf<String>()
         parts += "configJson=${ApkConfigJsonFactory.create(config)}"
@@ -412,6 +418,12 @@ class ApkBuildCache(private val context: Context) {
         }
         galleryItems.forEachIndexed { index, item ->
             parts += "gallery[$index]=${item.path}|${fileFingerprint(item.path)}|thumb=${fileFingerprint(item.thumbnailPath)}"
+        }
+        multiWebSiteGalleryItems.forEachIndexed { index, item ->
+            parts += "mwGallery[$index]=${item.path}|${fileFingerprint(item.path)}|thumb=${fileFingerprint(item.thumbnailPath)}"
+        }
+        multiWebSiteMediaPaths.forEachIndexed { index, path ->
+            parts += "mwMedia[$index]=${fileFingerprint(path)}"
         }
         return sha256(parts.joinToString("\n"))
     }

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -752,6 +752,10 @@ class ApkBuilder(private val context: Context) {
 
             logger.section("Incremental Build Plan")
             val hostVersionCode = rememberHostVersionCode()
+            // Media files of multi-web GALLERY/IMAGE/VIDEO sites are embedded
+            // under per-site prefixes; without their bytes in the key, editing
+            // a source gallery would keep serving a stale cached APK.
+            val mwSiteMedia = resolveMultiWebSiteMediaInputs(webApp)
             val incrementalPlan = buildCache.plan(
                 webApp = webApp,
                 packageName = packageName,
@@ -782,7 +786,9 @@ class ApkBuilder(private val context: Context) {
                     null
                 },
                 hostVersionCode = hostVersionCode,
-                forceFullRebuild = forceFullRebuild
+                forceFullRebuild = forceFullRebuild,
+                multiWebSiteGalleryItems = mwSiteMedia.galleryItems.values.flatten(),
+                multiWebSiteMediaPaths = mwSiteMedia.mediaPaths.values.toList()
             )
             logger.logKeyValue("incrementalMode", incrementalPlan.mode.name)
             logger.logKeyValue("incrementalReason", incrementalPlan.reason)
@@ -827,6 +833,8 @@ class ApkBuilder(private val context: Context) {
                             bgmCoverPaths = bgmCoverPaths,
                             htmlFiles = htmlFiles,
                             galleryItems = galleryItems,
+                            multiWebSiteGalleryItems = mwSiteMedia.galleryItems,
+                            multiWebSiteMediaPaths = mwSiteMedia.mediaPaths,
                             encryptionConfig = encryptionConfig,
                             encryptionKey = encryptionKey,
                             abiFilters = architecture.abiFilters,
@@ -866,6 +874,8 @@ class ApkBuilder(private val context: Context) {
                             bgmCoverPaths = bgmCoverPaths,
                             htmlFiles = htmlFiles,
                             galleryItems = galleryItems,
+                            multiWebSiteGalleryItems = mwSiteMedia.galleryItems,
+                            multiWebSiteMediaPaths = mwSiteMedia.mediaPaths,
                             encryptionConfig = encryptionConfig,
                             encryptionKey = encryptionKey,
                             abiFilters = architecture.abiFilters,
@@ -908,6 +918,8 @@ class ApkBuilder(private val context: Context) {
                         bgmCoverPaths = bgmCoverPaths,
                         htmlFiles = htmlFiles,
                         galleryItems = galleryItems,
+                        multiWebSiteGalleryItems = mwSiteMedia.galleryItems,
+                        multiWebSiteMediaPaths = mwSiteMedia.mediaPaths,
                         encryptionConfig = encryptionConfig,
                         encryptionKey = encryptionKey,
                         abiFilters = architecture.abiFilters,
@@ -1215,6 +1227,8 @@ class ApkBuilder(private val context: Context) {
         bgmCoverPaths: List<String?> = emptyList(),
         htmlFiles: List<com.webtoapp.data.model.HtmlFile> = emptyList(),
         galleryItems: List<com.webtoapp.data.model.GalleryItem> = emptyList(),
+        multiWebSiteGalleryItems: Map<String, List<com.webtoapp.data.model.GalleryItem>> = emptyMap(),
+        multiWebSiteMediaPaths: Map<String, String> = emptyMap(),
         encryptionConfig: EncryptionConfig = EncryptionConfig.DISABLED,
         encryptionKey: SecretKey? = null,
         abiFilters: List<String> = emptyList(),
@@ -1602,7 +1616,9 @@ class ApkBuilder(private val context: Context) {
                         fnAddPhpAppFiles = ::addPhpAppFilesToAssets,
                         fnAddPythonAppFiles = ::addPythonAppFilesToAssets,
                         fnAddGoAppFiles = ::addGoAppFilesToAssets,
-                        multiWebSiteSourceDirs = multiWebSiteSourceDirs
+                        multiWebSiteSourceDirs = multiWebSiteSourceDirs,
+                        multiWebSiteGalleryItems = multiWebSiteGalleryItems,
+                        multiWebSiteMediaPaths = multiWebSiteMediaPaths
                     )
                     val result = embedder.embed(zipOut, embedCtx)
                     logger.log("Content embedding [${config.appType}]: ${result.message}")
@@ -2032,12 +2048,13 @@ class ApkBuilder(private val context: Context) {
         }
     }
 
-    private fun addMediaContentToAssets(
+    internal fun addMediaContentToAssets(
         zipOut: ZipOutputStream,
         mediaPath: String,
         isVideo: Boolean,
         encryptor: AssetEncryptor? = null,
-        encryptionConfig: EncryptionConfig = EncryptionConfig.DISABLED
+        encryptionConfig: EncryptionConfig = EncryptionConfig.DISABLED,
+        assetNameOverride: String? = null
     ) {
         AppLogger.d("ApkBuilder", "Preparing to embed media content: path=$mediaPath, isVideo=$isVideo, encrypt=${encryptionConfig.enabled}")
 
@@ -2059,7 +2076,7 @@ class ApkBuilder(private val context: Context) {
         }
 
         val extension = if (isVideo) "mp4" else "png"
-        val assetName = "media_content.$extension"
+        val assetName = assetNameOverride ?: "media_content.$extension"
 
         try {
 
@@ -2097,13 +2114,14 @@ class ApkBuilder(private val context: Context) {
         }
     }
 
-    private fun addGalleryItemsToAssets(
+    internal fun addGalleryItemsToAssets(
         zipOut: ZipOutputStream,
         galleryItems: List<com.webtoapp.data.model.GalleryItem>,
         encryptor: AssetEncryptor? = null,
-        encryptionConfig: EncryptionConfig = EncryptionConfig.DISABLED
+        encryptionConfig: EncryptionConfig = EncryptionConfig.DISABLED,
+        assetPrefix: String = "gallery"
     ) {
-        AppLogger.d("ApkBuilder", "Preparing to embed ${galleryItems.size} gallery items, encrypt=${encryptionConfig.enabled}")
+        AppLogger.d("ApkBuilder", "Preparing to embed ${galleryItems.size} gallery items at $assetPrefix, encrypt=${encryptionConfig.enabled}")
 
         galleryItems.forEachIndexed { index, item ->
             try {
@@ -2118,7 +2136,7 @@ class ApkBuilder(private val context: Context) {
                 }
 
                 val ext = if (item.type == com.webtoapp.data.model.GalleryItemType.VIDEO) "mp4" else "png"
-                val assetName = "gallery/item_$index.$ext"
+                val assetName = "$assetPrefix/item_$index.$ext"
                 val isVideo = item.type == com.webtoapp.data.model.GalleryItemType.VIDEO
                 val fileSize = mediaFile.length()
                 val largeFileThreshold = 10 * 1024 * 1024L
@@ -2145,7 +2163,7 @@ class ApkBuilder(private val context: Context) {
                 item.thumbnailPath?.let { thumbPath ->
                     val thumbFile = File(thumbPath)
                     if (thumbFile.exists() && thumbFile.canRead()) {
-                        val thumbAssetName = "gallery/thumb_$index.jpg"
+                        val thumbAssetName = "$assetPrefix/thumb_$index.jpg"
                         val thumbBytes = thumbFile.readBytes()
                         if (encryptionConfig.enabled && encryptor != null) {
                             val encryptedThumb = encryptor.encrypt(thumbBytes, thumbAssetName)
@@ -4461,12 +4479,69 @@ private fun WebApp.buildMultiWebBlock(context: android.content.Context?, package
  * (deleted app) was always tolerated; the first two used to abort the whole
  * build with "MultiWeb site source cannot be MULTI_WEB".
  */
+/**
+ * Host-side media inputs of a multi-web app's media sites (GALLERY /
+ * IMAGE / VIDEO sources), keyed by site id. Resolved once per build and
+ * shared by the incremental-cache fingerprint and the embed step, so the
+ * two can never disagree about what a site contains.
+ *
+ * Remote-URL media is skipped (same as standalone export, which only ever
+ * embedded local files); only existing readable local files qualify.
+ */
+internal data class MultiWebSiteMediaInputs(
+    val galleryItems: Map<String, List<com.webtoapp.data.model.GalleryItem>> = emptyMap(),
+    val mediaPaths: Map<String, String> = emptyMap()
+)
+
+internal fun resolveMultiWebSiteMediaInputs(webApp: WebApp): MultiWebSiteMediaInputs {
+    if (webApp.appType != com.webtoapp.data.model.AppType.MULTI_WEB) return MultiWebSiteMediaInputs()
+    val sites = webApp.multiWebConfig?.sites.orEmpty().filter { it.enabled && it.sourceAppId > 0 }
+    if (sites.isEmpty()) return MultiWebSiteMediaInputs()
+    val repo = try {
+        org.koin.java.KoinJavaComponent.get<com.webtoapp.data.repository.WebAppRepository>(
+            com.webtoapp.data.repository.WebAppRepository::class.java
+        )
+    } catch (_: Exception) {
+        return MultiWebSiteMediaInputs()
+    }
+    val gallery = mutableMapOf<String, List<com.webtoapp.data.model.GalleryItem>>()
+    val media = mutableMapOf<String, String>()
+    for (site in sites) {
+        val source = try {
+            kotlinx.coroutines.runBlocking { repo.getWebApp(site.sourceAppId) }
+        } catch (_: Exception) {
+            null
+        } ?: continue
+        when (source.appType) {
+            com.webtoapp.data.model.AppType.GALLERY -> {
+                source.galleryConfig?.items?.takeIf { it.isNotEmpty() }?.let {
+                    gallery[site.id] = it
+                }
+            }
+            com.webtoapp.data.model.AppType.IMAGE,
+            com.webtoapp.data.model.AppType.VIDEO -> {
+                val raw = source.mediaConfig?.mediaPath?.takeIf { it.isNotBlank() }
+                    ?: source.url.takeIf { it.isNotBlank() }
+                    ?: continue
+                if (raw.startsWith("http://") || raw.startsWith("https://") ||
+                    raw.startsWith("asset://")
+                ) {
+                    continue
+                }
+                val file = java.io.File(raw)
+                if (file.isFile && file.canRead()) media[site.id] = file.absolutePath
+            }
+            else -> {}
+        }
+    }
+    return MultiWebSiteMediaInputs(gallery, media)
+}
+
 internal fun resolveMultiWebSiteSource(
     sourceApp: WebApp?,
     parentAppId: Long,
     siteName: String
-): WebApp? {
-    if (sourceApp == null) return null
+): WebApp? {    if (sourceApp == null) return null
     if (sourceApp.appType == com.webtoapp.data.model.AppType.MULTI_WEB) {
         AppLogger.w(
             "ApkBuilder",
@@ -4511,13 +4586,104 @@ internal fun buildSiteShellConfig(    sourceWebApp: WebApp,
     } else {
         "multiweb_$siteId"
     }
-    return shell.copy(
+    var out = shell.copy(
         siteId = siteId,
         siteDirName = siteDirName,
         siteAssetBase = assetBase,
         packageName = sitePkg,
         multiWebConfig = com.webtoapp.core.shell.MultiWebShellConfig()
     )
+    // Gallery sites render through ShellGalleryPlayer, which resolves every
+    // item through APK assets. Standalone gallery exports live at
+    // assets/gallery/, which a multi-web APK never populates for sites —
+    // without a rewrite every item 404s into a black cell (reported bug).
+    if (sourceWebApp.appType == com.webtoapp.data.model.AppType.GALLERY) {
+        out = if (isPreview) {
+            // Host run: point items at the source host files; the shell
+            // gallery loader prefers existing absolute paths over assets.
+            out.copy(
+                galleryConfig = out.galleryConfig.copy(
+                    items = previewGallerySiteItems(sourceWebApp)
+                )
+            )
+        } else {
+            out.copy(
+                galleryConfig = out.galleryConfig.copy(
+                    items = rewriteMultiWebGallerySitePaths(out.galleryConfig.items, siteId)
+                )
+            )
+        }
+    }
+    if (isPreview && (
+        sourceWebApp.appType == com.webtoapp.data.model.AppType.IMAGE ||
+            sourceWebApp.appType == com.webtoapp.data.model.AppType.VIDEO
+        )
+    ) {
+        out = out.copy(previewMediaPath = multiWebSitePreviewMediaPath(sourceWebApp))
+    }
+    return out
+}
+
+/** Asset prefix a multi-web gallery site's media is embedded under. */
+internal fun multiWebSiteGalleryAssetPrefix(siteId: String) = "multiweb_sites/$siteId/gallery"
+
+/**
+ * Rewrite gallery item paths to the per-site prefixed location used at
+ * export time. Index-aligned with [addGalleryItemsToAssets], which embeds
+ * source items in the same order under the same prefix.
+ */
+internal fun rewriteMultiWebGallerySitePaths(
+    items: List<com.webtoapp.core.shell.GalleryShellItem>,
+    siteId: String
+): List<com.webtoapp.core.shell.GalleryShellItem> {
+    val prefix = multiWebSiteGalleryAssetPrefix(siteId)
+    return items.mapIndexed { index, item ->
+        val ext = if (item.type == "VIDEO") "mp4" else "png"
+        item.copy(
+            assetPath = "$prefix/item_$index.$ext",
+            thumbnailPath = item.thumbnailPath?.let { "$prefix/thumb_$index.jpg" }
+        )
+    }
+}
+
+/**
+ * Gallery items for host-run preview: absolute host files straight from the
+ * source app (mirrors the fields buildGalleryBlock maps, minus asset naming).
+ */
+internal fun previewGallerySiteItems(
+    sourceWebApp: WebApp
+): List<com.webtoapp.core.shell.GalleryShellItem> {
+    return sourceWebApp.galleryConfig?.items?.map { item ->
+        com.webtoapp.core.shell.GalleryShellItem(
+            id = item.id,
+            assetPath = item.path,
+            type = item.type.name,
+            name = item.name,
+            duration = item.duration,
+            thumbnailPath = item.thumbnailPath
+        )
+    } ?: emptyList()
+}
+
+/**
+ * Host media file for an IMAGE/VIDEO multi-web site in host-run preview.
+ * Remote URLs are left null (unchanged behavior); only existing local files
+ * qualify, mirroring the export preflight's media path resolution.
+ */
+internal fun multiWebSitePreviewMediaPath(sourceWebApp: WebApp): String? {
+    if (sourceWebApp.appType != com.webtoapp.data.model.AppType.IMAGE &&
+        sourceWebApp.appType != com.webtoapp.data.model.AppType.VIDEO
+    ) {
+        return null
+    }
+    val raw = sourceWebApp.mediaConfig?.mediaPath?.takeIf { it.isNotBlank() }
+        ?: sourceWebApp.url.takeIf { it.isNotBlank() }
+        ?: return null
+    if (raw.startsWith("http://") || raw.startsWith("https://") || raw.startsWith("asset://")) {
+        return null
+    }
+    val file = java.io.File(raw)
+    return if (file.isFile && file.canRead()) file.absolutePath else null
 }
 
 private fun extractHostsFromUrl(url: String, customHosts: List<String> = emptyList()): List<String> {

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/AppContentEmbedder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/AppContentEmbedder.kt
@@ -22,16 +22,20 @@ class EmbedContext(
     val projectDir: File?,
     val secondaryProjectDir: File?,
 
-    val fnAddMediaContent: (ZipOutputStream, String, Boolean, AssetEncryptor?, EncryptionConfig) -> Unit,
+    val fnAddMediaContent: (ZipOutputStream, String, Boolean, AssetEncryptor?, EncryptionConfig, String?) -> Unit,
     val fnAddHtmlFiles: (ZipOutputStream, List<com.webtoapp.data.model.HtmlFile>, AssetEncryptor?, EncryptionConfig) -> Int,
-    val fnAddGalleryItems: (ZipOutputStream, List<com.webtoapp.data.model.GalleryItem>, AssetEncryptor?, EncryptionConfig) -> Unit,
+    val fnAddGalleryItems: (ZipOutputStream, List<com.webtoapp.data.model.GalleryItem>, AssetEncryptor?, EncryptionConfig, String) -> Unit,
     val fnAddWordPressFiles: (ZipOutputStream, File) -> Unit,
     val fnAddNodeJsFiles: (ZipOutputStream, File) -> Unit,
     val fnAddFrontendFiles: (ZipOutputStream, File, List<com.webtoapp.data.model.HtmlFile>) -> Unit,
     val fnAddPhpAppFiles: (ZipOutputStream, File) -> Unit,
     val fnAddPythonAppFiles: (ZipOutputStream, File) -> Unit,
     val fnAddGoAppFiles: (ZipOutputStream, File) -> Unit,
-    val multiWebSiteSourceDirs: Map<String, File> = emptyMap()
+    val multiWebSiteSourceDirs: Map<String, File> = emptyMap(),
+    /** Multi-web GALLERY site id -> source host-path items (embedded under the site prefix). */
+    val multiWebSiteGalleryItems: Map<String, List<com.webtoapp.data.model.GalleryItem>> = emptyMap(),
+    /** Multi-web IMAGE/VIDEO site id -> source host media path. */
+    val multiWebSiteMediaPaths: Map<String, String> = emptyMap()
 )
 
 data class EmbedResult(
@@ -65,7 +69,7 @@ class MediaContentEmbedder : AppContentEmbedder {
         val mediaPath = ctx.mediaContentPath ?: return EmbedResult(false, message = "No media content path")
         ctx.logger.log("Embedding single media content: $mediaPath")
         val isVideo = ctx.config.appType == "VIDEO"
-        ctx.fnAddMediaContent(zipOut, mediaPath, isVideo, ctx.encryptor, ctx.encryptionConfig)
+        ctx.fnAddMediaContent(zipOut, mediaPath, isVideo, ctx.encryptor, ctx.encryptionConfig, null)
         return EmbedResult(true, 1, "Media content embedded")
     }
 }
@@ -135,7 +139,7 @@ class GalleryContentEmbedder : AppContentEmbedder {
             return EmbedResult(false, message = "No gallery items")
         }
         ctx.logger.section("Embed Gallery Items")
-        ctx.fnAddGalleryItems(zipOut, ctx.galleryItems, ctx.encryptor, ctx.encryptionConfig)
+        ctx.fnAddGalleryItems(zipOut, ctx.galleryItems, ctx.encryptor, ctx.encryptionConfig, "gallery")
         ctx.logger.logKeyValue("galleryItemsEmbeddedCount", ctx.galleryItems.size)
         return EmbedResult(true, ctx.galleryItems.size, "${ctx.galleryItems.size} gallery items embedded")
     }
@@ -245,6 +249,46 @@ class MultiWebContentEmbedder : AppContentEmbedder {
                     runtimeType = "nodejs"
                 ),
                 logger = ctx.logger
+            )
+            embedded.add(site.id)
+        }
+        // Gallery sites: standalone gallery exports live at assets/gallery/,
+        // which a multi-web APK never populates for sites. Embed each site's
+        // media under its own prefix, matching rewriteMultiWebGallerySitePaths
+        // (same order, same naming), otherwise every cell renders black.
+        sites.forEach { site ->
+            if (site.appType.uppercase() != "GALLERY") return@forEach
+            val items = ctx.multiWebSiteGalleryItems[site.id].orEmpty()
+            if (items.isEmpty()) {
+                ctx.logger.warn("Multi-web gallery site ${site.id} (${site.name}) has no embeddable items")
+                return@forEach
+            }
+            ctx.logger.section("Embed Multi-Web Gallery Site ${site.id}")
+            ctx.fnAddGalleryItems(
+                zipOut, items, ctx.encryptor, ctx.encryptionConfig,
+                multiWebSiteGalleryAssetPrefix(site.id)
+            )
+            embedded.add(site.id)
+        }
+        // Single-media (IMAGE/VIDEO) sites: same gap, same treatment. The
+        // shell media player resolves multiweb_sites/<siteId>/media_content.*
+        // (see ShellContentRouter); without embedding it renders black.
+        sites.forEach { site ->
+            val siteType = site.appType.uppercase()
+            if (siteType != "IMAGE" && siteType != "VIDEO") return@forEach
+            val mediaPath = ctx.multiWebSiteMediaPaths[site.id]?.takeIf { it.isNotBlank() }
+                ?: return@forEach
+            val mediaFile = java.io.File(mediaPath)
+            if (!mediaFile.isFile || !mediaFile.canRead()) {
+                ctx.logger.warn("Multi-web media site ${site.id} (${site.name}) file missing: $mediaPath")
+                return@forEach
+            }
+            val ext = if (siteType == "VIDEO") "mp4" else "png"
+            ctx.logger.section("Embed Multi-Web Media Site ${site.id}")
+            ctx.fnAddMediaContent(
+                zipOut, mediaFile.absolutePath, siteType == "VIDEO",
+                ctx.encryptor, ctx.encryptionConfig,
+                "multiweb_sites/${site.id}/media_content.$ext"
             )
             embedded.add(site.id)
         }

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -453,7 +453,10 @@ data class ShellConfig(
     val siteDirName: String = "",
 
     @SerializedName("siteAssetBase")
-    val siteAssetBase: String = ""
+    val siteAssetBase: String = "",
+
+    @SerializedName("previewMediaPath")
+    val previewMediaPath: String? = null
 )
 
 data class EmbeddedShellModule(

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellContentRouter.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellContentRouter.kt
@@ -34,9 +34,17 @@ fun ShellContentRouter(
     when {
         appType == "IMAGE" || appType == "VIDEO" -> {
 
+            // Multi-web embedded sites keep their media under a per-site
+            // prefix (see MultiWebContentEmbedder); host-run preview instead
+            // carries an absolute host path on the site shell config. Null
+            // preserves the legacy hardcoded root asset (standalone export).
+            val isSiteVideo = appType == "VIDEO"
             MediaContentDisplay(
-                isVideo = appType == "VIDEO",
-                mediaConfig = config.mediaConfig
+                isVideo = isSiteVideo,
+                mediaConfig = config.mediaConfig,
+                mediaPath = config.previewMediaPath?.takeIf { it.isNotBlank() }
+                    ?: "multiweb_sites/${config.siteId}/media_content.${if (isSiteVideo) "mp4" else "png"}"
+                        .takeIf { config.siteId.isNotBlank() }
             )
         }
         appType == "GALLERY" -> {
@@ -44,7 +52,8 @@ fun ShellContentRouter(
             AppLogger.d("ShellScreen", "进入 GALLERY 分支，显示 ShellGalleryPlayer")
             ShellGalleryPlayer(
                 galleryConfig = config.galleryConfig,
-                onBack = onActivityFinish
+                onBack = onActivityFinish,
+                positionKeySuffix = config.siteId.takeIf { it.isNotBlank() }
             )
         }
         appType == "WORDPRESS" -> {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellGallery.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellGallery.kt
@@ -45,7 +45,8 @@ import kotlinx.coroutines.withContext
 @Composable
 fun ShellGalleryPlayer(
     galleryConfig: com.webtoapp.core.shell.GalleryShellConfig,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    positionKeySuffix: String? = null
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -93,6 +94,13 @@ fun ShellGalleryPlayer(
     val positionPrefs = remember {
         context.getSharedPreferences(SHELL_GALLERY_POSITION_PREFS, android.content.Context.MODE_PRIVATE)
     }
+    // rememberPosition: standalone galleries keep the historical fixed key;
+    // multi-web sites scope it per site so sibling galleries never restore
+    // each other's position (keys are clamped, so this was silent, not a crash).
+    val positionKey = remember(positionKeySuffix) {
+        if (positionKeySuffix.isNullOrBlank()) SHELL_GALLERY_POSITION_KEY
+        else "${SHELL_GALLERY_POSITION_KEY}_$positionKeySuffix"
+    }
     var positionRestored by remember { mutableStateOf(!galleryConfig.rememberPosition) }
     var showGrid by remember { mutableStateOf(true) }
     var enteredInPager by remember { mutableStateOf(false) }
@@ -102,7 +110,7 @@ fun ShellGalleryPlayer(
     LaunchedEffect(effectiveItems) {
         if (!positionRestored && effectiveItems.isNotEmpty()) {
             positionRestored = true
-            val saved = positionPrefs.getInt(SHELL_GALLERY_POSITION_KEY, 0)
+            val saved = positionPrefs.getInt(positionKey, 0)
                 .coerceIn(0, effectiveItems.size - 1)
             if (saved > 0) {
                 pagerState.scrollToPage(saved)
@@ -113,7 +121,7 @@ fun ShellGalleryPlayer(
     }
     LaunchedEffect(currentIndex) {
         if (galleryConfig.rememberPosition && positionRestored && currentIndex in effectiveItems.indices) {
-            positionPrefs.edit().putInt(SHELL_GALLERY_POSITION_KEY, currentIndex).apply()
+            positionPrefs.edit().putInt(positionKey, currentIndex).apply()
         }
     }
 
@@ -381,6 +389,31 @@ fun ShellGalleryPlayer(
     }
 }
 
+/**
+ * An item path is either an APK asset path (exported standalone app or
+ * multi-web site prefix like `multiweb_sites/<id>/gallery/...`) or — for
+ * host-run preview, where no APK was built — an absolute host file path
+ * mapped by buildSiteShellConfig. Absolute paths always win when readable.
+ */
+private fun isLocalMediaAssetPath(path: String) = path.startsWith("/")
+
+private fun loadGalleryAssetBytes(
+    context: android.content.Context,
+    assetDecryptor: com.webtoapp.core.crypto.AssetDecryptor,
+    assetPath: String
+): ByteArray {
+    if (isLocalMediaAssetPath(assetPath)) {
+        val file = java.io.File(assetPath)
+        if (file.isFile && file.canRead()) return file.readBytes()
+        AppLogger.w("ShellGallery", "Host media file missing, trying assets: $assetPath")
+    }
+    return try {
+        assetDecryptor.loadAsset(assetPath)
+    } catch (e: Exception) {
+        context.assets.open(assetPath).use { it.readBytes() }
+    }
+}
+
 private fun deriveGalleryItemsFromAssets(
     context: android.content.Context
 ): List<com.webtoapp.core.shell.GalleryShellItem> {
@@ -443,13 +476,7 @@ fun ShellGalleryImageViewer(
     LaunchedEffect(item.assetPath) {
         isLoading = true
         try {
-
-            val imageBytes = try {
-                assetDecryptor.loadAsset(item.assetPath)
-            } catch (e: Exception) {
-
-                context.assets.open(item.assetPath).use { it.readBytes() }
-            }
+            val imageBytes = loadGalleryAssetBytes(context, assetDecryptor, item.assetPath)
             bitmap = com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(imageBytes)
         } catch (e: Exception) {
             AppLogger.e("ShellGallery", "Failed to load image: ${item.assetPath}", e)
@@ -529,6 +556,19 @@ fun ShellGalleryVideoPlayer(
                 }
 
                 if (!isEncrypted) {
+                    // Host-run preview points at absolute host files: feed
+                    // them straight to the player instead of APK assets.
+                    val localFile = item.assetPath
+                        .takeIf { isLocalMediaAssetPath(it) }
+                        ?.let { java.io.File(it) }
+                        ?.takeIf { it.isFile && it.canRead() }
+                    if (localFile != null) {
+                        withContext(Dispatchers.Main) {
+                            mediaPlayer.setDataSource(localFile.absolutePath)
+                            mediaPlayer.prepareAsync()
+                        }
+                        return@launch
+                    }
 
                     try {
                         assetFd = context.assets.openFd(item.assetPath)
@@ -850,11 +890,7 @@ private fun ShellThumbnailCell(
         bitmap = null
         if (thumbAssetPath == null) return@LaunchedEffect
         bitmap = try {
-            val bytes = try {
-                assetDecryptor.loadAsset(thumbAssetPath)
-            } catch (_: Exception) {
-                context.assets.open(thumbAssetPath).use { it.readBytes() }
-            }
+            val bytes = loadGalleryAssetBytes(context, assetDecryptor, thumbAssetPath)
             com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(bytes)
         } catch (e: Exception) {
             AppLogger.e("ShellGallery", "Failed to load thumbnail: $thumbAssetPath", e)

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
@@ -300,9 +300,25 @@ fun ShellSplashOverlay(
 @Composable
 fun MediaContentDisplay(
     isVideo: Boolean,
-    mediaConfig: com.webtoapp.core.shell.MediaShellConfig
+    mediaConfig: com.webtoapp.core.shell.MediaShellConfig,
+    mediaPath: String? = null
 ) {
     val context = LocalContext.current
+
+    // mediaPath carries either an absolute host file (host-run preview) or a
+    // site-prefixed asset path (multi-web embedded site,
+    // multiweb_sites/<id>/media_content.*). Null preserves the legacy
+    // hardcoded root asset (standalone export). Same rule as the splash
+    // previewFile pattern: existing host files always win over assets.
+    val previewFile = remember(mediaPath) {
+        mediaPath?.let { java.io.File(it) }?.takeIf { it.isFile && it.canRead() }
+    }
+    // Unused when previewFile hits; otherwise the asset to open (site-prefixed
+    // for multi-web sites, legacy root asset for standalone exports).
+    val assetPath = remember(mediaPath, isVideo) {
+        mediaPath?.takeIf { it.isNotBlank() }
+            ?: if (isVideo) "media_content.mp4" else "media_content.png"
+    }
 
     val bgColor = remember(mediaConfig.backgroundColor) {
         try {
@@ -338,7 +354,6 @@ fun MediaContentDisplay(
             var tempVideoFile by remember { mutableStateOf<java.io.File?>(null) }
             var videoWidth by remember { mutableIntStateOf(0) }
             var videoHeight by remember { mutableIntStateOf(0) }
-            val assetPath = "media_content.mp4"
 
             AspectRatioSurface(
                 videoWidth = videoWidth,
@@ -347,7 +362,29 @@ fun MediaContentDisplay(
             modifier = Modifier.fillMaxSize(),
             onSurfaceCreated = { holder ->
                 try {
-                    val encryptedPath = "$assetPath.enc"
+                    // Host-run preview points at a real file: play it directly
+                    // (mirrors the splash previewFile branch).
+                    val hostFile = previewFile
+                    if (hostFile != null) {
+                        mediaPlayer = android.media.MediaPlayer().apply {
+                            setDataSource(hostFile.absolutePath)
+                            setSurface(holder.surface)
+                            val volume = if (mediaConfig.enableAudio) 1f else 0f
+                            setVolume(volume, volume)
+                            isLooping = mediaConfig.loop
+                            setOnPreparedListener { mp ->
+                                videoWidth = mp.videoWidth
+                                videoHeight = mp.videoHeight
+                                if (mediaConfig.autoPlay) start()
+                            }
+                            setOnVideoSizeChangedListener { _, width, height ->
+                                videoWidth = width
+                                videoHeight = height
+                            }
+                            prepareAsync()
+                        }
+                    } else {
+                        val encryptedPath = "$assetPath.enc"
                     val hasEncrypted = try {
                         context.assets.open(encryptedPath).use { true }
                     } catch (e: Exception) { false }
@@ -397,6 +434,7 @@ fun MediaContentDisplay(
                             prepareAsync()
                         }
                         afd.close()
+                        }
                     }
                 } catch (e: Exception) {
                     AppLogger.e("ShellActivity", "Operation failed", e)
@@ -423,11 +461,16 @@ fun MediaContentDisplay(
 
             var bitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
 
-            LaunchedEffect(Unit) {
+            LaunchedEffect(assetPath) {
                 bitmap = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
                     try {
-                        val decryptor = com.webtoapp.core.crypto.AssetDecryptor(context)
-                        val imageBytes = decryptor.loadAsset("media_content.png")
+                        val hostFile = previewFile
+                        val imageBytes = if (hostFile != null) {
+                            hostFile.readBytes()
+                        } else {
+                            val decryptor = com.webtoapp.core.crypto.AssetDecryptor(context)
+                            decryptor.loadAsset(assetPath)
+                        }
                         com.webtoapp.util.BoundedBitmaps.decodeBoundedBitmapBytes(imageBytes)
                     } catch (e: Exception) {
                         AppLogger.e("MediaContent", "Failed to load image media", e)

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebGallerySiteTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebGallerySiteTest.kt
@@ -1,0 +1,125 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.shell.GalleryShellItem
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.GalleryConfig
+import com.webtoapp.data.model.GalleryItem
+import com.webtoapp.data.model.GalleryItemType
+import com.webtoapp.data.model.MediaConfig
+import com.webtoapp.data.model.WebApp
+import java.io.File
+import java.nio.file.Files
+import org.junit.Test
+
+class MultiWebGallerySiteTest {
+
+    private fun shellItem(
+        assetPath: String,
+        type: String = "IMAGE",
+        thumbnailPath: String? = null
+    ) = GalleryShellItem(
+        id = assetPath,
+        assetPath = assetPath,
+        type = type,
+        name = assetPath,
+        thumbnailPath = thumbnailPath
+    )
+
+    @Test
+    fun `gallery prefix is namespaced per site`() {
+        assertThat(multiWebSiteGalleryAssetPrefix("abc"))
+            .isEqualTo("multiweb_sites/abc/gallery")
+    }
+
+    @Test
+    fun `export rewrite points items at the site prefix`() {
+        val items = listOf(
+            shellItem("gallery/item_0.png", "IMAGE", "gallery/thumb_0.jpg"),
+            shellItem("gallery/item_1.png", "VIDEO", null)
+        )
+        val rewritten = rewriteMultiWebGallerySitePaths(items, "s1")
+        assertThat(rewritten[0].assetPath).isEqualTo("multiweb_sites/s1/gallery/item_0.png")
+        assertThat(rewritten[0].thumbnailPath).isEqualTo("multiweb_sites/s1/gallery/thumb_0.jpg")
+        assertThat(rewritten[1].assetPath).isEqualTo("multiweb_sites/s1/gallery/item_1.mp4")
+        assertThat(rewritten[1].thumbnailPath).isNull()
+        // Untouched metadata survives the rewrite.
+        assertThat(rewritten[0].id).isEqualTo("gallery/item_0.png")
+        assertThat(rewritten[1].type).isEqualTo("VIDEO")
+    }
+
+    @Test
+    fun `export rewrite of empty list stays empty`() {
+        assertThat(rewriteMultiWebGallerySitePaths(emptyList(), "s1")).isEmpty()
+    }
+
+    @Test
+    fun `preview items carry absolute host paths`() {
+        val dir = Files.createTempDirectory("wta-mwgal").toFile()
+        try {
+            val photo = File(dir, "a.jpg").also { it.writeBytes(byteArrayOf(1, 2, 3)) }
+            val app = WebApp(
+                id = 5,
+                name = "g",
+                url = "",
+                appType = AppType.GALLERY,
+                galleryConfig = GalleryConfig(
+                    items = listOf(
+                        GalleryItem(path = photo.absolutePath, type = GalleryItemType.IMAGE, name = "a")
+                    )
+                )
+            )
+            val items = previewGallerySiteItems(app)
+            assertThat(items).hasSize(1)
+            assertThat(items[0].assetPath).isEqualTo(photo.absolutePath)
+            assertThat(items[0].type).isEqualTo("IMAGE")
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `preview items of non-gallery source are empty`() {
+        val app = WebApp(id = 5, name = "w", url = "https://example.com", appType = AppType.WEB)
+        assertThat(previewGallerySiteItems(app)).isEmpty()
+    }
+
+    @Test
+    fun `preview media path accepts local files only`() {
+        val dir = Files.createTempDirectory("wta-mwmed").toFile()
+        try {
+            val video = File(dir, "v.mp4").also { it.writeBytes(byteArrayOf(9)) }
+            val app = WebApp(
+                id = 6,
+                name = "v",
+                url = "",
+                appType = AppType.VIDEO,
+                mediaConfig = MediaConfig(mediaPath = video.absolutePath)
+            )
+            assertThat(multiWebSitePreviewMediaPath(app)).isEqualTo(video.absolutePath)
+
+            val remote = WebApp(
+                id = 7,
+                name = "r",
+                url = "https://example.com/v.mp4",
+                appType = AppType.VIDEO,
+                mediaConfig = MediaConfig(mediaPath = "https://example.com/v.mp4")
+            )
+            assertThat(multiWebSitePreviewMediaPath(remote)).isNull()
+
+            val missing = WebApp(
+                id = 8,
+                name = "m",
+                url = "",
+                appType = AppType.IMAGE,
+                mediaConfig = MediaConfig(mediaPath = File(dir, "gone.png").absolutePath)
+            )
+            assertThat(multiWebSitePreviewMediaPath(missing)).isNull()
+
+            val web = WebApp(id = 9, name = "w", url = "https://example.com", appType = AppType.WEB)
+            assertThat(multiWebSitePreviewMediaPath(web)).isNull()
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebSiteMediaEmbedTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebSiteMediaEmbedTest.kt
@@ -1,0 +1,122 @@
+package com.webtoapp.core.apkbuilder
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.GalleryItem
+import com.webtoapp.data.model.GalleryItemType
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipInputStream
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Zip-level proof that multi-web site media lands where the shell players
+ * look: gallery sites under assets/multiweb_sites/<siteId>/gallery/ and
+ * single-media sites under assets/multiweb_sites/<siteId>/media_content.*.
+ * Before the fix, site media was never embedded at all (black cells).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MultiWebSiteMediaEmbedTest {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun zipEntries(bytes: ByteArray): Map<String, ByteArray> {
+        val out = mutableMapOf<String, ByteArray>()
+        ZipInputStream(bytes.inputStream()).use { zin ->
+            while (true) {
+                val entry = zin.nextEntry ?: break
+                out[entry.name] = zin.readBytes()
+                zin.closeEntry()
+            }
+        }
+        return out
+    }
+
+    private fun galleryItem(dir: java.io.File, name: String, type: GalleryItemType): GalleryItem {
+        val file = java.io.File(dir, name).also { it.writeBytes(byteArrayOf(1, 2, 3, 4)) }
+        return GalleryItem(path = file.absolutePath, type = type, name = name)
+    }
+
+    @Test
+    fun `site gallery items embed under the site prefix`() {
+        val dir = createTempDir("mwgal")
+        try {
+            val builder = ApkBuilder(context)
+            val items = listOf(
+                galleryItem(dir, "a.png", GalleryItemType.IMAGE),
+                galleryItem(dir, "b.mp4", GalleryItemType.VIDEO)
+            )
+            val baos = ByteArrayOutputStream()
+            java.util.zip.ZipOutputStream(baos).use { zipOut ->
+                builder.addGalleryItemsToAssets(
+                    zipOut, items, null,
+                    com.webtoapp.core.crypto.EncryptionConfig.DISABLED,
+                    multiWebSiteGalleryAssetPrefix("s1")
+                )
+            }
+            val entries = zipEntries(baos.toByteArray())
+            assertThat(entries.keys).containsAtLeast(
+                "assets/multiweb_sites/s1/gallery/item_0.png",
+                "assets/multiweb_sites/s1/gallery/item_1.mp4"
+            )
+            assertThat(entries["assets/multiweb_sites/s1/gallery/item_0.png"])
+                .isEqualTo(byteArrayOf(1, 2, 3, 4))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `standalone gallery prefix is unchanged`() {
+        val dir = createTempDir("mwgalroot")
+        try {
+            val builder = ApkBuilder(context)
+            val items = listOf(galleryItem(dir, "a.png", GalleryItemType.IMAGE))
+            val baos = ByteArrayOutputStream()
+            java.util.zip.ZipOutputStream(baos).use { zipOut ->
+                builder.addGalleryItemsToAssets(
+                    zipOut, items, null,
+                    com.webtoapp.core.crypto.EncryptionConfig.DISABLED
+                )
+            }
+            val entries = zipEntries(baos.toByteArray())
+            assertThat(entries.keys).contains("assets/gallery/item_0.png")
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `site single media embeds under the site prefix`() {
+        val dir = createTempDir("mwmed")
+        try {
+            val builder = ApkBuilder(context)
+            val media = java.io.File(dir, "v.mp4").also { it.writeBytes(byteArrayOf(9, 9, 9)) }
+            val baos = ByteArrayOutputStream()
+            java.util.zip.ZipOutputStream(baos).use { zipOut ->
+                builder.addMediaContentToAssets(
+                    zipOut, media.absolutePath, true, null,
+                    com.webtoapp.core.crypto.EncryptionConfig.DISABLED,
+                    "multiweb_sites/s2/media_content.mp4"
+                )
+            }
+            val entries = zipEntries(baos.toByteArray())
+            assertThat(entries.keys).contains("assets/multiweb_sites/s2/media_content.mp4")
+            assertThat(entries["assets/multiweb_sites/s2/media_content.mp4"])
+                .isEqualTo(byteArrayOf(9, 9, 9))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    private fun createTempDir(prefix: String): java.io.File {
+        val dir = java.io.File(context.cacheDir, "$prefix-${System.nanoTime()}")
+        dir.mkdirs()
+        return dir
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebSiteShellMappingTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebSiteShellMappingTest.kt
@@ -1,0 +1,108 @@
+package com.webtoapp.core.apkbuilder
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.GalleryConfig
+import com.webtoapp.data.model.GalleryItem
+import com.webtoapp.data.model.GalleryItemType
+import com.webtoapp.data.model.MediaConfig
+import com.webtoapp.data.model.WebApp
+import java.io.File
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies the multi-web site shell-config mapping end to end (minus the DB):
+ * export rewrites gallery items to the per-site asset prefix, preview maps
+ * them (and single media) to absolute host files the shell players can read.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MultiWebSiteShellMappingTest {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun tempMedia(dir: File, name: String): File =
+        File(dir, name).also { it.writeBytes(byteArrayOf(7, 7, 7)) }
+
+    private fun gallerySource(dir: File): WebApp {
+        val photo = tempMedia(dir, "a.png")
+        return WebApp(
+            id = 11,
+            name = "gallery-src",
+            url = "",
+            appType = AppType.GALLERY,
+            galleryConfig = GalleryConfig(
+                items = listOf(
+                    GalleryItem(path = photo.absolutePath, type = GalleryItemType.IMAGE, name = "a")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `export maps gallery site items to the site asset prefix`() {
+        val dir = File(context.cacheDir, "mwmap-${System.nanoTime()}").also { it.mkdirs() }
+        try {
+            val shell = buildSiteShellConfig(gallerySource(dir), "com.example", "s9", context, isPreview = false)
+            assertThat(shell.siteId).isEqualTo("s9")
+            val items = shell.galleryConfig.items
+            assertThat(items).hasSize(1)
+            assertThat(items[0].assetPath).isEqualTo("multiweb_sites/s9/gallery/item_0.png")
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `preview maps gallery site items to host files`() {
+        val dir = File(context.cacheDir, "mwmap-${System.nanoTime()}").also { it.mkdirs() }
+        try {
+            val photo = tempMedia(dir, "b.png")
+            val source = WebApp(
+                id = 12,
+                name = "gallery-src",
+                url = "",
+                appType = AppType.GALLERY,
+                galleryConfig = GalleryConfig(
+                    items = listOf(
+                        GalleryItem(path = photo.absolutePath, type = GalleryItemType.IMAGE, name = "b")
+                    )
+                )
+            )
+            val shell = buildSiteShellConfig(source, "preview", "s9", context, isPreview = true)
+            val items = shell.galleryConfig.items
+            assertThat(items).hasSize(1)
+            assertThat(items[0].assetPath).isEqualTo(photo.absolutePath)
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `preview sets previewMediaPath for local single media`() {
+        val dir = File(context.cacheDir, "mwmap-${System.nanoTime()}").also { it.mkdirs() }
+        try {
+            val video = tempMedia(dir, "v.mp4")
+            val source = WebApp(
+                id = 13,
+                name = "video-src",
+                url = "",
+                appType = AppType.VIDEO,
+                mediaConfig = MediaConfig(mediaPath = video.absolutePath)
+            )
+            val shell = buildSiteShellConfig(source, "preview", "s9", context, isPreview = true)
+            assertThat(shell.previewMediaPath).isEqualTo(video.absolutePath)
+
+            val exported = buildSiteShellConfig(source, "com.example", "s9", context, isPreview = false)
+            assertThat(exported.previewMediaPath).isNull()
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+}

--- a/scripts/config_field_drift_allowlist.json
+++ b/scripts/config_field_drift_allowlist.json
@@ -12,6 +12,7 @@
 
     {"key": "siteDirName", "reason": "ShellConfig field present for runtime session isolation; export payload never emits it (preview-only)."},
     {"key": "siteId", "reason": "ShellConfig field present for runtime session isolation; export payload never emits it (preview-only)."},
+    {"key": "previewMediaPath", "reason": "ShellConfig host-preview-only field: absolute host media path for IMAGE/VIDEO multi-web sites in host-run preview; export payload never emits it (like siteId/siteDirName)."},
 
     {"key": "textColor", "reason": "Nested object field of LrcTheme; serialized via bgm.lrcTheme in BgmBlock → ShellConfig.bgmLrcTheme: LrcShellTheme."},
     {"key": "highlightColor", "reason": "Nested object field of LrcTheme; see textColor."},


### PR DESCRIPTION
Fixes #797.

## Symptom

Gallery (and single IMAGE/VIDEO) apps embedded as multi-web sites render black — both in exported APKs and in host-run preview.

## Root cause

- **Export**: `MultiWebContentEmbedder` only embedded HTML/FRONTEND site project dirs. Gallery/IMAGE/VIDEO site media was never written into the APK, while the site shell config still pointed at standalone paths (`gallery/item_N`, `media_content.*`). Every load 404s into a black cell.
- **Host run**: the same shell players only read APK assets, which never contain the user's host files.

## Changes

- **Export embed**: gallery site media goes to `assets/multiweb_sites/<siteId>/gallery/`, single media to `assets/multiweb_sites/<siteId>/media_content.*` (encryption/thumbnail/large-file handling reused via new prefix params on the existing embed helpers).
- **Export config**: site gallery item paths rewritten to the prefixed location (index-aligned with embedding); single-media resolved from siteId at runtime.
- **Host preview**: preview site configs map gallery items and single media to absolute host paths (`previewMediaPath` on `ShellConfig`, drift-allowlisted as preview-only like `siteId`); shell gallery/media players load existing host files first, assets otherwise (same pattern as the splash `mediaPath` preview parameter).
- **Cache**: site gallery items and media files feed the incremental-build fingerprint (`mwGallery[]`/`mwMedia[]`), so editing a source gallery invalidates the cache.
- **Incidental**: gallery `rememberPosition` keyed per site so sibling galleries no longer restore each other's position.

## Verification

- New tests: `MultiWebGallerySiteTest` (6), `MultiWebSiteMediaEmbedTest` (3, zip-level byte checks), `MultiWebSiteShellMappingTest` (3, full `buildSiteShellConfig` mapping under Robolectric).
- Related suites green (26 tests incl. `ApkBuildCacheTest`, `ShellUiParityTest`); `check_config_field_drift` OK.
- On-device repro (seeded gallery + multi-web apps, host run): grid thumbnails render, fullscreen pager matches Fit math pixel-exact, video position advances 00:00 → 00:01, zero load failures in logcat.