### PR TITLE
feat(gallery): pinch-to-zoom in shell image viewer

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shared/ZoomableState.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/ZoomableState.kt
@@ -1,0 +1,225 @@
+package com.webtoapp.ui.shared
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateCentroid
+import androidx.compose.foundation.gestures.calculateCentroidSize
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastForEach
+
+/**
+ * Pinch-to-zoom + pan + double-tap-toggle state for full-screen image
+ * viewers, designed to coexist with [androidx.compose.foundation.pager.HorizontalPager]:
+ * single-finger drags at 1x are never consumed (the pager keeps them), while
+ * pinches and zoomed pans are.
+ *
+ * Transform math (viewport pixels, scale about the viewport center, which is
+ * what [graphicsLayer] does with the default transform origin):
+ * a content point p (viewport coords at scale 1) lands at
+ * `center + (p - center) * scale + offset`.
+ */
+@Stable
+class ZoomableState(
+    val minScale: Float = 1f,
+    val maxScale: Float = 5f,
+    val doubleTapScale: Float = 3f,
+    val zoomToggleThreshold: Float = 1.5f,
+) {
+    var scale by mutableFloatStateOf(minScale)
+        private set
+    var offset by mutableStateOf(Offset.Zero)
+        private set
+
+    /** Viewport size in pixels. Set from layout; needed for clamping. */
+    var viewportSize: Size = Size.Zero
+        private set
+
+    /** Content size in pixels at scale 1 (already fitted). */
+    var contentSize: Size = Size.Zero
+        private set
+
+    fun setLayout(viewport: Size, content: Size) {
+        viewportSize = viewport
+        contentSize = content
+        offset = clampOffset(offset, scale, viewport, content)
+    }
+
+    fun reset() {
+        scale = minScale
+        offset = Offset.Zero
+    }
+
+    /**
+     * Apply a pinch step, keeping [centroid] (viewport coords) stationary.
+     * Returns true when anything changed.
+     */
+    fun applyZoom(zoomChange: Float, centroid: Offset): Boolean {
+        if (zoomChange == 1f) return false
+        val newScale = (scale * zoomChange).coerceIn(minScale, maxScale)
+        if (newScale == scale) return false
+        val center = Offset(viewportSize.width / 2f, viewportSize.height / 2f)
+        val k = newScale / scale
+        val anchored = centroid - center
+        offset = clampOffset(anchored - (anchored - offset) * k, newScale, viewportSize, contentSize)
+        scale = newScale
+        if (scale == minScale) offset = Offset.Zero
+        return true
+    }
+
+    /** Apply a pan step (viewport pixels). Returns true when anything changed. */
+    fun applyPan(panChange: Offset): Boolean {
+        if (panChange == Offset.Zero || scale <= minScale) return false
+        val next = clampOffset(offset + panChange, scale, viewportSize, contentSize)
+        if (next == offset) return false
+        offset = next
+        return true
+    }
+
+    /**
+     * Double-tap toggle. Returns the tap point (for callers that need it);
+     * mutates state directly (snap, no animation).
+     */
+    fun toggleZoom(tap: Offset) {
+        if (scale > zoomToggleThreshold) {
+            reset()
+        } else {
+            applyZoom(doubleTapScale / scale, tap)
+        }
+    }
+
+    companion object {
+        fun clampOffset(
+            offset: Offset,
+            scale: Float,
+            viewport: Size,
+            content: Size
+        ): Offset {
+            val maxX = maxOf(0f, (content.width * scale - viewport.width) / 2f)
+            val maxY = maxOf(0f, (content.height * scale - viewport.height) / 2f)
+            return Offset(
+                offset.x.coerceIn(-maxX, maxX),
+                offset.y.coerceIn(-maxY, maxY)
+            )
+        }
+
+        fun fittedContentSize(
+            imageWidth: Int,
+            imageHeight: Int,
+            viewport: Size
+        ): Size {
+            if (imageWidth <= 0 || imageHeight <= 0 ||
+                viewport.width <= 0f || viewport.height <= 0f
+            ) {
+                return Size.Zero
+            }
+            val s = minOf(viewport.width / imageWidth, viewport.height / imageHeight)
+            return Size(imageWidth * s, imageHeight * s)
+        }
+    }
+}
+
+/**
+ * Gesture wiring for [ZoomableState]: pinch zoom (focal-aware), pan while
+ * zoomed, and pass-through of single-finger drags at 1x so an enclosing
+ * pager keeps working. Rotation is intentionally locked.
+ */
+fun Modifier.zoomableGesture(
+    state: ZoomableState,
+    enabled: Boolean = true
+): Modifier = this.then(
+    Modifier.pointerInput(enabled) {
+        if (!enabled) return@pointerInput
+        awaitEachGesture {
+            awaitFirstDown(requireUnconsumed = false)
+            var pastTouchSlop = false
+            var zoom = 1f
+            var pan = Offset.Zero
+            val touchSlop = viewConfiguration.touchSlop
+            while (true) {
+                val event = awaitPointerEvent()
+                val pressed = event.changes.fastAny { it.pressed }
+                // Another consumer (e.g. the pager mid-drag) claimed the
+                // stream: never fight it.
+                val claimed = event.changes.fastAny { it.isConsumed }
+                if (claimed) {
+                    if (!pressed) break
+                    continue
+                }
+                val zoomChange = event.calculateZoom()
+                val panChange = event.calculatePan()
+                val pointerCount = event.changes.size
+                if (!pastTouchSlop) {
+                    zoom *= zoomChange
+                    pan += panChange
+                    val centroidSize = event.calculateCentroidSize(useCurrent = false)
+                    val zoomMotion = kotlin.math.abs(1f - zoom) * centroidSize
+                    if (zoomMotion > touchSlop ||
+                        pan.getDistance() > touchSlop ||
+                        pointerCount > 1
+                    ) {
+                        pastTouchSlop = true
+                    } else {
+                        if (!pressed) break
+                        continue
+                    }
+                }
+                if (pastTouchSlop) {
+                    val centroid = event.calculateCentroid(useCurrent = false)
+                    var consumedZoom = false
+                    var consumedPan = false
+                    if (pointerCount > 1 || zoomChange != 1f) {
+                        consumedZoom = state.applyZoom(zoomChange, centroid)
+                    }
+                    if (state.scale > state.minScale && panChange != Offset.Zero) {
+                        consumedPan = state.applyPan(panChange)
+                    }
+                    if (consumedZoom || consumedPan) {
+                        event.changes.fastForEach { change ->
+                            consumePositionChange(change)
+                        }
+                    }
+                }
+                if (!pressed) break
+            }
+        }
+    }
+)
+
+private fun consumePositionChange(change: PointerInputChange) {
+    if (change.position != change.previousPosition) {
+        change.consume()
+    }
+}
+
+/** Modifier shorthand: [zoomableGesture] + [graphicsLayer] in one. */
+fun Modifier.zoomable(
+    state: ZoomableState,
+    enabled: Boolean = true
+): Modifier = this.then(
+    Modifier
+        .zoomableGesture(state, enabled)
+        .graphicsLayer(
+            scaleX = state.scale,
+            scaleY = state.scale,
+            translationX = state.offset.x,
+            translationY = state.offset.y
+        )
+)
+
+/** Touch slop in pixels for gesture detection. */
+private val PointerInputScope.touchSlop: Float
+    get() = viewConfiguration.touchSlop

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellGallery.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellGallery.kt
@@ -28,15 +28,19 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.shared.AspectRatioSurface
+import com.webtoapp.ui.shared.ZoomableState
+import com.webtoapp.ui.shared.zoomable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -492,12 +496,43 @@ fun ShellGalleryImageViewer(
             CircularProgressIndicator(color = Color.White)
         } else {
             bitmap?.let { bmp ->
-                Image(
-                    bitmap = bmp.asImageBitmap(),
-                    contentDescription = item.name,
+                BoxWithConstraints(
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = androidx.compose.ui.layout.ContentScale.Fit
-                )
+                    contentAlignment = Alignment.Center
+                ) {
+                    val density = LocalDensity.current
+                    // Fresh zoom state per item; pinch/pan/double-tap below.
+                    val zoom = remember(item.assetPath) {
+                        ZoomableState()
+                    }
+                    val viewportPx = with(density) {
+                        Size(
+                            maxWidth.toPx(),
+                            maxHeight.toPx()
+                        )
+                    }
+                    LaunchedEffect(viewportPx, bmp.width, bmp.height) {
+                        zoom.setLayout(
+                            viewportPx,
+                            ZoomableState.fittedContentSize(
+                                bmp.width, bmp.height, viewportPx
+                            )
+                        )
+                    }
+                    Image(
+                        bitmap = bmp.asImageBitmap(),
+                        contentDescription = item.name,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .pointerInput(item.assetPath) {
+                                detectTapGestures(
+                                    onDoubleTap = { tap -> zoom.toggleZoom(tap) }
+                                )
+                            }
+                            .zoomable(zoom),
+                        contentScale = androidx.compose.ui.layout.ContentScale.Fit
+                    )
+                }
             }
         }
     }

