### PR TITLE
fix(bgm): shuffle first track and cycle order in shell player

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ShellBgmPlayer.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellBgmPlayer.kt
@@ -30,6 +30,32 @@ class BgmPlayerState internal constructor(
     var currentPosition: Long by _currentPosition
 }
 
+/**
+ * Shuffle order state. Mirrors the host [com.webtoapp.core.bgm.BgmPlayer]
+ * semantics: a full permutation per cycle (no repeats), reshuffled on wrap.
+ */
+internal data class BgmShuffleOrder(
+    val order: List<Int> = emptyList(),
+    val pos: Int = 0
+) {
+    fun currentIndex(): Int = order.getOrElse(pos) { 0 }
+}
+
+internal fun initialBgmOrder(size: Int, shuffle: Boolean): BgmShuffleOrder {
+    if (size <= 0) return BgmShuffleOrder()
+    val order = if (shuffle) (0 until size).shuffled() else (0 until size).toList()
+    return BgmShuffleOrder(order, 0)
+}
+
+internal fun advanceBgmOrder(state: BgmShuffleOrder, size: Int): BgmShuffleOrder {
+    if (size <= 0) return BgmShuffleOrder()
+    val nextPos = state.pos + 1
+    if (nextPos < state.order.size && nextPos < size) {
+        return state.copy(pos = nextPos)
+    }
+    return BgmShuffleOrder((0 until size).shuffled(), 0)
+}
+
 internal fun parseLrcText(text: String): LrcData? {
     val lines = mutableListOf<LrcLine>()
 
@@ -133,9 +159,12 @@ fun rememberBgmPlayerState(
         if (!enabled) return@LaunchedEffect
         if (config.bgmEnabled && config.bgmPlaylist.isNotEmpty()) {
             try {
+                val isShuffle = config.bgmPlayMode == "SHUFFLE"
+                var shuffleOrder = initialBgmOrder(config.bgmPlaylist.size, isShuffle)
 
                 val player = MediaPlayer()
-                val firstItem = config.bgmPlaylist.first()
+                val firstIndex = shuffleOrder.currentIndex()
+                val firstItem = config.bgmPlaylist[firstIndex]
 
                 setBgmDataSource(player, firstItem.assetPath)
 
@@ -145,7 +174,10 @@ fun rememberBgmPlayerState(
                 player.setOnCompletionListener {
 
                     val nextIndex = when (config.bgmPlayMode) {
-                        "SHUFFLE" -> (0 until config.bgmPlaylist.size).random()
+                        "SHUFFLE" -> {
+                            shuffleOrder = advanceBgmOrder(shuffleOrder, config.bgmPlaylist.size)
+                            shuffleOrder.currentIndex()
+                        }
                         "SEQUENTIAL" -> if (currentBgmIndex + 1 < config.bgmPlaylist.size) currentBgmIndex + 1 else -1
                         else -> (currentBgmIndex + 1) % config.bgmPlaylist.size
                     }
@@ -174,8 +206,9 @@ fun rememberBgmPlayerState(
                 }
 
                 bgmPlayer = player
+                currentBgmIndex = firstIndex
 
-                loadLrcForCurrentBgm(0)
+                loadLrcForCurrentBgm(firstIndex)
 
                 AppLogger.d("ShellActivity", "BGM 播放器初始化成功: ${firstItem.name}")
             } catch (e: Exception) {

--- a/app/src/test/java/com/webtoapp/ui/shell/ShellBgmPlayerTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/shell/ShellBgmPlayerTest.kt
@@ -1,0 +1,66 @@
+package com.webtoapp.ui.shell
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ShellBgmPlayerTest {
+
+    @Test
+    fun `non-shuffle initial order is identity`() {
+        val state = initialBgmOrder(4, shuffle = false)
+        assertThat(state.order).containsExactly(0, 1, 2, 3).inOrder()
+        assertThat(state.pos).isEqualTo(0)
+        assertThat(state.currentIndex()).isEqualTo(0)
+    }
+
+    @Test
+    fun `shuffle initial order is a full permutation`() {
+        repeat(10) {
+            val state = initialBgmOrder(5, shuffle = true)
+            assertThat(state.order).hasSize(5)
+            assertThat(state.order.sorted()).containsExactly(0, 1, 2, 3, 4).inOrder()
+            assertThat(state.pos).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `initial order handles degenerate sizes`() {
+        assertThat(initialBgmOrder(0, shuffle = true).order).isEmpty()
+        assertThat(initialBgmOrder(0, shuffle = true).currentIndex()).isEqualTo(0)
+        assertThat(initialBgmOrder(1, shuffle = true).order).containsExactly(0)
+    }
+
+    @Test
+    fun `shuffle does not always start on the first track`() {
+        // Regression test for "shuffle always plays song #1": with 5 tracks,
+        // always landing on index 0 across 30 shuffles has probability
+        // (1/5)^30 ~= 1e-21, i.e. deterministic for practical purposes.
+        val firsts = (0 until 30).map { initialBgmOrder(5, shuffle = true).currentIndex() }.toSet()
+        assertThat(firsts.size).isGreaterThan(1)
+    }
+
+    @Test
+    fun `advance walks the permutation then reshuffles on wrap`() {
+        val start = BgmShuffleOrder(listOf(2, 0, 1), 0)
+        assertThat(start.currentIndex()).isEqualTo(2)
+        val mid = advanceBgmOrder(start, 3)
+        assertThat(mid.order).containsExactly(2, 0, 1).inOrder()
+        assertThat(mid.pos).isEqualTo(1)
+        assertThat(mid.currentIndex()).isEqualTo(0)
+        val wrapped = advanceBgmOrder(advanceBgmOrder(mid, 3), 3)
+        assertThat(wrapped.pos).isEqualTo(0)
+        assertThat(wrapped.order.sorted()).containsExactly(0, 1, 2).inOrder()
+    }
+
+    @Test
+    fun `advance on empty or zero size stays empty`() {
+        val state = advanceBgmOrder(BgmShuffleOrder(), 0)
+        assertThat(state.order).isEmpty()
+        assertThat(state.currentIndex()).isEqualTo(0)
+    }
+
+    @Test
+    fun `currentIndex falls back to zero when out of range`() {
+        assertThat(BgmShuffleOrder(listOf(2, 0), 7).currentIndex()).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
Fixes #802.

## Problem
In generated apps, BGM shuffle mode always started with the first playlist track, and the completion listener picked a uniform random index (repeats possible within a cycle). The host preview player already used a shuffled permutation per cycle; the shell runtime never got the equivalent logic.

## Changes
- `ui/shell/ShellBgmPlayer.kt`: add `BgmShuffleOrder` + `initialBgmOrder`/`advanceBgmOrder` helpers (full permutation per cycle, reshuffle on wrap, mirroring host `BgmPlayer` semantics); init now starts from the shuffled order's head and syncs `currentBgmIndex`; `SHUFFLE` completion advances through the order; LRC loading uses the actual first index.
- `ui/shell/ShellBgmPlayerTest.kt` (new): 7 unit tests covering first-track distribution, no in-cycle repeats, reshuffle on wrap, size 0/1 edges, and non-shuffle order preservation.

## Verification
- `testStandardDebugUnitTest --tests ShellBgmPlayerTest`: 7/7 pass.
- `:app:assembleStandardDebug`: success.
- On-device E2E via a temporary instrumented activity (removed afterwards): 6 cold launches yielded first-track indices 0, 2, 1, 2, 0, 2 — no longer stuck on 0.