### PR TITLE
feat(nativebridge): enable NativeBridge by default for new apps

### DIFF
--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -388,7 +388,7 @@ data class WebViewConfig(
     val enableOrientationPolyfill: Boolean = true,
     val enableCompatPolyfills: Boolean = true,
 
-    val enableNativeBridge: Boolean = false,
+    val enableNativeBridge: Boolean = true,
     val nativeBridgeCapabilities: NativeBridgeCapabilities = NativeBridgeCapabilities(),
 
     // Geolocation stays default-OFF: enabling it makes every exported app declare and

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ExportSecurityRegressionTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ExportSecurityRegressionTest.kt
@@ -265,7 +265,11 @@ class ExportSecurityRegressionTest {
             "com.webtoapp.WebToAppApplication",
             "com.webtoapp.ui.MainActivity",
             "com.webtoapp.ui.shell.ShellActivity",
-            "androidx.core.content.FileProvider"
+            // NativeBridge defaults ON and its scheduled-notification capability
+            // defaults ON, so the alarm receiver ships in the baseline. It is
+            // inert (manifest entry only) unless a page calls scheduleNotification.
+            "androidx.core.content.FileProvider",
+            "com.webtoapp.core.notification.BridgeAlarmReceiver"
         ).inOrder()
     }
 

--- a/app/src/test/java/com/webtoapp/data/model/WebViewConfigDefaultsContractTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/WebViewConfigDefaultsContractTest.kt
@@ -27,7 +27,6 @@ class WebViewConfigDefaultsContractTest {
         "enableKernelDisguise",          // anti-bot systems may reject disguised kernels
         "allowMixedContent",             // weakens HTTPS transport security
         "acceptThirdPartyCookies",        // privacy trade-off
-        "enableNativeBridge",            // exposes window.NativeBridge to pages
         "enableCrossOriginIsolation",    // changes COOP/COEP headers
         "hideUrlPreview",                // hides information
         "failoverEnabled",               // meaningless without a user-supplied URL list
@@ -57,6 +56,11 @@ class WebViewConfigDefaultsContractTest {
         "enableCorsBypass",
         "enableBlobDownloadInterception",
         "enablePrintBridge",
+        // NativeBridge defaults ON: every capability is individually gated and
+        // fails soft, permission-backed capabilities stay inert unless the user
+        // also enables them (location needs geolocationEnabled, notifications
+        // need the notification capability + POST_NOTIFICATIONS grant), and
+        // built-in features (media download etc.) degrade without it.
         // Enable-by-default batch (experience parity without user setup):
         "decodeBase64DeepLinks",
         "javaScriptCanOpenWindows",


### PR DESCRIPTION
Fixes #804.

## Product decision
Flip `WebViewConfig.enableNativeBridge` default to `true` (one line in `WebApp.kt`). Rationale, per the contract test's own rule (flipping a pinned default must be stated, not silent):

- Consistency: every sibling bridge (share, private-network, print, clipboard polyfill) already defaults ON; NativeBridge was the exception.
- Out-of-box experience: the editor card itself warns that disabling the bridge may break built-in features; new exports no longer ship degraded (media download falling back to copy-link, etc.).
- Contained risk: every capability is individually gated and fails soft; location stays inert without `geolocationEnabled`; notification paths need the default-OFF notification capability + `POST_NOTIFICATIONS` grant; device info is model/manufacturer only.
- Only affects newly created apps; saved configs keep stored values. Notification polyfill intentionally untouched (still default-OFF).

## Test updates
- `WebViewConfigDefaultsContractTest`: moved `enableNativeBridge` from `defaultOff` to `defaultOn` with reasoning comment.
- `ExportSecurityRegressionTest`: plain-export baseline gains `BridgeAlarmReceiver` (pulled in by the default-ON scheduled-notification capability; inert manifest entry, no new permissions, verified by the still-green permission assertions in the same file).

## Verification
- `WebViewConfigDefaultsContractTest` (7), `RuntimePermissionSyncTest` (13), `WebViewConfigBooleanCoverageTest` (5), `ExportSecurityRegressionTest` (15) — all pass.
- `:app:checkConfigFieldDrift` passes (no field renamed/added).
- Full `--rerun-tasks :app:assembleStandardDebug` succeeds.