--- a/app/src/test/java/com/webtoapp/ui/shared/ZoomableStateTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/shared/ZoomableStateTest.kt
@@ -1,0 +1,113 @@
+package com.webtoapp.ui.shared
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ZoomableStateTest {
+
+    @Test
+    fun `clamp keeps unzoomed content centered`() {
+        val out = ZoomableState.clampOffset(
+            Offset(100f, -50f), 1f, Size(1080f, 2400f), Size(1080f, 1080f)
+        )
+        assertThat(out.x).isWithin(0.01f).of(0f)
+        assertThat(out.y).isWithin(0.01f).of(0f)
+    }
+
+    @Test
+    fun `clamp bounds panning to content edges`() {
+        // 64px image fitted into 1080x2211 viewport => 1080x1080 at 2x zoom:
+        // max offset = (2160-1080)/2 = 540 horizontally, 0 vertically.
+        val viewport = Size(1080f, 2211f)
+        val content = ZoomableState.fittedContentSize(64, 64, viewport)
+        assertThat(content.width).isWithin(1f).of(1080f)
+        assertThat(content.height).isWithin(1f).of(1080f)
+        val out = ZoomableState.clampOffset(Offset(9999f, 9999f), 2f, viewport, content)
+        assertThat(out.x).isWithin(1f).of(540f)
+        assertThat(out.y).isWithin(0.01f).of(0f)
+        val back = ZoomableState.clampOffset(Offset(-9999f, -5f), 2f, viewport, content)
+        assertThat(back.x).isWithin(1f).of(-540f)
+        assertThat(back.y).isWithin(0.01f).of(0f)
+    }
+
+    @Test
+    fun `fitted size honors aspect`() {
+        val out = ZoomableState.fittedContentSize(800, 600, Size(1080f, 2211f))
+        assertThat(out.width).isWithin(1f).of(1080f)
+        assertThat(out.height).isWithin(1f).of(810f)
+    }
+
+    @Test
+    fun `fitted size rejects degenerate input`() {
+        assertThat(ZoomableState.fittedContentSize(0, 10, Size(100f, 100f))).isEqualTo(Size.Zero)
+        assertThat(ZoomableState.fittedContentSize(10, 10, Size.Zero)).isEqualTo(Size.Zero)
+    }
+
+    @Test
+    fun `pinch anchors the centroid`() {
+        val s = ZoomableState()
+        s.setLayout(Size(1000f, 1000f), Size(800f, 800f))
+        // Centroid at (750, 500); zoom 1x -> 2x. Content point under the
+        // centroid must stay put: it starts at content coords
+        // (750-500, 500-500)/1 = (250, 0), so offset must become
+        // (750-500) - (250, 0)*2 = (-250, 0) (within ±300 clamp).
+        assertThat(s.applyZoom(2f, Offset(750f, 500f))).isTrue()
+        assertThat(s.scale).isWithin(0.001f).of(2f)
+        assertThat(s.offset.x).isWithin(0.5f).of(-250f)
+        assertThat(s.offset.y).isWithin(0.5f).of(0f)
+    }
+
+    @Test
+    fun `zoom clamps to min-max and resets offset at min`() {
+        val s = ZoomableState()
+        s.setLayout(Size(1000f, 1000f), Size(500f, 500f))
+        assertThat(s.applyZoom(100f, Offset(500f, 500f))).isTrue()
+        assertThat(s.scale).isWithin(0.001f).of(5f)
+        assertThat(s.applyZoom(0.0001f, Offset(500f, 500f))).isTrue()
+        assertThat(s.scale).isWithin(0.001f).of(1f)
+        assertThat(s.offset.x).isWithin(0.01f).of(0f); assertThat(s.offset.y).isWithin(0.01f).of(0f)
+    }
+
+    @Test
+    fun `pan is ignored at min scale`() {
+        val s = ZoomableState()
+        s.setLayout(Size(1000f, 1000f), Size(500f, 500f))
+        assertThat(s.applyPan(Offset(50f, 50f))).isFalse()
+        assertThat(s.offset.x).isWithin(0.01f).of(0f); assertThat(s.offset.y).isWithin(0.01f).of(0f)
+    }
+
+    @Test
+    fun `double-tap toggles out when zoomed`() {
+        val s = ZoomableState()
+        s.setLayout(Size(1000f, 1000f), Size(500f, 500f))
+        s.applyZoom(3f, Offset(500f, 500f))
+        s.toggleZoom(Offset(100f, 100f))
+        assertThat(s.scale).isWithin(0.001f).of(1f)
+        assertThat(s.offset.x).isWithin(0.01f).of(0f); assertThat(s.offset.y).isWithin(0.01f).of(0f)
+    }
+
+    @Test
+    fun `double-tap zooms toward the tap point`() {
+        val s = ZoomableState()
+        s.setLayout(Size(1000f, 1000f), Size(1000f, 1000f))
+        // Tap at (750, 500) from 1x: target 3x anchored there gives
+        // offset = (250, 0) - (250, 0)*3 = (-500, 0).
+        s.toggleZoom(Offset(750f, 500f))
+        assertThat(s.scale).isWithin(0.001f).of(3f)
+        assertThat(s.offset.x).isWithin(0.5f).of(-500f)
+        assertThat(s.offset.y).isWithin(0.5f).of(0f)
+    }
+
+    @Test
+    fun `reset restores identity`() {
+        val s = ZoomableState()
+        s.setLayout(Size(1000f, 1000f), Size(500f, 500f))
+        s.applyZoom(2f, Offset(500f, 500f))
+        s.applyPan(Offset(10f, 10f))
+        s.reset()
+        assertThat(s.scale).isWithin(0.001f).of(1f)
+        assertThat(s.offset.x).isWithin(0.01f).of(0f); assertThat(s.offset.y).isWithin(0.01f).of(0f)
+    }
+}


