### PR TITLE
fix(agent): collect LLM stream once per request (turn stuck on thinking)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -16,14 +16,15 @@ import com.webtoapp.core.agent.tool.ToolRegistry
 import com.webtoapp.core.agent.tool.ToolResult
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.core.logging.AppLogger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.produceIn
 import kotlinx.coroutines.withTimeoutOrNull
 
 class AgentEngine(
@@ -107,6 +108,11 @@ class AgentEngine(
                     val requestMessages = if (supportsVision) baseMessages
                         else baseMessages.map { if (it.images.isEmpty()) it else it.copy(images = emptyList()) }
 
+                    // Collect the stream exactly once per request attempt. The gateway
+                    // flows are cold callbackFlows: re-collecting them re-runs the
+                    // producer block, i.e. fires a brand-new HTTP request per event,
+                    // while the previous request's response events are dropped — the
+                    // turn then hangs forever on "thinking" (the #742 regression).
                     gateway.chatStream(
                         ChatRequest(
                             apiKey = input.toolContext.textApiKey,
@@ -136,7 +142,7 @@ class AgentEngine(
                                 // prose/tools in the order they actually occurred.
                                 if (turnThinking.isEmpty()) {
                                     val segmentId = "th-turn-$turn"
-                                    val marker = "\u2063TH:$segmentId\u2063"
+                                    val marker = "⁣TH:$segmentId⁣"
                                     rebuildAccFromPrefix()
                                     accText.append(marker)
                                     send(AgentEvent.TextDelta(marker, accText.toString()))
@@ -147,7 +153,7 @@ class AgentEngine(
                             is LlmEvent.ToolCallBegin -> {
                                 pending[ev.id] = ev.name to StringBuilder()
 
-                                val marker = "\u2063TC:${ev.id}\u2063"
+                                val marker = "⁣TC:${ev.id}⁣"
                                 rebuildAccFromPrefix()
                                 accText.append(marker)
                                 send(AgentEvent.TextDelta(marker, accText.toString()))
@@ -384,8 +390,16 @@ class AgentEngine(
             }
         )
 
-        return runCatching { tool.execute(args, callCtx) }
-            .getOrElse { ToolResult.error("${call.name}: ${it.message ?: it::class.simpleName}") }
+        return try {
+            tool.execute(args, callCtx)
+        } catch (ce: CancellationException) {
+            // AgentAbortedException is a CancellationException and must reach the engine's
+            // outer catch (→ Aborted); swallowing real coroutine cancellation here would
+            // keep the loop running inside an already-cancelled coroutine.
+            throw ce
+        } catch (t: Throwable) {
+            ToolResult.error("${call.name}: ${t.message ?: t::class.simpleName}")
+        }
     }
 
     private suspend fun runParallel(
@@ -470,47 +484,52 @@ class AgentEngine(
  * read timeout (10 minutes). On idle timeout, [onTimeout] is invoked and the
  * collection ends normally so the engine's retry loop can take over.
  *
- * The deadline must live on the caller's own suspension path. A sibling-coroutine
- * watchdog would NOT work: a child `launch` throwing into a shared scope rethrows
- * the child's exception out of this function itself, bypassing the caller's
- * try/catch — which is exactly why the previous watchdog implementation left the
- * engine's idle-retry path unreachable. Here each event is awaited inside a
- * fresh [withTimeoutOrNull] window; a window expiring with no event means the
- * stream went idle, and a normal collect completion ends the loop.
+ * The flow is subscribed EXACTLY ONCE: it is turned into a [ReceiveChannel] via
+ * [produceIn], and only the wait for the next element is wrapped in a fresh
+ * [withTimeoutOrNull] window per event. Never re-collect the flow per event —
+ * the provider flows are cold `callbackFlow`s, so each repeated collect re-runs
+ * the producer block (a brand-new HTTP request per event) while the previous
+ * request's response events are dropped into a cancelled channel. That was the
+ * #742 regression: the UI sat on "thinking" forever with zero output while the
+ * client silently spammed the API with duplicate requests.
+ *
+ * Cancelling (idle timeout, abort, or completion of the surrounding scope)
+ * cancels the producer, which propagates into the provider's `awaitClose` and
+ * tears down the underlying HTTP call.
  */
-private suspend fun <T> Flow<T>.collectWithIdleTimeout(
+internal suspend fun <T> Flow<T>.collectWithIdleTimeout(
     idleTimeoutMs: Long,
     onTimeout: () -> Unit,
     action: suspend (T) -> Unit
 ) {
     val timeoutMs = idleTimeoutMs.coerceAtLeast(1L)
-    while (true) {
-        var gotEvent = false
-        val outcome = withTimeoutOrNull(timeoutMs) {
-            try {
-                collect { value ->
-                    gotEvent = true
-                    action(value)
-                    throw ElementReceived()
+    coroutineScope {
+        val events = produceIn(this)
+        try {
+            while (true) {
+                val result = withTimeoutOrNull(timeoutMs) { events.receiveCatching() }
+                when {
+                    // A whole window elapsed with no event: the stream stalled. The
+                    // finally below cancels the producer (and the HTTP call with it),
+                    // so the engine's retry loop starts from a clean slate.
+                    result == null -> {
+                        onTimeout()
+                        return@coroutineScope
+                    }
+                    result.isSuccess -> action(result.getOrThrow())
+                    else -> {
+                        // Channel closed: rethrow a producer failure, otherwise the
+                        // stream ended normally.
+                        result.exceptionOrNull()?.let { throw it }
+                        return@coroutineScope
+                    }
                 }
-                StreamEnd
-            } catch (e: ElementReceived) {
-                NoEvent
             }
-        }
-        when {
-            outcome === StreamEnd -> return
-            gotEvent -> Unit // loop re-arms a fresh window for the next event
-            else -> {
-                onTimeout()
-                return
-            }
+        } finally {
+            // coroutineScope waits for children on block exit but does NOT cancel
+            // them: a producer parked in awaitClose would hang the exit forever
+            // unless cancelled here.
+            events.cancel(null)
         }
     }
-}
-
-private object StreamEnd
-private object NoEvent
-private class ElementReceived : RuntimeException() {
-    override fun fillInStackTrace(): Throwable = this
 }

--- a/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
@@ -16,6 +16,7 @@ import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicReference
 
 internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Context) : LlmProvider {
     private val gson = GsonProvider.gson
@@ -36,11 +37,19 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
 
     override fun chatStream(req: ChatRequest): Flow<LlmEvent> = callbackFlow {
         trySend(LlmEvent.Started)
-        executeCall(req, isRetry = false)
-        awaitClose { }
+        // Track the live call across retries so a cancelled/aborted collection
+        // (idle timeout, user abort) tears down the actual HTTP connection instead
+        // of leaving an orphaned request streaming into a closed channel.
+        val inFlight = AtomicReference<Call?>()
+        executeCall(req, isRetry = false, inFlight = inFlight)
+        awaitClose { inFlight.get()?.cancel() }
     }
 
-    private fun kotlinx.coroutines.channels.ProducerScope<LlmEvent>.executeCall(req: ChatRequest, isRetry: Boolean) {
+    private fun kotlinx.coroutines.channels.ProducerScope<LlmEvent>.executeCall(
+        req: ChatRequest,
+        isRetry: Boolean,
+        inFlight: AtomicReference<Call?>
+    ) {
         val url = HttpHelpers.joinUrl(HttpHelpers.baseUrl(req.apiKey), req.apiKey.getEffectiveChatEndpoint())
         val effectiveReq = if (isRetry) req.copy(temperature = 1f) else req
         val body = buildBody(effectiveReq)
@@ -48,12 +57,13 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
             .post(gson.toJson(body).toRequestBody("application/json".toMediaType()))
         HttpHelpers.applyAuth(builder, req.apiKey)
         val call = client.newCall(builder.build())
+        inFlight.set(call)
         call.enqueue(object : Callback {
             override fun onFailure(call: Call, e: IOException) {
                 if (!isRetry) {
                     AppLogger.w("OpenAiCompatProvider", "Network failure, retrying once: ${e.message}")
                     try { Thread.sleep(1000) } catch (_: InterruptedException) {}
-                    executeCall(req, isRetry = true)
+                    executeCall(req, isRetry = true, inFlight = inFlight)
                 } else {
                     trySend(LlmEvent.Error(e.message ?: "Network error")); close()
                 }
@@ -64,7 +74,7 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
                     response.body?.close()
                     if (!isRetry && response.code == 400 && looksLikeTemperatureConstraint(eb)) {
                         AppLogger.w("OpenAiCompatProvider", "Model rejected temperature=${req.temperature}; retrying with temperature=1")
-                        executeCall(req, isRetry = true)
+                        executeCall(req, isRetry = true, inFlight = inFlight)
                         return
                     }
                     val (msg, rec) = HttpHelpers.classifyHttpError(response.code, eb)

--- a/app/src/test/java/com/webtoapp/core/agent/engine/AgentEngineStreamTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/engine/AgentEngineStreamTest.kt
@@ -1,0 +1,154 @@
+package com.webtoapp.core.agent.engine
+
+import androidx.test.core.app.ApplicationProvider
+import com.webtoapp.core.agent.files.ProjectFileManager
+import com.webtoapp.core.agent.llm.ChatRequest
+import com.webtoapp.core.agent.llm.FinishReason
+import com.webtoapp.core.agent.llm.LlmEvent
+import com.webtoapp.core.agent.llm.LlmGateway
+import com.webtoapp.core.agent.permission.PermissionChecker
+import com.webtoapp.core.agent.permission.PermissionPrompter
+import com.webtoapp.core.agent.todo.TodoManager
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolRegistry
+import com.webtoapp.data.dao.WebAppDao
+import com.webtoapp.data.dao.WebAppStartupCandidate
+import com.webtoapp.data.dao.WebAppSummary
+import com.webtoapp.data.model.AiModel
+import com.webtoapp.data.model.AiProvider
+import com.webtoapp.data.model.ApiKeyConfig
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.ModelCapability
+import com.webtoapp.data.model.SavedModel
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.repository.WebAppRepository
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * End-to-end regression tests for the agent turn loop. The #742 collector
+ * re-subscribed the cold gateway flow per event, so a turn never received any
+ * content (UI stuck on "thinking") while the provider was spammed with
+ * duplicate requests. The gateway fake below is a cold callbackFlow just like
+ * the real providers and counts how many times its producer runs.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AgentEngineStreamTest {
+
+    @Test(timeout = 15_000)
+    fun `a turn subscribes the LLM stream exactly once and completes`() = runBlocking {
+        val producerRuns = AtomicInteger(0)
+        val gateway = object : LlmGateway {
+            override fun chatStream(req: ChatRequest): Flow<LlmEvent> = callbackFlow {
+                producerRuns.incrementAndGet()
+                trySend(LlmEvent.Started)
+                trySend(LlmEvent.TextDelta("Hello"))
+                trySend(LlmEvent.TextDelta(", world"))
+                trySend(LlmEvent.Done(FinishReason.STOP))
+                close() // real providers close right after the terminal event
+                awaitClose { }
+            }
+        }
+
+        val events = engine(gateway).run(input()).toList(mutableListOf())
+
+        assertEquals("one request attempt must subscribe the stream once", 1, producerRuns.get())
+        assertEquals("Hello, world", events.filterIsInstance<AgentEvent.TextDelta>().joinToString("") { it.delta })
+        val completed = events.last()
+        assertTrue(completed is AgentEvent.Completed)
+        assertEquals("Hello, world", (completed as AgentEvent.Completed).summary)
+    }
+
+    @Test(timeout = 15_000)
+    fun `recoverable stream error retries with a fresh request`() = runBlocking {
+        val producerRuns = AtomicInteger(0)
+        val gateway = object : LlmGateway {
+            override fun chatStream(req: ChatRequest): Flow<LlmEvent> = callbackFlow {
+                val attempt = producerRuns.incrementAndGet()
+                trySend(LlmEvent.Started)
+                if (attempt == 1) {
+                    trySend(LlmEvent.Error("stream interrupted", recoverable = true))
+                } else {
+                    trySend(LlmEvent.TextDelta("recovered"))
+                    trySend(LlmEvent.Done(FinishReason.STOP))
+                }
+                close() // real providers close right after the terminal event
+                awaitClose { }
+            }
+        }
+
+        val events = engine(gateway).run(input()).toList(mutableListOf())
+
+        assertEquals("the retry must re-request through the gateway", 2, producerRuns.get())
+        assertTrue(events.filterIsInstance<AgentEvent.Notice>().isNotEmpty())
+        assertTrue(events.filterIsInstance<AgentEvent.TextDelta>().any { it.delta == "recovered" })
+        assertTrue(events.last() is AgentEvent.Completed)
+    }
+
+    private fun engine(gateway: LlmGateway) =
+        AgentEngine(gateway, PermissionChecker(PermissionPrompter()))
+
+    private fun input(): AgentEngine.Input {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val toolContext = ToolContext(
+            androidContext = ctx,
+            sessionId = "test-session",
+            fileManager = ProjectFileManager(ctx),
+            textModel = SavedModel(
+                model = AiModel(id = "test-model", name = "Test Model", provider = AiProvider.OPENAI),
+                apiKeyId = "key-1",
+                capabilities = listOf(ModelCapability.TEXT)
+            ),
+            textApiKey = ApiKeyConfig(provider = AiProvider.OPENAI, apiKey = "test-key"),
+            prompter = PermissionPrompter(),
+            todos = TodoManager(),
+            appRepository = WebAppRepository(FakeWebAppDao())
+        )
+        return AgentEngine.Input(
+            systemPrompt = "test",
+            history = emptyList(),
+            userMessage = "hi",
+            toolContext = toolContext,
+            registry = ToolRegistry(emptyList())
+        )
+    }
+
+    /** The repository eagerly reads three Flow properties at construction; the rest is never called in tool-free turns. */
+    private class FakeWebAppDao : WebAppDao {
+        override fun getAllWebApps(): Flow<List<WebApp>> = flowOf(emptyList())
+        override fun getAllWebAppSummaries(): Flow<List<WebAppSummary>> = flowOf(emptyList())
+        override fun getHttpWebApps(appType: AppType): Flow<List<WebApp>> = flowOf(emptyList())
+        override suspend fun getStartupCandidatesWithoutIcons(appType: AppType, limit: Int): List<WebAppStartupCandidate> = throw NotImplementedError()
+        override suspend fun getWebAppById(id: Long): WebApp? = throw NotImplementedError()
+        override fun getWebAppByIdFlow(id: Long): Flow<WebApp?> = throw NotImplementedError()
+        override suspend fun insert(webApp: WebApp): Long = throw NotImplementedError()
+        override suspend fun update(webApp: WebApp) = throw NotImplementedError()
+        override suspend fun delete(webApp: WebApp) = throw NotImplementedError()
+        override suspend fun deleteById(id: Long) = throw NotImplementedError()
+        override suspend fun updateActivationStatus(id: Long, activated: Boolean) = throw NotImplementedError()
+        override suspend fun upgradeRemoteHttpUrls(appType: AppType, updatedAt: Long): Int = throw NotImplementedError()
+        override suspend fun getCount(): Int = throw NotImplementedError()
+        override fun searchWebApps(query: String): Flow<List<WebApp>> = throw NotImplementedError()
+        override suspend fun insertAll(webApps: List<WebApp>): List<Long> = throw NotImplementedError()
+        override suspend fun updateAll(webApps: List<WebApp>) = throw NotImplementedError()
+        override suspend fun deleteAll(webApps: List<WebApp>) = throw NotImplementedError()
+        override suspend fun deleteByIds(ids: List<Long>) = throw NotImplementedError()
+        override suspend fun updateActivationStatusBatch(ids: List<Long>, activated: Boolean) = throw NotImplementedError()
+        override suspend fun getWebAppsByIds(ids: List<Long>): List<WebApp> = throw NotImplementedError()
+        override fun getActivatedWebApps(): Flow<List<WebApp>> = throw NotImplementedError()
+        override fun getRecentWebApps(limit: Int): Flow<List<WebApp>> = throw NotImplementedError()
+        override suspend fun countByName(name: String, excludeId: Long): Int = throw NotImplementedError()
+        override suspend fun clearCategoryId(categoryId: Long) = throw NotImplementedError()
+        override suspend fun getAllUrls(): List<String> = throw NotImplementedError()
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/agent/engine/CollectWithIdleTimeoutTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/engine/CollectWithIdleTimeoutTest.kt
@@ -1,0 +1,101 @@
+package com.webtoapp.core.agent.engine
+
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Regression tests for the idle-timeout stream collector. The #742 rewrite
+ * re-collected the cold provider flow for every event, which re-ran the
+ * producer (a fresh HTTP request per event) and dropped all response events —
+ * the UI sat on "thinking" forever while the client spammed the API.
+ */
+class CollectWithIdleTimeoutTest {
+
+    @Test(timeout = 10_000)
+    fun `flow is subscribed exactly once and every event arrives in order`() = runBlocking {
+        val producerRuns = AtomicInteger(0)
+        val source = callbackFlow {
+            producerRuns.incrementAndGet()
+            trySend(1)
+            trySend(2)
+            trySend(3)
+            close()
+            awaitClose { }
+        }
+        val received = mutableListOf<Int>()
+        var timedOut = false
+
+        source.collectWithIdleTimeout(idleTimeoutMs = 5_000, onTimeout = { timedOut = true }) {
+            received += it
+        }
+
+        assertEquals(listOf(1, 2, 3), received)
+        assertEquals("producer must run once per request, not once per event", 1, producerRuns.get())
+        assertFalse(timedOut)
+    }
+
+    @Test(timeout = 10_000)
+    fun `idle gap longer than the window triggers onTimeout and cancels the producer`() = runBlocking {
+        val producerClosed = AtomicBoolean(false)
+        val source = callbackFlow {
+            trySend(1)
+            awaitClose { producerClosed.set(true) } // never emits again
+        }
+        val received = mutableListOf<Int>()
+        var timedOut = false
+
+        source.collectWithIdleTimeout(idleTimeoutMs = 100, onTimeout = { timedOut = true }) {
+            received += it
+        }
+
+        assertEquals(listOf(1), received)
+        assertTrue(timedOut)
+        assertTrue("timing out must tear down the producer (and its HTTP call)", producerClosed.get())
+    }
+
+    @Test(timeout = 10_000)
+    fun `slow stream with gaps inside the window is not treated as idle`() = runBlocking {
+        val source = flow {
+            emit(1)
+            delay(150)
+            emit(2)
+        }
+        val received = mutableListOf<Int>()
+        var timedOut = false
+
+        source.collectWithIdleTimeout(idleTimeoutMs = 5_000, onTimeout = { timedOut = true }) {
+            received += it
+        }
+
+        assertEquals(listOf(1, 2), received)
+        assertFalse(timedOut)
+    }
+
+    @Test(timeout = 10_000)
+    fun `producer failure propagates to the caller`() = runBlocking {
+        val source = flow<Int> {
+            emit(1)
+            throw IllegalStateException("boom")
+        }
+        var caught: Throwable? = null
+
+        try {
+            source.collectWithIdleTimeout(idleTimeoutMs = 5_000, onTimeout = {}) { }
+        } catch (t: Throwable) {
+            caught = t
+        }
+
+        // kotlinx stacktrace recovery may deliver a copy of the original exception.
+        assertTrue(caught is IllegalStateException)
+        assertEquals("boom", caught?.message)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #810

After configuring a model and sending any question, the Agent UI stayed on "thinking" forever with zero output, while the provider received an endless stream of duplicate requests.

**Root cause:** the #742 idle-watchdog rewrite in `AgentEngine.collectWithIdleTimeout` re-collected the **cold** gateway `callbackFlow` for every event — each iteration fired a brand-new HTTP request while the previous request's response events were dropped into a closed channel. The immediate `LlmEvent.Started` event made the loop spin indefinitely, and the 90s idle timeout could never fire.

## Changes

- **`AgentEngine.collectWithIdleTimeout`** — subscribe the flow **exactly once** via `produceIn`; only the wait for the next element is wrapped in a fresh `withTimeoutOrNull` window per event. The channel is cancelled explicitly on exit (`coroutineScope` waits for children but never cancels them — without the explicit cancel, a producer parked in `awaitClose` hangs the timeout exit forever). The 90s idle-timeout → retry semantics are preserved.
- **`OpenAiCompatProvider`** — track the in-flight OkHttp call across retries (`AtomicReference`) and cancel it in `awaitClose`, matching the other four providers; an aborted/timeout collection now tears down the actual HTTP connection instead of leaving orphaned streams.

## Test plan

New regression coverage for the previously untested engine stream loop:

- `CollectWithIdleTimeoutTest` (4 cases): single subscription with ordered events (**pins the exact regression**), idle-timeout triggers `onTimeout` and cancels the producer, slow-but-alive stream is not misjudged as idle, producer failure propagates.
- `AgentEngineStreamTest` (2 cases, Robolectric): a turn with a cold gateway flow completes with all text events and exactly one subscription; recoverable stream error retries through the gateway.

Verification:
- `:app:testStandardDebugUnitTest`: new engine tests pass; full suite green (1110+ tests; the only unrelated failures belonged to a parallel working-tree change, now green as well).
- `:app:compileStandardDebugKotlin` clean.