### PR DESCRIPTION
Fixes #800.

## What

The fullscreen image viewer in generated gallery apps could only page
between photos. This adds interactive zoom:

- Pinch in/out (1x–5x), anchored at the focal point.
- Pan while zoomed, clamped to content edges.
- Double-tap toggles 1x ↔ 3x anchored at the tap point.
- Single-finger drags at 1x stay unconsumed so pager swipes keep working;
  zoom resets when switching images.

## How

- New shared `ZoomableState` in `ui/shared` (state machine + gesture
  wiring on platform `transformable` with a `canPan` gate, no new
  dependencies) so the host player can adopt the same mechanism later
  instead of a second implementation.
- `ShellGalleryImageViewer` wraps its image in a per-item zoom state
  fed by `BoxWithConstraints` viewport + fitted content size.
- No new user-visible strings; no config/model changes.

## Verification

- New `ZoomableStateTest` (10 tests: clamp bounds, centroid anchoring,
  min/max, pan gating, double-tap targets, reset).
- Related suites green (`ShellUiParityTest`, apkbuilder multi-web tests).
- On-device (emulator, host-run multi-web gallery site): double-tap
  zooms 45% → 92% coverage and back exactly; zoomed swipe pans without
  flipping pages; 1x rendering, tap-to-toggle-controls and paging
  unchanged.