### PR TITLE
fix(security): harden TLS MITM trust chain, JS bridges, export pipeline and runtimes

### DIFF
--- a/.github/scripts/ci/generate_submissions.py
+++ b/.github/scripts/ci/generate_submissions.py
@@ -14,11 +14,14 @@ introduced or last touched it, then queries the GitHub REST API for the
 PR associated with that commit. If the PR is found and merged, we record
 PR number, merge timestamp, and the merger's GitHub identity. If no PR
 is found, the commit is taken as a direct push and we record the
-commit's author timestamp instead — but only when the author is a
-known maintainer login passed via `--maintainers`. Anything else (a
-direct push by a non-maintainer that somehow got through, an orphan
-folder added without a commit) ends up unrecorded, and the in-app
-market hides it.
+commit's author timestamp and resolved GitHub login — any human author
+is recorded (modules only reach `main` through review or a maintainer
+push; hiding non-maintainer authors made real contributor modules
+disappear from the in-app market). Only bot identities
+(github-actions[bot], web-flow, dependabot[bot]) are excluded, with the
+repo owner as the fallback when a commit email maps to no GitHub
+account. An orphan folder added without a commit ends up unrecorded,
+and the in-app market hides it.
 
 Run locally (no network access — uses cache only):
 

--- a/.github/scripts/ci/validate_modules.py
+++ b/.github/scripts/ci/validate_modules.py
@@ -365,6 +365,8 @@ def _validate_registry(report: Report, registry: dict[str, Any]) -> list[dict[st
         if eid:
             if eid in seen_ids:
                 report.error(f"{where}::modules[{i}]", f"duplicate id {eid!r}")
+            if not KEBAB_CASE_RE.match(eid):
+                report.error(f"{where}::modules[{i}]", f"id {eid!r} must be kebab-case")
             seen_ids.add(eid)
 
         epath = entry.get("path") if _is_str(entry.get("path")) else None

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -18,8 +18,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages-${{ github.ref }}
@@ -62,6 +60,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Only this job touches Pages: the build job runs on pull_requests (including
+    # same-repo branches) and executes third-party dependency postinstall code, so it
+    # must not hold Pages/OIDC write capabilities.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
     environment:
       name: github-pages

--- a/.github/workflows/modules-publish.yml
+++ b/.github/workflows/modules-publish.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Generate submissions.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Comma-separated list of GitHub logins that may seed modules
-          # via a direct push (no PR). Anything else without a merged PR
-          # stays hidden from the catalog.
+          # Legacy parameter: the generator records every human direct-push
+          # author (modules only reach main via review or maintainer push)
+          # and only excludes bot identities.
           MAINTAINERS: shiaho777
         run: |
           python3 .github/scripts/ci/generate_submissions.py \
@@ -73,6 +73,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           GIT_AUTH_USER: x-access-token
           GIT_AUTH_PWD: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          HAS_PAT: ${{ secrets.PAT_TOKEN != '' }}
           BRANCH: ci/regenerate-submissions
         run: |
           if git diff --quiet -- modules/submissions.json; then
@@ -91,7 +92,7 @@ jobs:
           git commit -m "chore(modules): regenerate submissions.json"
 
           REPO="github.com/${GITHUB_REPOSITORY}"
-          if [ -n "${{ secrets.PAT_TOKEN }}" ]; then
+          if [ "$HAS_PAT" = "true" ]; then
             git push --force-with-lease "https://${GIT_AUTH_USER}:${GIT_AUTH_PWD}@${REPO}" "$BRANCH"
           else
             git push --force-with-lease origin "$BRANCH"
@@ -115,7 +116,7 @@ jobs:
           # wait for its "check" to report then enable auto-merge (GitHub merges
           # automatically once all required checks pass). With GITHUB_TOKEN there
           # is no check to wait on, so the PR is left for a manual merge.
-          if [ -n "${{ secrets.PAT_TOKEN }}" ]; then
+          if [ "$HAS_PAT" = "true" ]; then
             gh pr merge "$PR_NUMBER" --squash --auto --delete-branch \
               || echo "::warning::Auto-merge setup failed; PR #$PR_NUMBER left open for manual merge."
           else

--- a/.gitignore
+++ b/.gitignore
@@ -71,4 +71,5 @@ server/
 admin/
 node_modules/
 __pycache__/
-*.pyc.kotlin/
+*.pyc
+.kotlin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Instructions for coding agents working in this repository.
 |------|------|
 | `app/` | Full builder host: editor UI, export pipeline, runtimes, preview. |
 | `shell/` | Runtime template. Built to `app/src/main/assets/template/webview_shell.apk` via `:shell:assembleRelease` + `:app:syncShellTemplateApk`. |
-| `clone-host/` | Host-side APK clone / identity reshape support library (compiled to a DEX asset). |
+| `clone-host/` | Host-side APK clone / identity reshape support library. Its DEX asset generation (`syncCloneHostDex`) is deliberately disabled (`enabled = false`, AV false-positive mitigation, e0d2d4d6) — `AppCloner` runs fail-soft without the asset. |
 | `modules/` | Module Market catalog (`registry.json` + per-module folders). |
 | `docs/` | VitePress documentation site (guide / developer / extensions, EN + ZH), published to https://shiaho777.github.io/web-to-app/ by `.github/workflows/docs-deploy.yml`. Site URL paths map 1:1 to files under `docs/` (`/zh/...` → `docs/zh/...`). |
 | `scripts/` | Build helpers and gates (`check_config_field_drift.py`). |
@@ -57,6 +57,7 @@ Mental model:
 
 - Generated apps keep a low `targetSdk` (28) on the shell path because they rely on on-device fork+exec runtimes. Do not raise shell targetSdk casually.
 - The host app targets SDK 35 (antivirus reputation); SELinux W^X therefore blocks host-side exec of downloaded runtimes. `RuntimeExecPolicy` (`core/linux`) gates those previews by probing the installed targetSdk — generated APKs (always 28) pass unconditionally. Node preview (JNI via native libs) is unaffected.
+- Launch runtime / toolchain processes through `HostProcessLauncher` (`core/linux`): plain `ProcessBuilder` fork+exec where the platform allows it (generated APKs, targetSdk 28), the user-mode static exec loader (`StaticExecProcess`, memfd-based) on W^X hosts (targetSdk ≥ 29), or a degraded error when no static exec bridge is available. A raw `Runtime.exec` on a downloaded binary crashes the host app on W^X devices (#795).
 - Avoid new third-party dependencies unless strongly justified (`app/build.gradle.kts` / `shell/build.gradle.kts`). Prefer platform APIs and existing modules.
 - Notification push channels: Web Notification polyfill, polling, WebSocket, FCM (developer-owned Firebase config). Do not add OEM vendor push SDKs by default.
 - Foreground services and notification helpers must use `SafeNotificationChannels` (or equivalent fail-soft create). Channel creation failures must not crash FGS startup.
@@ -209,16 +210,18 @@ Checklist in order:
 1. Allocate ports through `PortManager` with the configured conflict policy; implement real stop handlers.
 2. Wire fork+exec processes into `LocalDnsBridgeProxy` when they need host DNS/proxy env.
 3. Use `NetworkModule.downloadClient` for large dependency / engine / runtime downloads.
+4. Launch processes through `HostProcessLauncher` (`core/linux`) so W^X hosts (targetSdk ≥ 29) degrade to the user-mode static exec loader instead of crashing.
 
 ### 10. Node.js / Go export
 
 1. Node.js: ensure `injectNodeJsNativeLibs` embeds `libnode_bridge.so` + `libnode.so` (16KB-aligned via `ElfAligner16k`) + `libc++_shared.so`. Node binary resolution prefers `nativeLibraryDir`, falls back to download cache.
 2. Go: ensure `injectGoExecLoaderNativeLib` embeds `libgo_exec_loader.so`.
-3. `NodeService` runs in a dedicated `:nodejs` OS process so V8 lifecycle is isolated from the host.
+3. Go host-side builds never run the multi-process `go build` driver: `GoDirectBuilder` replays `compile`/`asm`/`link` as single-shot processes through `HostProcessLauncher` (user-mode static exec loader on W^X hosts), with a content-keyed persistent package archive cache (#796).
+4. `NodeService` runs in a dedicated `:nodejs` OS process so V8 lifecycle is isolated from the host.
 
 ### 11. Change a feature that has an Agent tool
 
-The in-app Agent exposes 57 tools that wrap host service classes. When you change a feature, trace the tool chain:
+The in-app Agent exposes up to 57 tools — 52 base + 2 plan-mode + 3 imagery (imagery only load with an image-capable model; see `ToolRegistryFactory.build()`) — that wrap host service classes. When you change a feature, trace the tool chain:
 
 ```text
 LLM response (tool_calls)
@@ -265,6 +268,8 @@ The editor screens are built from `WtaSettingCard`s that share one visual gramma
 | Sub-toggles / fields inside an expanded zone | `staticAssetPack` block, proxy block |
 | Nested conditional content | proxy MANUAL/PAC `AnimatedVisibility` swap |
 
+Inputs and dialogs follow the same grammar: text inputs are `PremiumTextField`, list-manager dialogs are `Dialog` + `WtaCard` + embedded `TopAppBar` (see `AdBlockSubscriptionSelectorDialog`), and `ActivationCodeCard`'s offline-policy rows are another canonical radio reference.
+
 Hard rules learned the hard way:
 
 1. **Two sanctioned card shapes.** Toggle header: `WtaSettingCard { WtaToggleRow(header); AnimatedVisibility(enabled, CardExpandTransition/CardCollapseTransition) { Column { WtaSectionDivider(); full-bleed rows separated by more dividers } } }`. Collapse header: `WtaSettingCard { Column { WtaChoiceRow(header); AnimatedVisibility(expanded) { Column(padding(horizontal = WtaSpacing.RowHorizontal, vertical = WtaSpacing.ContentGap), spacedBy(WtaSpacing.ContentGap)) { … } } } }`.
@@ -274,17 +279,9 @@ Hard rules learned the hard way:
 5. **Expansion state ≠ feature state.** Never bind a section's `isExpanded` / `AnimatedVisibility(visible=…)` to the feature's `enabled` flag — expanding a panel must never switch the feature on. Section collapse state is its own `remember { mutableStateOf }`.
 6. **Conditional sub-blocks** (mode swaps, dependent fields) use `AnimatedVisibility` with `CardExpandTransition` / `CardCollapseTransition`, never bare `if` inside the card body.
 7. **Compile ≠ verified.** After any card UI change, build + install on the emulator and check the rendered card: `uiautomator dump` element bounds, compare left edges / row heights of the changed card against its neighbours on the same screen (they must share the same content columns), plus a screenshot pass. Content a few dp off the grid is invisible in code review and obvious on screen.
+8. **If a UI rework PR gets "this doesn't match the other cards" feedback**, the fix is realignment to these patterns, not further invention.
 
 ---
-
-### 12. Change or add editor / common-config UI
-
-The editor screens have an established card language. **Find the neighboring cards first and copy their patterns element by element — do not invent your own layout**, even if it looks better in isolation. Hard rules learned the hard way (#571):
-
-1. **Container**: `WtaSettingCard`. **Header toggle**: `WtaToggleRow` (icon + title + subtitle + switch). **Collapsible section**: `WtaChoiceRow` + `AnimatedVisibility(CardExpandTransition)`. **Inner toggles**: `WtaToggleRow`. **Separators**: `WtaSectionDivider`. **Single-choice**: radio rows (see the offline-policy selector). **Text input**: `PremiumTextField`. **List-manager dialogs**: `Dialog` + `WtaCard` + embedded `TopAppBar` (see `AdBlockSubscriptionSelectorDialog`).
-2. **Never couple `isExpanded` to a feature `enabled` flag** — expanding a card to look around must never change app state; only the row's switch does.
-3. Canonical templates: `FullscreenModeCard` (toggle card), `BrowserAdvancedConfigCard` (collapsible config card), `ActivationCodeCard`'s offline-policy rows (radio selection).
-4. If a UI rework PR gets "this doesn't match the other cards" feedback, the fix is realignment to these patterns, not further invention.
 
 ## Easy-to-miss points
 
@@ -337,6 +334,8 @@ python3 scripts/check_config_field_drift.py
 
 Use these when you change shell membership, export packaging, or config fields. For host-only UI/string work, targeted compile on `:app` is usually enough.
 
+CI note: the PR `check` job compiles only `:shell:compileDebugKotlin` (debug variant) and skips template sync (`-PskipShellTemplateSync=true`). The shell **release** variant (R8 / proguard) and the template pipeline are exercised only by the manual `workflow_dispatch` packaging job — after touching `shell/proguard-rules.pro` or shell packaging, run the first command locally before pushing.
+
 Related focused tests often worth running after nearby edits: `ApkBuildCacheTest`, `AdBlockerHostRuntimeTest`, `AdBlockExportWiringTest`, `PortManagerTest`, `BuildInputPreflightTest`, `GoBuildEnvironmentTest`, `RuntimePermissionSyncTest`.
 
 ---
@@ -356,9 +355,16 @@ Landed:
 - HTML/FRONTEND file-access for packaged local shells
 - Node.js export: `libnode_bridge.so` + 16KB-aligned `libnode.so` + `libc++_shared.so`; 16KB app-compat before dlopen; stable `NodeJniOutputBridge` JNI callback
 - Go export: `libgo_exec_loader.so` embedded; in-app build ENOSPC handling + GOTMPDIR relocation
+- Go host-side builds on W^X hosts: `GoDirectBuilder` replays `compile`/`asm`/`link` as single-shot processes through `HostProcessLauncher` (user-mode static exec loader), with a content-keyed persistent package archive cache (#796)
+- Multi-web: gallery/media site sources embedded into the APK and resolved at runtime; nested site sources degrade to a URL instead of aborting the build (#798, #792)
+- Gallery playback: shuffleOnLoop, rememberPosition, overview grid, thumbnail bar, pinch-to-zoom viewer, with host/shell parity enforced by `ShellUiParityTest` (#781, #786, #801)
+- Untrusted bitmap decodes bounded (oversized-image crash fix) (#788)
+- Backup/restore coverage aligned with the current storage layout; restarts only when local files change, with throttled progress callbacks (#790, #794)
+- NativeBridge enabled by default for newly created apps (#805)
 - Runtime permission sync (feature-driven)
 - Splash preview media path fallback
 - Config field drift detection (`checkConfigFieldDrift`)
 - Module Market: Chrome Web Store live search + GreasyFork browse
 - Code editor find-and-replace
-- Agent tool system: 57 tools (app lifecycle, config templates, ports/engine, hosts/runtime, stats/modifier/import, build env/Play, modules, files, imagery) with Channel-based permission prompting, per-section SSE parse resilience, and plan mode; runtime/build-env tools surface `localExecAllowed` so the LLM knows targetSdk>=29 hosts cannot exec app-storage binaries
+- Security hardening sweep: TLS-fingerprint bridge validates upstream certs (system + custom CAs + hostname) and its local CA is signature-verified with no error-type fallback; JS bridges are caller/origin/scheme-gated (NativeBridge CORS bypass, GM bridge, MV3 `ChromeHostPermissions`); MITM proxy host-allowlisted and CA key wrapped at rest; zip extraction routed through `util/SafeZip`; concurrent exports serialized per package with per-package work dirs; multi-web server-runtime site sources degrade to URL; PHP/Python/WP embed failures fail the build; error pages and `TranslateBridge` callbacks JSON-escaped; keystore password sidecars excluded from backups
+- Agent tool system: up to 57 tools — 52 base + 2 plan-mode + 3 imagery (image-capable models only) — covering app lifecycle, config templates, ports/engine, hosts/runtime, stats/modifier/import, build env/Play, modules, files, and imagery, with Channel-based permission prompting, per-section SSE parse resilience, and plan mode; runtime/build-env tools surface `localExecAllowed` so the LLM knows targetSdk>=29 hosts cannot exec app-storage binaries

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -668,11 +668,14 @@ tasks.register("checkConfigFieldDrift") {
     val apkConfigFile = file("src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt")
     val shellConfigFile = file("src/main/java/com/webtoapp/core/shell/ShellModeManager.kt")
     val allowlist = rootProject.file("scripts/config_field_drift_allowlist.json")
+    // Configuration-cache safe: capture values at configuration time; the doLast action
+    // must not reach through Project.
+    val rootDir = rootProject.projectDir
     inputs.files(script, payloadFile, apkConfigFile, shellConfigFile, allowlist)
     outputs.upToDateWhen { false }
     doLast {
         val pb = ProcessBuilder(resolvePython3Command() + script.absolutePath)
-        pb.directory(rootProject.projectDir)
+        pb.directory(rootDir)
         pb.redirectErrorStream(true)
         val proc = pb.start()
         val log = proc.inputStream.bufferedReader().readText()

--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -364,28 +364,33 @@ class AgentService : Service() {
     }
 
     private fun ensureChannel() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (nm.getNotificationChannel(CHANNEL_ID) == null) {
-            nm.createNotificationChannel(
-                NotificationChannel(CHANNEL_ID, Strings.agentTitle, NotificationManager.IMPORTANCE_LOW)
-            )
-        }
+        com.webtoapp.util.SafeNotificationChannels.ensure(
+            context = this,
+            id = CHANNEL_ID,
+            name = Strings.agentTitle,
+            importance = android.app.NotificationManager.IMPORTANCE_LOW
+        )
     }
 
     private fun promoteToForeground(text: String) {
         if (inForeground) return
         val notification = buildNotification(text)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-            )
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+            inForeground = true
+        } catch (e: Exception) {
+            // Background FGS starts are throttled from Android 12 on; failing to promote
+            // must not crash the agent loop — keep running un-promoted instead.
+            com.webtoapp.core.logging.AppLogger.w("AgentService", "startForeground failed: ${e.message}")
         }
-        inForeground = true
     }
 
     private fun buildNotification(text: String) = NotificationCompat.Builder(this, CHANNEL_ID)

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
@@ -288,6 +288,8 @@ class ApkBuildCache(private val context: Context) {
         if (entryName == "assets/wta_adblock_compiled.txt") return true
         if (entryName == "assets/wta_perf_optimize.js") return true
         if (entryName == "assets/statusbar_background.png") return true
+        if (entryName == "assets/statusbar_background_dark.png") return true
+        if (entryName == "assets/announcement_icon.png") return true
         if (entryName == "assets/floating_window_minimized_icon.png") return true
         if (entryName.startsWith("assets/splash_media.")) return true
         if (entryName.startsWith("assets/error_page_media.")) return true
@@ -298,11 +300,13 @@ class ApkBuildCache(private val context: Context) {
         if (entryName.startsWith("assets/html_projects/")) return true
         if (entryName.startsWith("assets/nodejs_app/")) return true
         if (entryName.startsWith("assets/php_app/")) return true
+        if (entryName.startsWith("assets/python/")) return true
         if (entryName.startsWith("assets/python_app/")) return true
         if (entryName.startsWith("assets/go_app/")) return true
         if (entryName.startsWith("assets/frontend_app/")) return true
         if (entryName.startsWith("assets/static_pack/")) return true
         if (entryName.startsWith("assets/wordpress/")) return true
+        if (entryName.startsWith("assets/wta_custom_ca/")) return true
         if (entryName.startsWith("assets/multiweb_sites/")) return true
         if (entryName.startsWith("assets/multi_web/")) return true
         return false

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -32,6 +32,8 @@ import com.webtoapp.ui.theme.ThemeManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.*
 import java.util.zip.*
@@ -57,6 +59,21 @@ class ApkBuilder(private val context: Context) {
         private val PACKAGE_NAME_REGEX = AppConstants.PACKAGE_NAME_REGEX
         private val CHARSET_REGEX = AppConstants.CHARSET_REGEX
         private const val FLOATING_WINDOW_MINIMIZED_ICON_ASSET = "floating_window_minimized_icon.png"
+
+        /**
+         * Per-package build locks, shared by every [ApkBuilder] instance. Multiple entry
+         * points (export screen, home share button, agent tools, batch export) can start
+         * builds concurrently, and a build writes to deterministic temp paths keyed by
+         * package name — without serialization two builds of the same package interleave
+         * (one build's cleanup deletes the other's in-flight template copy / aligned ELF /
+         * unsigned APK mid-sign).
+         */
+        private val buildLocks = java.util.concurrent.ConcurrentHashMap<String, Mutex>()
+
+        private fun lockFor(packageName: String): Mutex =
+            buildLocks.getOrPut(packageName.replace(Regex("[^A-Za-z0-9_.-]"), "_")) {
+                Mutex()
+            }
 
         /** Adaptive icon canvas size (108dp @ xxxhdpi) used for foreground/background layers. */
         private const val ADAPTIVE_ICON_PX = 432
@@ -232,6 +249,18 @@ class ApkBuilder(private val context: Context) {
     private val outputDir = resolveOutputDir(context)
     private val tempDir = File(context.cacheDir, "apk_build_temp").apply { mkdirs() }
 
+    /**
+     * Working directory of the in-flight build (per package). Same-package builds are
+     * serialized by the companion [buildLocks], so the deterministic paths inside it
+     * (unsigned APK, template copy, aligned-ELF outputs) can never be touched by a
+     * concurrent build; different packages get different directories.
+     */
+    @Volatile
+    private var activeWorkDir: File? = null
+
+    private fun pkgWorkDir(packageName: String): File =
+        File(tempDir, "pkg_" + packageName.replace(Regex("[^A-Za-z0-9_.-]"), "_")).apply { mkdirs() }
+
     private val originalAppName = "WebToApp"
     private val originalPackageName = "com.webtoapp"
 
@@ -294,16 +323,21 @@ class ApkBuilder(private val context: Context) {
         forceFullRebuild: Boolean = false,
         onProgress: (Int, String) -> Unit = { _, _ -> }
     ): BuildResult = withContext(Dispatchers.IO) {
-        val versioned = withInstallAwareVersion(context, webApp)
-        if (versioned !== webApp) {
-            AppLogger.i(
-                "ApkBuilder",
-                "Bumped version for ${resolvePackageName(webApp)}: " +
-                    "${webApp.apkExportConfig?.customVersionCode ?: 1} -> " +
-                    "${versioned.apkExportConfig?.customVersionCode}"
-            )
+        // Serialize builds of the same package across all entry points (export screen,
+        // home share, agent tools): the build writes deterministic temp paths keyed by
+        // package name, so two overlapping builds would corrupt each other's files.
+        lockFor(resolvePackageName(webApp)).withLock {
+            val versioned = withInstallAwareVersion(context, webApp)
+            if (versioned !== webApp) {
+                AppLogger.i(
+                    "ApkBuilder",
+                    "Bumped version for ${resolvePackageName(webApp)}: " +
+                        "${webApp.apkExportConfig?.customVersionCode ?: 1} -> " +
+                        "${versioned.apkExportConfig?.customVersionCode}"
+                )
+            }
+            buildApkInternal(versioned, forceFullRebuild, onProgress)
         }
-        buildApkInternal(versioned, forceFullRebuild, onProgress)
     }
 
     private suspend fun buildApkInternal(
@@ -399,6 +433,8 @@ class ApkBuilder(private val context: Context) {
             logger.section("Generate Package Name")
             val packageName = resolvePackageName(webApp)
             currentPackageName = packageName
+            val workDir = pkgWorkDir(packageName)
+            activeWorkDir = workDir
 
             val customPkg = webApp.apkExportConfig?.customPackageName?.takeIf {
                 it.isNotBlank() && it.matches(PACKAGE_NAME_REGEX)
@@ -421,7 +457,7 @@ class ApkBuilder(private val context: Context) {
             onProgress(10, "Checking template...")
             logger.section("Parallel Resource Preparation")
 
-            val unsignedApk = File(tempDir, "${packageName}_unsigned.apk")
+            val unsignedApk = File(workDir, "${packageName}_unsigned.apk")
             val signedApk = File(outputDir, "${sanitizeFileName(webApp.name)}_v${config.versionName}.APK")
             currentUnsignedApkPath = unsignedApk.absolutePath
             currentSignedApkPath = signedApk.absolutePath
@@ -1109,7 +1145,6 @@ class ApkBuilder(private val context: Context) {
                 }
                 val cleanupDeferred = async {
                     unsignedApk.delete()
-                    cleanTempFiles()
                 }
 
                 cleanupDeferred.await()
@@ -1145,8 +1180,6 @@ class ApkBuilder(private val context: Context) {
             )
 
         } catch (e: Exception) {
-            cleanTempFiles()
-
             failBuild(
                 stage = currentStage,
                 cause = BuildFailureCause.UNHANDLED_EXCEPTION,
@@ -1160,6 +1193,13 @@ class ApkBuilder(private val context: Context) {
                     "signedApk" to currentSignedApkPath
                 )
             )
+        } finally {
+            // Per-build artifacts live under the package work dir; drop the unsigned APK on
+            // every exit path (failBuild returns inside try leave it behind otherwise) and
+            // clear the work-dir pointer. The cached template copy and aligned-ELF outputs
+            // stay for the next build of the same package.
+            try { currentUnsignedApkPath?.let { File(it).delete() } } catch (_: Exception) {}
+            activeWorkDir = null
         }
     }
 
@@ -1196,7 +1236,10 @@ class ApkBuilder(private val context: Context) {
         return try {
             val sourceTemplate = templateProvider.getTemplateFor(config) ?: return null
             val sourceName = sourceTemplate.name
-            val templateFile = File(tempDir, "base_template_${sourceName.substringBeforeLast('.')}.apk")
+            // Inside the per-package work dir: same-package builds are mutex-serialized, so
+            // the cached copy can be reused without a concurrent build truncating it.
+            val workDir = activeWorkDir ?: pkgWorkDir(config.packageName)
+            val templateFile = File(workDir, "base_template_${sourceName.substringBeforeLast('.')}.apk")
 
             val needsCopy = !templateFile.exists() ||
                 templateFile.length() != sourceTemplate.length() ||
@@ -1322,6 +1365,13 @@ class ApkBuilder(private val context: Context) {
                                     entry.name.endsWith(".DSA") || entry.name == "META-INF/MANIFEST.MF") -> {
                             }
                             buildCache.isContentReplaceableEntry(entry.name) -> {
+                            }
+                            // The injection phase below re-embeds the runtime native libs for the
+                            // device ABI on every build regardless of mode; copying the cached
+                            // copies here too would emit each lib twice (near-2x bloat and
+                            // undefined duplicate-entry behavior).
+                            entry.name in injectedDeviceLibs -> {
+                                AppLogger.d("ApkBuilder", "Skipping cached native lib (re-injected this build): ${entry.name}")
                             }
                             else -> {
                                 ZipUtils.copyEntryPreserveMethod(zipIn, zipOut, entry)
@@ -2028,7 +2078,9 @@ class ApkBuilder(private val context: Context) {
                 displayName == "libpython3.so" ||
                 displayName == "libmusl-linker.so"
         return try {
-            val result = ElfAligner16k.ensureAligned(sourceFile, File(tempDir, "elf16k"))
+            // Per-package work dir keeps the aligned outputs (and the in-memory cache
+            // entries pointing at them) isolated from concurrent builds of other apps.
+            val result = ElfAligner16k.ensureAligned(sourceFile, File(activeWorkDir ?: tempDir, "elf16k"))
             when {
                 result.alreadyAligned -> logger.log("ELF 16KB already aligned: $displayName")
                 result.repacked -> logger.log(
@@ -2216,19 +2268,24 @@ class ApkBuilder(private val context: Context) {
         logger.logKeyValue("wordpressTotalSize", "${totalSize / 1024} KB")
 
         val phpBinary = resolvePhpBinary()
-        if (phpBinary != null && phpBinary.canRead()) {
-            try {
-                val abi = com.webtoapp.core.wordpress.WordPressDependencyManager.getDeviceAbi()
-                val alignedPhpBinary = ensureAligned16kNativeLib(phpBinary, "libphp.so")
+        if (phpBinary == null || !phpBinary.canRead()) {
+            throw IllegalStateException(
+                "WordPress export needs the PHP runtime, but the PHP binary is missing or unreadable. " +
+                    "Download the PHP runtime in WebToApp (Linux Environment) and rebuild."
+            )
+        }
+        try {
+            val abi = com.webtoapp.core.wordpress.WordPressDependencyManager.getDeviceAbi()
+            val alignedPhpBinary = ensureAligned16kNativeLib(phpBinary, "libphp.so")
 
-                writeEntryStoredStreaming(zipOut, "lib/$abi/libphp.so", alignedPhpBinary)
-                logger.log("PHP binary injected as native lib: lib/$abi/libphp.so (${alignedPhpBinary.length() / 1024} KB)")
-
-            } catch (e: Exception) {
-                logger.error("Failed to embed PHP binary", e)
-            }
-        } else {
-            logger.warn("PHP binary not found")
+            writeEntryStoredStreaming(zipOut, "lib/$abi/libphp.so", alignedPhpBinary)
+            logger.log("PHP binary injected as native lib: lib/$abi/libphp.so (${alignedPhpBinary.length() / 1024} KB)")
+        } catch (e: Exception) {
+            // A WordPress APK without libphp.so installs fine but crashes on launch — fail the
+            // build instead of shipping a broken app (mirrors injectNodeJsNativeLibs).
+            throw IllegalStateException(
+                "Failed to embed the PHP binary as libphp.so for the WordPress app: ${e.message}", e
+            )
         }
     }
 
@@ -2394,19 +2451,23 @@ class ApkBuilder(private val context: Context) {
         RuntimeAssetEmbedder.embedProjectFiles(zipOut, projectDir, RuntimeAssetEmbedder.phpConfig(), logger)
 
         val phpBinary = resolvePhpBinary()
-        if (phpBinary != null && phpBinary.canRead()) {
-            try {
-                val abi = com.webtoapp.core.wordpress.WordPressDependencyManager.getDeviceAbi()
-                val alignedPhpBinary = ensureAligned16kNativeLib(phpBinary, "libphp.so")
+        if (phpBinary == null || !phpBinary.canRead()) {
+            throw IllegalStateException(
+                "PHP app export needs the PHP runtime, but the PHP binary is missing or unreadable. " +
+                    "Download the PHP runtime in WebToApp (Linux Environment) and rebuild."
+            )
+        }
+        try {
+            val abi = com.webtoapp.core.wordpress.WordPressDependencyManager.getDeviceAbi()
+            val alignedPhpBinary = ensureAligned16kNativeLib(phpBinary, "libphp.so")
 
-                writeEntryStoredStreaming(zipOut, "lib/$abi/libphp.so", alignedPhpBinary)
-                logger.log("PHP binary injected as native lib: lib/$abi/libphp.so (${alignedPhpBinary.length() / 1024} KB)")
-
-            } catch (e: Exception) {
-                logger.error("Failed to embed PHP binary for PHP app", e)
-            }
-        } else {
-            logger.warn("PHP binary not found")
+            writeEntryStoredStreaming(zipOut, "lib/$abi/libphp.so", alignedPhpBinary)
+            logger.log("PHP binary injected as native lib: lib/$abi/libphp.so (${alignedPhpBinary.length() / 1024} KB)")
+        } catch (e: Exception) {
+            // Swallowing this produced "successful" builds whose APKs crash on launch.
+            throw IllegalStateException(
+                "Failed to embed the PHP binary as libphp.so for the PHP app: ${e.message}", e
+            )
         }
     }
 
@@ -2562,20 +2623,25 @@ builtins.__import__ = _w2a_import
         }
 
         val abi = com.webtoapp.core.wordpress.WordPressDependencyManager.getDeviceAbi()
-        if (pythonBinary != null && pythonBinary.canRead()) {
-            try {
+        if (pythonBinary == null || !pythonBinary.canRead()) {
+            throw IllegalStateException(
+                "Python app export needs the Python runtime, but the interpreter is missing or unreadable " +
+                    "(looked for $versionedPythonBinaryName / python3 under $pythonHome). " +
+                    "Download the Python runtime in WebToApp (Linux Environment) and rebuild."
+            )
+        }
+        try {
+            val alignedPythonBinary = ensureAligned16kNativeLib(pythonBinary, "libpython3.so")
+            writeEntryStoredStreaming(zipOut, "lib/$abi/libpython3.so", alignedPythonBinary)
+            logger.log("Python binary embedded as native lib: lib/$abi/libpython3.so (${alignedPythonBinary.length() / 1024} KB, src=${pythonBinary.name})")
 
-                val alignedPythonBinary = ensureAligned16kNativeLib(pythonBinary, "libpython3.so")
-                writeEntryStoredStreaming(zipOut, "lib/$abi/libpython3.so", alignedPythonBinary)
-                logger.log("Python binary embedded as native lib: lib/$abi/libpython3.so (${alignedPythonBinary.length() / 1024} KB, src=${pythonBinary.name})")
-
-                writeEntryStoredSimple(zipOut, "assets/python/$abi/python3", alignedPythonBinary.readBytes())
-            } catch (e: Exception) {
-                logger.error("Failed to embed Python binary", e)
-            }
-        } else {
-            logger.error("⚠️ CRITICAL: Python binary not available! The exported APK will NOT be able to run Python apps. Please ensure Python runtime is downloaded in WebToApp settings.")
-            logger.warn("Python binary not found or too small: ${versionedPythonBinaryName}=${pythonBinaryVersioned.let { "${it.exists()}/${it.length()}" }}, python3=${pythonBinary3.let { "${it.exists()}/${it.length()}" }}")
+            writeEntryStoredSimple(zipOut, "assets/python/$abi/python3", alignedPythonBinary.readBytes())
+        } catch (e: Exception) {
+            // A Python APK without the interpreter installs fine but cannot run — fail the
+            // build instead of shipping it (mirrors injectNodeJsNativeLibs).
+            throw IllegalStateException(
+                "Failed to embed the Python binary as libpython3.so for the Python app: ${e.message}", e
+            )
         }
 
         val muslLinkerName = com.webtoapp.core.python.PythonDependencyManager.getMuslLinkerName(abi)
@@ -4440,8 +4506,15 @@ private fun WebApp.buildMultiWebBlock(context: android.content.Context?, package
         } else null
         // A site left without embedded config but still typed MULTI_WEB would hit
         // the shell's recursive-nesting guard and render blank: normalize it to a
-        // plain URL site, which the shell always knows how to display.
-        val siteAppType = if (siteShellConfig == null && site.appType == "MULTI_WEB") "WEB" else site.appType
+        // plain URL site, which the shell always knows how to display. Server-runtime
+        // types are normalized too — without embedded config the shell would route them
+        // into a *ShellMode that fork+execs an interpreter that was never packaged.
+        val siteAppType = when {
+            siteShellConfig != null -> site.appType
+            site.appType == "MULTI_WEB" -> "WEB"
+            com.webtoapp.data.model.AppType.fromPersistedName(site.appType)?.requiresProcessExec == true -> "WEB"
+            else -> site.appType
+        }
         com.webtoapp.core.shell.MultiWebSiteShellConfig(
             id = site.id,
             name = site.name,
@@ -4547,6 +4620,20 @@ internal fun resolveMultiWebSiteSource(
             "ApkBuilder",
             "MultiWeb site \"$siteName\" points at another multi-web app " +
                 "(id=${sourceApp.id}); nesting is not supported, embedding its URL instead"
+        )
+        return null
+    }
+    if (sourceApp.appType.requiresProcessExec) {
+        // Server-runtime sources cannot ship inside a multi-web APK: the per-site embedder
+        // only packages HTML/FRONTEND/gallery/media assets and the native-lib injection is
+        // keyed on the top-level app type, so a PHP/Node/Python/Go/WordPress site would
+        // route into its *ShellMode at runtime with neither the interpreter nor the project
+        // files present. Degrade to the site's URL (#792 pattern) instead of a broken export.
+        AppLogger.w(
+            "ApkBuilder",
+            "MultiWeb site \"$siteName\" sources a ${sourceApp.appType.name} app; " +
+                "server-runtime sites are not embeddable in multi-web exports, " +
+                "embedding its URL instead"
         )
         return null
     }

--- a/app/src/main/java/com/webtoapp/core/backup/DataBackupManager.kt
+++ b/app/src/main/java/com/webtoapp/core/backup/DataBackupManager.kt
@@ -139,14 +139,17 @@ class DataBackupManager(private val context: Context) {
          * Signing identity lives as loose files in filesDir root (JarSigner):
          * losing them means published apps can never be updated again.
          * Restored verbatim by exact file name (no traversal possible).
+         *
+         * NOTE: the password sidecars (custom_keystore_password.txt,
+         * custom_keystore_keypass.txt, .ks_credential) are deliberately NOT backed up:
+         * a user-shared backup zip would carry the private key AND its plaintext
+         * password together. Restore keeps the keystores; passwords are re-entered
+         * the next time a build signs with them.
          */
         private val KEYSTORE_FILES = listOf(
             "webtoapp_keystore.p12",
             "custom_keystore.p12",
-            "custom_keystore_password.txt",
             "custom_keystore_alias.txt",
-            "custom_keystore_keypass.txt",
-            ".ks_credential",
             "signing_scheme_options.json"
         )
 

--- a/app/src/main/java/com/webtoapp/core/download/DependencyDownloadEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/download/DependencyDownloadEngine.kt
@@ -271,7 +271,12 @@ object DependencyDownloadEngine {
                     body.use { responseBody ->
                         val contentLength = responseBody.contentLength()
                         val totalBytes = if (response.code == 206) {
-                            downloadedBytes + contentLength
+                            // A mirror may reply 206 without Content-Length (-1): the sum
+                            // would then read as downloadedBytes - 1, the final size check
+                            // would mismatch, and the resume temp would be deleted — turning
+                            // a resumable download into a from-zero restart. Keep the hint
+                            // unknown in that case instead.
+                            if (contentLength >= 0) downloadedBytes + contentLength else -1
                         } else {
                             contentLength
                         }

--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -165,6 +165,10 @@ class GeckoViewEngine(
 
         fun setTlsMitmActive(active: Boolean) {
             tlsMitmActive = active
+            // Gecko's network stack has no per-request callback the host can feed the MITM
+            // bridge's host allowlist from, so enforcing it here would block legitimate
+            // third-party resource CONNECTs. The WebView engine path keeps enforcement on.
+            com.webtoapp.core.webview.TlsMitmBridge.setHostAllowlistEnforcement(!active)
         }
 
         fun applyAntiCapture(active: Boolean) {
@@ -712,6 +716,13 @@ class GeckoViewEngine(
                 hasUserGesture: Boolean
             ) {
                 currentUrl = url
+                // Gecko traffic bypasses WebViewClient.shouldInterceptRequest, so the TLS
+                // MITM bridge's host allowlist is fed here instead.
+                if (com.webtoapp.core.webview.TlsMitmBridge.isRunning()) {
+                    com.webtoapp.core.webview.TlsMitmBridge.allowHost(
+                        runCatching { android.net.Uri.parse(url ?: "").host }.getOrNull()
+                    )
+                }
             }
 
             override fun onCanGoBack(session: GeckoSession, canGoBack: Boolean) {

--- a/app/src/main/java/com/webtoapp/core/errorpage/ErrorPageManager.kt
+++ b/app/src/main/java/com/webtoapp/core/errorpage/ErrorPageManager.kt
@@ -135,10 +135,17 @@ class ErrorPageManager(private val config: ErrorPageConfig) {
             return generateLegacyPage(style, strings, retryBtnText, showGame, gameType, autoRetry, failedUrl, diagnostic, report)
         }
 
+        // failedUrl is attacker-controllable (whatever URL the app failed to load).
+        // JS-encode it first — the old ' -> \' swap left backslashes alone, so `\';payload;//`
+        // escaped the JS string — then escape single quotes for the single-quoted JS string
+        // literals it is interpolated into, and neutralize "</" so the payload cannot close
+        // the host <script> block either. For the onclick= attributes use [attrSafeUrl]:
+        // the `\"` pair must become &quot; there or it closes the HTML attribute early.
         val safeUrl = failedUrl
-            ?.replace("'", "\\'")
-            ?.replace("\"", "&quot;")
+            ?.let { com.webtoapp.util.JsStrings.escape(it) }
+            ?.replace("</", "<\\/")
             ?: ""
+        val attrSafeUrl = safeUrl.replace("\\\"", "&quot;")
 
         val gameJs = if (showGame) ErrorPageGames.getGameJs(gameType) else ""
 
@@ -380,10 +387,17 @@ function startGame(){
         val styleBody = ErrorPageStyles.getStyleBody(style, resolvedTitle, resolvedSubtitle)
         val gameJs = if (showGame) ErrorPageGames.getGameJs(gameType) else ""
 
+        // failedUrl is attacker-controllable (whatever URL the app failed to load).
+        // JS-encode it first — the old ' -> \' swap left backslashes alone, so `\';payload;//`
+        // escaped the JS string — then escape single quotes for the single-quoted JS string
+        // literals it is interpolated into, and neutralize "</" so the payload cannot close
+        // the host <script> block either. For the onclick= attributes use [attrSafeUrl]:
+        // the `\"` pair must become &quot; there or it closes the HTML attribute early.
         val safeUrl = failedUrl
-            ?.replace("'", "\\'")
-            ?.replace("\"", "&quot;")
+            ?.let { com.webtoapp.util.JsStrings.escape(it) }
+            ?.replace("</", "<\\/")
             ?: ""
+        val attrSafeUrl = safeUrl.replace("\\\"", "&quot;")
 
         return """
 <!DOCTYPE html>
@@ -519,10 +533,17 @@ function startGame(){
         val mediaPath = config.customMediaPath ?: ""
         val retryBtnText = config.retryButtonText.ifBlank { strings.retryButton }
         val isVideo = mediaPath.endsWith(".mp4") || mediaPath.endsWith(".webm")
+        // failedUrl is attacker-controllable (whatever URL the app failed to load).
+        // JS-encode it first — the old ' -> \' swap left backslashes alone, so `\';payload;//`
+        // escaped the JS string — then escape single quotes for the single-quoted JS string
+        // literals it is interpolated into, and neutralize "</" so the payload cannot close
+        // the host <script> block either. For the onclick= attributes use [attrSafeUrl]:
+        // the `\"` pair must become &quot; there or it closes the HTML attribute early.
         val safeUrl = failedUrl
-            ?.replace("'", "\\'")
-            ?.replace("\"", "&quot;")
+            ?.let { com.webtoapp.util.JsStrings.escape(it) }
+            ?.replace("</", "<\\/")
             ?: ""
+        val attrSafeUrl = safeUrl.replace("\\\"", "&quot;")
 
         val mediaSrc = resolveMediaSrc(mediaPath, isVideo)
 
@@ -580,7 +601,7 @@ body{
 </head>
 <body>
 <div class="media-container">$mediaHtml</div>
-<button class="retry-btn" onclick="var u='$safeUrl';if(u)location.href=u;else location.reload();">$retryBtnText</button>
+<button class="retry-btn" onclick="var u='$attrSafeUrl';if(u)location.href=u;else location.reload();">$retryBtnText</button>
 <script>
 (function(){
     var v=document.getElementById('v');if(!v)return;
@@ -688,10 +709,17 @@ body{
     ): String {
         val strings = getStrings()
         val retryBtnText = config.retryButtonText.ifBlank { strings.retryButton }
+        // failedUrl is attacker-controllable (whatever URL the app failed to load).
+        // JS-encode it first — the old ' -> \' swap left backslashes alone, so `\';payload;//`
+        // escaped the JS string — then escape single quotes for the single-quoted JS string
+        // literals it is interpolated into, and neutralize "</" so the payload cannot close
+        // the host <script> block either. For the onclick= attributes use [attrSafeUrl]:
+        // the `\"` pair must become &quot; there or it closes the HTML attribute early.
         val safeUrl = failedUrl
-            ?.replace("'", "\\'")
-            ?.replace("\"", "&quot;")
+            ?.let { com.webtoapp.util.JsStrings.escape(it) }
+            ?.replace("</", "<\\/")
             ?: ""
+        val attrSafeUrl = safeUrl.replace("\\\"", "&quot;")
         val severityColor = when (diag.severity) {
             NetworkErrorDiagnostics.Severity.ERROR -> "#b3261e"
             NetworkErrorDiagnostics.Severity.WARNING -> "#ad590b"
@@ -749,7 +777,7 @@ ${errorDetailsCss()}
 <p class="cause">${escapeHtml(diag.cause)}</p>
 <div class="head">$head</div>
 <ul>$items</ul>
-<button onclick="var u='$safeUrl';if(u)location.href=u;else location.reload();">${escapeHtml(retryBtnText)}</button>
+<button onclick="var u='$attrSafeUrl';if(u)location.href=u;else location.reload();">${escapeHtml(retryBtnText)}</button>
 <div class="code">${escapeHtml(diag.key)}</div>
 ${errorDetailsHtml(report, strings)}
 </div>

--- a/app/src/main/java/com/webtoapp/core/extension/ChromeExtensionRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ChromeExtensionRuntime.kt
@@ -28,6 +28,13 @@ class ChromeExtensionRuntime(
     @Volatile
     private var popupPathOverride: String? = null
 
+    /** Host URL patterns this extension declared in its manifest (host_permissions et al). */
+    private val hostPatterns: List<String> by lazy {
+        ChromeHostPermissions.declaredPatterns(manifestJson)
+    }
+
+    fun declaredHostPatterns(): List<String> = hostPatterns
+
     @SuppressLint("SetJavaScriptEnabled")
     fun initialize(mainWebView: WebView) {
         if (isInitialized) return
@@ -243,18 +250,36 @@ $polyfill
 
         @JavascriptInterface
         fun nativeFetch(url: String, method: String, headersJson: String, body: String): String {
+            if (!hostAllows(url)) return hostDenied(url, "nativeFetch")
             return performNativeFetch(url, method, headersJson, body, originUrl)
         }
 
         @JavascriptInterface
         fun getCookies(url: String): String {
+            if (!hostAllows(url)) return ""
             return CookieManager.getInstance().getCookie(url) ?: ""
         }
 
         @JavascriptInterface
         fun setCookieValue(url: String, cookie: String) {
+            if (!hostAllows(url)) return
             CookieManager.getInstance().setCookie(url, cookie)
             CookieManager.getInstance().flush()
+        }
+
+        /** The background page may only touch origins the manifest declared. */
+        private fun hostAllows(url: String): Boolean =
+            hostPatterns.any { ChromeHostPermissions.matches(it, url) }
+
+        private fun hostDenied(url: String, api: String): String {
+            AppLogger.w(TAG, "[$extensionId] $api blocked: $url matches no declared host permission")
+            return org.json.JSONObject()
+                .put("ok", false)
+                .put("status", 0)
+                .put("statusText", "Blocked: URL matches no declared host permission")
+                .put("headers", org.json.JSONObject())
+                .put("body", "")
+                .toString()
         }
 
         @JavascriptInterface
@@ -413,6 +438,10 @@ $polyfill
         @JavascriptInterface
         fun startDownload(url: String, filename: String, headersJson: String): String {
             return try {
+                if (hostPatterns.none { ChromeHostPermissions.matches(it, url) }) {
+                    AppLogger.w(TAG, "[$extensionId] startDownload blocked: $url matches no declared host permission")
+                    return "-1"
+                }
                 val request = android.app.DownloadManager.Request(android.net.Uri.parse(url))
                 if (filename.isNotEmpty()) {
                     request.setDestinationInExternalPublicDir(
@@ -448,18 +477,36 @@ class ContentExtensionBridge(
 
     @JavascriptInterface
     fun nativeFetch(url: String, method: String, headersJson: String, body: String): String {
+        // This bridge is registered on the MAIN WebView — every page and iframe reaches it,
+        // so the target must be allowed by at least one installed extension's manifest.
+        if (!ChromeHostPermissions.anyRuntimeAllows(runtimes, url)) {
+            return hostDenied(url, "nativeFetch")
+        }
         return performNativeFetch(url, method, headersJson, body, null)
     }
 
     @JavascriptInterface
     fun getCookies(url: String): String {
+        if (!ChromeHostPermissions.anyRuntimeAllows(runtimes, url)) return ""
         return android.webkit.CookieManager.getInstance().getCookie(url) ?: ""
     }
 
     @JavascriptInterface
     fun setCookieValue(url: String, cookie: String) {
+        if (!ChromeHostPermissions.anyRuntimeAllows(runtimes, url)) return
         android.webkit.CookieManager.getInstance().setCookie(url, cookie)
         android.webkit.CookieManager.getInstance().flush()
+    }
+
+    private fun hostDenied(url: String, api: String): String {
+        AppLogger.w("ChromeExtRuntime", "$api blocked: $url matches no installed extension's host permission")
+        return org.json.JSONObject()
+            .put("ok", false)
+            .put("status", 0)
+            .put("statusText", "Blocked: URL matches no installed extension's host permission")
+            .put("headers", org.json.JSONObject())
+            .put("body", "")
+            .toString()
     }
 
     @JavascriptInterface

--- a/app/src/main/java/com/webtoapp/core/extension/ChromeHostPermissions.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ChromeHostPermissions.kt
@@ -1,0 +1,121 @@
+package com.webtoapp.core.extension
+
+/**
+ * Host-permission gate for the MV3 polyfill bridge (WtaExtBridge / ContentExtensionBridge).
+ *
+ * The bridge objects are added to the main WebView via addJavascriptInterface, so every
+ * page and iframe in the app can reach them — not just pages the extension declared in
+ * its manifest. Without this gate, `getCookies(url)` and the credentialed `nativeFetch`
+ * (it attaches and stores the WebView's cookies) let arbitrary embedded content read
+ * cookies for any origin, far beyond what the user agreed to when installing the
+ * extension. Every bridge method that acts on a URL must verify the target against the
+ * host permissions of the installed extension(s).
+ */
+object ChromeHostPermissions {
+
+    /**
+     * Extract the URL match patterns an extension declared: `host_permissions` entries
+     * plus the URL-pattern entries found in `permissions` (MV2 style manifests also put
+     * hosts there). API permission strings without a scheme are ignored.
+     */
+    fun declaredPatterns(manifestJson: String): List<String> = runCatching {
+        val manifest = org.json.JSONObject(manifestJson)
+        val out = mutableListOf<String>()
+        listOf("host_permissions", "permissions", "optional_permissions").forEach { key ->
+            manifest.optJSONArray(key)?.let { arr ->
+                for (i in 0 until arr.length()) {
+                    val entry = arr.optString(i) ?: continue
+                    if (entry == "<all_urls>" || entry.contains("://")) out.add(entry)
+                }
+            }
+        }
+        out
+    }.getOrDefault(emptyList())
+
+    /**
+     * Chrome match pattern matching: `<all_urls>`, `scheme://host/path` where scheme may
+     * be `*`, host may be `*` or `*.example.com`, and the path may contain `*`. Parsing is
+     * deliberately manual: `java.net.URI` rejects `*` schemes and Android's Uri is not
+     * available under plain-JVM unit tests.
+     */
+    fun matches(pattern: String, url: String): Boolean {
+        if (pattern == "<all_urls>") return true
+
+        val pParts = splitPattern(pattern) ?: return false
+        val uParts = splitPattern(url) ?: return false
+
+        if (pParts.scheme != "*" && pParts.scheme != uParts.scheme) return false
+        if (!hostMatches(pParts.host, uParts.host)) return false
+        return pathMatches(pParts.path, uParts.path)
+    }
+
+    private data class UrlParts(val scheme: String, val host: String, val port: String, val path: String)
+
+    private fun splitPattern(raw: String): UrlParts? {
+        val sep = raw.indexOf("://")
+        if (sep <= 0) return null
+        val scheme = raw.substring(0, sep).lowercase()
+        val rest = raw.substring(sep + 3)
+        if (rest.isEmpty()) return null
+
+        val pathStart = rest.indexOf('/')
+        val authority = if (pathStart >= 0) rest.substring(0, pathStart) else rest
+        val path = if (pathStart >= 0) rest.substring(pathStart) else "/"
+
+        // authority = host[:port] (userinfo@ not valid in match patterns; brackets for IPv6)
+        val host: String
+        val port: String
+        if (authority.startsWith("[")) {
+            val close = authority.indexOf(']')
+            if (close < 0) return null
+            host = authority.substring(0, close + 1)
+            port = authority.substring(close + 1).removePrefix(":")
+        } else {
+            val colon = authority.lastIndexOf(':')
+            if (colon > authority.indexOf(']') || colon == -1) {
+                host = authority
+                port = ""
+            } else {
+                host = authority.substring(0, colon)
+                port = authority.substring(colon + 1)
+            }
+        }
+        if (host.isEmpty()) return null
+        return UrlParts(scheme, host.lowercase(), port, path)
+    }
+
+    private fun hostMatches(patternHost: String, host: String): Boolean {
+        if (patternHost == "*" || patternHost == host) return true
+        if (patternHost.startsWith("*.")) {
+            val suffix = patternHost.substring(1) // ".example.com"
+            if (host.endsWith(suffix)) return true
+            // `*.example.com` also matches `example.com` itself in Chrome.
+            return host == suffix.removePrefix(".")
+        }
+        return false
+    }
+
+    private fun pathMatches(patternPath: String, path: String): Boolean {
+        if (patternPath == "/*" || patternPath == "*" || patternPath == path) return true
+        if (!patternPath.contains('*')) return false
+        val regex = buildString {
+            append('^')
+            patternPath.forEach { ch ->
+                when (ch) {
+                    '*' -> append(".*")
+                    else -> {
+                        if ("\\.[]{}()+?^$|".contains(ch)) append('\\')
+                        append(ch)
+                    }
+                }
+            }
+            append('$')
+        }
+        return runCatching { Regex(regex).matches(path) }.getOrDefault(false)
+    }
+
+    /** True iff [url] is allowed by at least one extension's declared host patterns. */
+    fun anyRuntimeAllows(runtimes: Map<String, ChromeExtensionRuntime>, url: String): Boolean {
+        return runtimes.values.any { runtime -> runtime.declaredHostPatterns().any { matches(it, url) } }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/extension/GreasemonkeyBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/GreasemonkeyBridge.kt
@@ -224,27 +224,49 @@ class GreasemonkeyBridge(
 
     private val httpClient get() = NetworkModule.defaultClient
 
-    private fun getPrefs(scriptId: String) =
-        context.getSharedPreferences("$PREFS_PREFIX$scriptId", Context.MODE_PRIVATE)
+    /**
+     * Storage namespaces are addressed through unguessable per-script aliases instead of
+     * the raw script id: the bridge object is reachable from every page and iframe in the
+     * app, so with raw ids any embedded content could read/write another script's GM
+     * storage by simply naming it. The alias is random per script; only the pages that
+     * received the polyfill ever see it.
+     */
+    private val aliasByScriptId = java.util.concurrent.ConcurrentHashMap<String, String>()
+    private val scriptIdByAlias = java.util.concurrent.ConcurrentHashMap<String, String>()
 
-    @JavascriptInterface
-    fun getValue(scriptId: String, key: String, defaultValue: String?): String? {
-        return getPrefs(scriptId).getString(key, defaultValue)
+    fun storageAliasFor(scriptId: String): String {
+        aliasByScriptId.getOrPut(scriptId) {
+            val alias = "ns_" + java.security.SecureRandom().nextInt(Int.MAX_VALUE).toString(36) +
+                "_" + java.security.SecureRandom().nextInt(Int.MAX_VALUE).toString(36)
+            scriptIdByAlias[alias] = scriptId
+            alias
+        }
+        return aliasByScriptId[scriptId] ?: scriptId
+    }
+
+    private fun getPrefs(alias: String): android.content.SharedPreferences? {
+        val scriptId = scriptIdByAlias[alias] ?: return null
+        return context.getSharedPreferences("$PREFS_PREFIX$scriptId", Context.MODE_PRIVATE)
     }
 
     @JavascriptInterface
-    fun setValue(scriptId: String, key: String, value: String) {
-        getPrefs(scriptId).edit().putString(key, value).apply()
+    fun getValue(alias: String, key: String, defaultValue: String?): String? {
+        return getPrefs(alias)?.getString(key, defaultValue)
     }
 
     @JavascriptInterface
-    fun deleteValue(scriptId: String, key: String) {
-        getPrefs(scriptId).edit().remove(key).apply()
+    fun setValue(alias: String, key: String, value: String) {
+        getPrefs(alias)?.edit()?.putString(key, value)?.apply()
     }
 
     @JavascriptInterface
-    fun listValues(scriptId: String): String {
-        val keys = getPrefs(scriptId).all.keys
+    fun deleteValue(alias: String, key: String) {
+        getPrefs(alias)?.edit()?.remove(key)?.apply()
+    }
+
+    @JavascriptInterface
+    fun listValues(alias: String): String {
+        val keys = getPrefs(alias)?.all?.keys ?: emptySet()
         return JSONArray(keys.toList()).toString()
     }
 
@@ -258,6 +280,29 @@ class GreasemonkeyBridge(
                 val data = details.optString("data", "")
                 val headersObj = details.optJSONObject("headers")
                 val responseType = details.optString("responseType", "")
+
+                // GM_xmlhttpRequest is cross-origin by design, but only for the open
+                // internet: the bridge object is reachable from any frame of any page
+                // the app displays, so private/loopback targets are reserved for local
+                // (packaged / local-server) pages.
+                val uri = runCatching { java.net.URI(url) }.getOrNull()
+                val scheme = uri?.scheme?.lowercase()
+                if (scheme != "http" && scheme != "https") {
+                    throw IllegalArgumentException("GM_xmlhttpRequest supports HTTP(S) URLs only")
+                }
+                val targetIsPrivate = com.webtoapp.core.webview.NativeBridge.isPrivateNetworkHost(uri?.host)
+                if (targetIsPrivate) {
+                    val pageUrl = runCatching {
+                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) { webViewProvider()?.url }
+                    }.getOrNull().orEmpty()
+                    val pageIsLocal = com.webtoapp.core.webview.NativeBridge.isPrivateNetworkUrl(pageUrl) ||
+                        pageUrl.startsWith("file:") || pageUrl.startsWith("content://")
+                    if (!pageIsLocal) {
+                        throw IllegalArgumentException(
+                            "GM_xmlhttpRequest to local network addresses is only allowed from local pages"
+                        )
+                    }
+                }
 
                 val requestBuilder = Request.Builder().url(url)
 
@@ -323,6 +368,14 @@ class GreasemonkeyBridge(
     @JavascriptInterface
     fun openInTab(url: String, openInBackground: Boolean): Boolean {
         return try {
+            // Scheme allowlist: GM_openInTab takes a raw URL from script/page context and an
+            // `intent://` / `file://` value here would turn into component-launch or
+            // local-file access (intent redirection). Web URLs only.
+            val scheme = runCatching { java.net.URI(url).scheme?.lowercase() }.getOrNull()
+            if (scheme != "http" && scheme != "https") {
+                AppLogger.w(TAG, "GM_openInTab blocked non-web URL: $url")
+                return false
+            }
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(intent)
@@ -339,19 +392,24 @@ class GreasemonkeyBridge(
     }
 
     private fun callbackToJs(callbackId: String, event: String, dataJson: String) {
+        // callbackId comes from page JS; quote it as a JSON string so a crafted id
+        // ('x');payload();//) cannot break out of the JS string literal and execute
+        // in whatever page is loaded when the async callback lands.
+        val quotedCallbackId = com.webtoapp.util.JsStrings.quote(callbackId ?: "")
+        val quotedEvent = com.webtoapp.util.JsStrings.quote(event)
         val escapedData = dataJson.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
         val js = """
             (function() {
-                var cb = window.__WTA_GM_CALLBACKS__['$callbackId'];
-                if (cb && cb['$event']) {
+                var cb = window.__WTA_GM_CALLBACKS__[$quotedCallbackId];
+                if (cb && cb[$quotedEvent]) {
                     try {
-                        cb['$event'](JSON.parse('$escapedData'));
+                        cb[$quotedEvent](JSON.parse('$escapedData'));
                     } catch(e) {
                         console.error('[GM Bridge] Callback error:', e);
                     }
                 }
-                if ('$event' === 'onload' || '$event' === 'onerror' || '$event' === 'ontimeout') {
-                    delete window.__WTA_GM_CALLBACKS__['$callbackId'];
+                if ($quotedEvent === 'onload' || $quotedEvent === 'onerror' || $quotedEvent === 'ontimeout') {
+                    delete window.__WTA_GM_CALLBACKS__[$quotedCallbackId];
                 }
             })();
         """.trimIndent()

--- a/app/src/main/java/com/webtoapp/core/floatingwindow/FloatingWindowService.kt
+++ b/app/src/main/java/com/webtoapp/core/floatingwindow/FloatingWindowService.kt
@@ -304,7 +304,8 @@ class FloatingWindowService : Service() {
                             capabilities = capabilities,
                             corsBypass = shellConfig.webViewConfig.enableCorsBypass,
                             downloadLocationMode = downloadLocationMode,
-                            customDownloadDirUri = customDownloadDirUri
+                            customDownloadDirUri = customDownloadDirUri,
+                            appOriginUrl = shellConfig.targetUrl
                         )
                         webView.addJavascriptInterface(
                             nativeBridge,
@@ -315,7 +316,8 @@ class FloatingWindowService : Service() {
                             context = this@FloatingWindowService,
                             scope = serviceScope,
                             webViewProvider = { webView },
-                            corsBypass = shellConfig.webViewConfig.enableCorsBypass
+                            corsBypass = shellConfig.webViewConfig.enableCorsBypass,
+                            appOriginUrl = shellConfig.targetUrl
                         )
                         webView.addJavascriptInterface(
                             privateNetworkBridge,

--- a/app/src/main/java/com/webtoapp/core/frontend/GitHubRepoFetcher.kt
+++ b/app/src/main/java/com/webtoapp/core/frontend/GitHubRepoFetcher.kt
@@ -184,7 +184,8 @@ class GitHubRepoFetcher(private val context: Context) {
                     }
 
                     val target = File(extractDir, entryName).canonicalFile
-                    if (!target.path.startsWith(extractDir.canonicalPath)) {
+                    // + File.separator: a bare prefix match lets sibling directories through.
+                    if (!target.path.startsWith(extractDir.canonicalPath + File.separator)) {
                         AppLogger.w(TAG, "Skip unsafe zip entry: $entryName")
                         zis.closeEntry()
                         entry = zis.nextEntry

--- a/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
@@ -142,6 +142,9 @@ class GoRuntime(private val context: Context) {
 
             if (!wxRestricted && !GoDependencyManager.isGoExecLoaderReady(context)) {
                 val path = GoDependencyManager.getGoExecLoaderPath(context)
+                // The allocation taken two lines up must go back before bailing out.
+                PortManager.release(serverPort)
+                currentPort = 0
                 _serverState.value = ServerState.Error(
                     "Go executable loader 未就绪 ($path)。导出的 GO_APP 需包含 libgo_exec_loader.so；请用含原生 loader 的构建器重新导出。"
                 )
@@ -252,6 +255,12 @@ class GoRuntime(private val context: Context) {
         } catch (e: Exception) {
             AppLogger.e(TAG, "启动 Go 服务器失败", e)
             ShellLogger.e(TAG, "启动 Go 服务器失败: ${e.message}${channelNote()}")
+            // The port allocation from before the failure must be released too (the DNS
+            // proxy is stopped explicitly above because stopServer is process-oriented).
+            if (currentPort > 0) {
+                runCatching { PortManager.release(currentPort) }
+                currentPort = 0
+            }
             if (dnsProxyStarted) {
                 LocalDnsBridgeProxy.stop()
                 dnsProxyStarted = false

--- a/app/src/main/java/com/webtoapp/core/golang/GoToolchainManager.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoToolchainManager.kt
@@ -382,7 +382,11 @@ object GoToolchainManager {
                     entry = tar.nextTarEntry
                     continue
                 }
-                val out = File(destGoRoot, rel)
+                val out = com.webtoapp.util.SafeZip.safeChild(destGoRoot, rel) ?: run {
+                    skipped++
+                    entry = tar.nextTarEntry
+                    continue
+                }
                 when {
                     entry.isDirectory -> {
                         out.mkdirs()

--- a/app/src/main/java/com/webtoapp/core/linux/LocalBuildEnvironment.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/LocalBuildEnvironment.kt
@@ -852,7 +852,12 @@ object LocalBuildEnvironment {
             TarArchiveInputStream(gzip).use { tar ->
                 var entry = tar.nextTarEntry
                 while (entry != null) {
-                    val dest = File(destinationDir, entry.name.removePrefix("./"))
+                    val dest = com.webtoapp.util.SafeZip.safeChild(
+                        destinationDir, entry.name.removePrefix("./")
+                    ) ?: run {
+                        entry = tar.nextTarEntry
+                        continue
+                    }
                     if (entry.isDirectory) {
                         dest.mkdirs()
                     } else {

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeRuntime.kt
@@ -116,8 +116,12 @@ class NodeRuntime(private val context: Context) {
                         }, "NodePortStop")
                         stopper.isDaemon = true
                         stopper.start()
+                        // This stop handler runs on PortManager.release() from the UI's
+                        // onDispose — i.e. the main thread. The IPC stop can stall while
+                        // the :nodejs process is mid-restart; a 5s join would drop frames
+                        // or ANR. The handler thread finishes on its own either way.
                         try {
-                            stopper.join(5_000L)
+                            stopper.join(500L)
                         } catch (_: InterruptedException) {
                             Thread.currentThread().interrupt()
                         }

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
@@ -81,8 +81,13 @@ class NodeService : Service() {
                 NodeServiceProtocol.MSG_STOP_SERVER -> {
                     val replyTo = msg.replyTo
                     service.workerHandler.post {
-                        service.stopServerInternal()
+                        val engineKilled = service.stopServerInternal()
                         sendBack(replyTo, NodeServiceProtocol.MSG_SERVER_STOPPED, Bundle())
+                        if (engineKilled) {
+                            // Reply already queued; now tear down the poisoned :nodejs process
+                            // so the framework restarts a clean engine on the next start.
+                            Process.killProcess(Process.myPid())
+                        }
                     }
                 }
                 NodeServiceProtocol.MSG_KILL_ENGINE -> {
@@ -302,6 +307,9 @@ class NodeService : Service() {
 
             try { Thread.sleep(300) } catch (_: InterruptedException) {}
             if (nodeThread?.isAlive != true) {
+                // The port was reclaimed by the node thread's own finally, but the DNS
+                // bridge refcount taken above is still held — stopServerInternal releases it.
+                stopServerInternal()
                 replyFailed(replyTo, requestId, "Node.js 启动后立即退出")
                 return
             }
@@ -322,16 +330,28 @@ class NodeService : Service() {
             }
         } catch (e: Exception) {
             AppLogger.e(TAG, "handleStartServer 异常", e)
+            // Partially-started state (allocated port, DNS bridge refcount) must not leak
+            // past a failed start — the next successful start/stop pair would then never
+            // bring the shared DNS proxy back down.
+            runCatching { stopServerInternal() }
             replyFailed(replyTo, requestId, "启动失败: ${e.message}")
         }
     }
 
-    private fun stopServerInternal() {
+    /**
+     * Stop the running Node server. Returns true when the native V8 event loop survived
+     * interrupt+join and the whole :nodejs process had to be killed (the caller must send
+     * its IPC reply first, then honor this by self-terminating so the framework rebuilds
+     * a clean engine).
+     */
+    private fun stopServerInternal(): Boolean {
+        var threadStuck = false
         try {
             nodeThread?.let { thread ->
                 if (thread.isAlive) {
                     thread.interrupt()
                     thread.join(2000)
+                    threadStuck = thread.isAlive
                 }
             }
         } catch (e: Exception) {
@@ -348,6 +368,14 @@ class NodeService : Service() {
             currentPort = 0
             isRunning = false
         }
+        if (threadStuck) {
+            // Thread.interrupt() cannot break the native V8 event loop (the bootstrap keeps
+            // it alive on purpose): the port is released above but the JS server still holds
+            // the socket bound with nobody tracking it. Escalate to a full engine kill.
+            AppLogger.w(TAG, "Node 线程在 interrupt+join 后仍在运行，升级为 KILL_ENGINE 重建 :nodejs 进程")
+            ShellLogger.w(TAG, "Node 线程未能停止，正在重建 :nodejs 进程")
+        }
+        return threadStuck
     }
 
     private fun isServerRunningInternal(): Boolean = isRunning && nodeThread?.isAlive == true

--- a/app/src/main/java/com/webtoapp/core/notification/NotificationWebSocketService.kt
+++ b/app/src/main/java/com/webtoapp/core/notification/NotificationWebSocketService.kt
@@ -677,17 +677,13 @@ class NotificationWebSocketService : Service() {
     }
 
     private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                Strings.websocketNotificationChannelName,
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = Strings.websocketNotificationChannelDescription
-                setShowBadge(true)
-            }
-            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
-        }
+        com.webtoapp.util.SafeNotificationChannels.ensure(
+            context = this,
+            id = CHANNEL_ID,
+            name = Strings.websocketNotificationChannelName,
+            importance = NotificationManager.IMPORTANCE_DEFAULT,
+            description = Strings.websocketNotificationChannelDescription
+        ) { setShowBadge(true) }
     }
 
     private fun createForegroundNotification(connected: Boolean = false): Notification {

--- a/app/src/main/java/com/webtoapp/core/notification/PushNotificationHelper.kt
+++ b/app/src/main/java/com/webtoapp/core/notification/PushNotificationHelper.kt
@@ -21,19 +21,13 @@ object PushNotificationHelper {
         channelName: String,
         channelDescription: String
     ) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        val manager = context.getSystemService(NotificationManager::class.java) ?: return
-        val existing = manager.getNotificationChannel(channelId)
-        if (existing != null) return
-        val channel = NotificationChannel(
-            channelId,
-            channelName,
-            NotificationManager.IMPORTANCE_DEFAULT
-        ).apply {
+        com.webtoapp.util.SafeNotificationChannels.ensure(
+            context = context,
+            id = channelId,
+            name = channelName,
+            importance = android.app.NotificationManager.IMPORTANCE_DEFAULT,
             description = channelDescription
-            setShowBadge(true)
-        }
-        manager.createNotificationChannel(channel)
+        ) { setShowBadge(true) }
     }
 
     fun canPostNotifications(context: Context): Boolean {

--- a/app/src/main/java/com/webtoapp/core/php/PhpAppRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/php/PhpAppRuntime.kt
@@ -216,6 +216,11 @@ class PhpAppRuntime(private val context: Context) {
             }
         } catch (e: Exception) {
             AppLogger.e(TAG, "启动 PHP 服务器失败", e)
+            // The port allocation and the DNS-bridge refcount taken above this catch must
+            // not outlive the failed start (the runtime instance dies with the composable,
+            // so nothing else would release them: port purges only after the 120s stale
+            // sweep, and the proxy refcount never).
+            runCatching { stopServer() }
             _serverState.value = ServerState.Error("启动失败: ${e.message}")
             -1
         }

--- a/app/src/main/java/com/webtoapp/core/playstore/aab/AabExportCoordinator.kt
+++ b/app/src/main/java/com/webtoapp/core/playstore/aab/AabExportCoordinator.kt
@@ -25,6 +25,20 @@ class AabExportCoordinator(private val context: Context) {
         onProgress: ((stage: AabExporter.Stage, percent: Int) -> Unit)? = null
     ): AabExporter.Result {
 
+        // The AAB pipeline rewrites targetSdk to the Play-required level (>= 29). A
+        // server-runtime app (Node/PHP/Python/Go/WordPress, directly or via a multi-web
+        // site that survived source resolution) cannot exec its bundled runtimes under the
+        // W^X that follows, so converting it would mint an AAB whose app can never start.
+        // The interactive path blocks this via PlayPolicyChecker; this guard covers
+        // programmatic callers (agent tools, future automation).
+        if (webApp.appType.requiresProcessExec) {
+            throw AabExportException(
+                FailureStage.BUILD_APK,
+                "${webApp.appType.name} apps cannot be exported as Play AABs: the required " +
+                    "targetSdk rewrite (>= 29) enables W^X, which blocks the bundled runtime binaries."
+            )
+        }
+
         val sourceApk = findMostRecentApkFor(webApp)
         val apkToConvert = if (sourceApk != null) {
             AppLogger.d(

--- a/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
@@ -888,8 +888,29 @@ sys.exit(main())
 
         extraEnv.forEach { (k, v) -> env[k] = v }
 
+        // pip needs the same DNS bridge the server does: the musl resolver cannot reach
+        // Android's resolver, and pip talks HTTPS to PyPI by hostname. Hold a proxy
+        // reference for the duration of the command and release it afterwards.
+        val proxyPort = com.webtoapp.core.linux.LocalDnsBridgeProxy.start()
+        if (proxyPort > 0) {
+            com.webtoapp.core.linux.LocalDnsBridgeProxy.proxyEnvFor(proxyPort).forEach { (k, v) -> env[k] = v }
+        }
+
         AppLogger.i(TAG, "executeCommand: starting process...")
-        val process = processBuilder.start()
+        try {
+            val process = processBuilder.start()
+            return executeCommandAwait(process, onOutput)
+        } finally {
+            if (proxyPort > 0) {
+                com.webtoapp.core.linux.LocalDnsBridgeProxy.stop()
+            }
+        }
+    }
+
+    private fun executeCommandAwait(
+        process: Process,
+        onOutput: ((String) -> Unit)?
+    ): CommandResult {
 
         val output = StringBuilder()
         val outputLock = Any()

--- a/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
@@ -20,6 +20,8 @@ import java.net.URL
 
 class PythonRuntime(private val context: Context) {
 
+    private var dnsProxyStarted = false
+
     companion object {
         private const val TAG = "PythonRuntime"
 
@@ -244,6 +246,17 @@ class PythonRuntime(private val context: Context) {
 
             envVars.forEach { (k, v) -> env[k] = v }
 
+            // The bundled Python is musl-linked and its resolver reads /etc/resolv.conf,
+            // which does not exist on Android — same situation as the Go runtime. Route
+            // its HTTP(S) through the JVM DNS bridge so on-device DNS works.
+            val proxyPort = com.webtoapp.core.linux.LocalDnsBridgeProxy.start()
+            if (proxyPort > 0) {
+                com.webtoapp.core.linux.LocalDnsBridgeProxy.proxyEnvFor(proxyPort).forEach { (k, v) -> env[k] = v }
+                dnsProxyStarted = true
+                AppLogger.i(TAG, "已启用 DNS 桥接代理 (port=$proxyPort) 供 Python 进程解析外部域名")
+                ShellLogger.i(TAG, "已启用 DNS 桥接代理: 127.0.0.1:$proxyPort")
+            }
+
             pythonOutputBuffer.setLength(0)
             pythonStderrBuffer.setLength(0)
             val readinessBudget = ReadinessBudget(
@@ -311,6 +324,10 @@ class PythonRuntime(private val context: Context) {
         } catch (e: Exception) {
             AppLogger.e(TAG, "Starting Python serverfailed", e)
             ShellLogger.e(TAG, "启动 Python 服务器失败: ${e.message}")
+            // stopServer's finally releases the allocated port and process state; without
+            // this the port lingers until the 120s stale sweep because the runtime instance
+            // dies together with the failed start.
+            runCatching { stopServer() }
             _serverState.value = ServerState.Error("启动失败: ${e.message}")
             -1
         }
@@ -330,6 +347,10 @@ class PythonRuntime(private val context: Context) {
             AppLogger.w(TAG, "Python server stop raised an exception: ${e.message}")
         } finally {
             if (currentPort > 0) PortManager.release(currentPort)
+            if (dnsProxyStarted) {
+                com.webtoapp.core.linux.LocalDnsBridgeProxy.stop()
+                dnsProxyStarted = false
+            }
             pythonProcess = null
             currentPort = 0
             _serverState.value = ServerState.Stopped

--- a/app/src/main/java/com/webtoapp/core/shell/ShellServerLauncher.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellServerLauncher.kt
@@ -314,6 +314,7 @@ object ShellServerLauncher {
             }
             runCatching {
                 com.webtoapp.core.wordpress.WordPressManager.applyRuntimeConfig(
+                    context = context,
                     phpBinary = runtime.getPhpBinaryPath(),
                     projectDir = wpDir,
                     siteTitle = config.wordpressConfig.siteTitle,

--- a/app/src/main/java/com/webtoapp/core/stats/LivePreviewServerLauncher.kt
+++ b/app/src/main/java/com/webtoapp/core/stats/LivePreviewServerLauncher.kt
@@ -211,6 +211,7 @@ object LivePreviewServerLauncher {
                 siteLanguage = config.siteLanguage.ifBlank { "en_US" },
             )
             WordPressManager.applyRuntimeConfig(
+                context = context,
                 phpBinary = runtime.getPhpBinaryPath(),
                 projectDir = projectDir,
                 siteTitle = config.siteTitle.ifBlank { "My Site" },

--- a/app/src/main/java/com/webtoapp/core/webview/CertificateHostnameMatcher.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/CertificateHostnameMatcher.kt
@@ -1,0 +1,100 @@
+package com.webtoapp.core.webview
+
+import org.bouncycastle.asn1.x500.X500Name
+import java.security.cert.X509Certificate
+import java.util.Locale
+
+/**
+ * RFC 6125 hostname matching for [TlsUpstreamConnector]: the bridge must verify that the
+ * upstream server's certificate actually covers the host it was contacted as. Plain
+ * [javax.net.ssl.SSLSocket] handshakes validate the chain but never the hostname, so without
+ * this check the fingerprint-spoofing path would accept a valid certificate for the wrong
+ * domain (a static-exhaustion / mis-issuance hole an active attacker can aim at).
+ *
+ * Pure JVM, unit-testable: SubjectAlternativeName dNSName / iPAddress entries win (wildcards
+ * match exactly one left-most label), CN is only consulted when the certificate has no SANs
+ * of either kind (legacy certs).
+ */
+object CertificateHostnameMatcher {
+
+    fun matches(host: String, cert: X509Certificate): Boolean {
+        val normalizedHost = host.trim().lowercase(Locale.ROOT).trimEnd('.').removeSurrounding("[", "]")
+        if (normalizedHost.isEmpty()) return false
+
+        // CONNECT targets arrive with IPv6 brackets already stripped by the caller.
+        val isIpv6 = normalizedHost.contains(':')
+        val isIpv4 = normalizedHost.isNotEmpty() &&
+            normalizedHost.all { it.isDigit() || it == '.' } &&
+            normalizedHost.count { it == '.' } == 3
+        if (isIpv6 || isIpv4) {
+            return matchesIpAddress(normalizedHost, cert)
+        }
+
+        val sans = runCatching { cert.subjectAlternativeNames }.getOrNull()
+        var sawDnsSan = false
+        if (sans != null) {
+            for (san in sans) {
+                val type = san.getOrNull(0)
+                val value = san.getOrNull(1) as? String ?: continue
+                when (type) {
+                    2 -> { // dNSName
+                        sawDnsSan = true
+                        if (matchesDnsName(normalizedHost, value.trim().lowercase(Locale.ROOT))) return true
+                    }
+                    7 -> { // iPAddress
+                        if (matchesIpAddress(normalizedHost.removeSurrounding("[", "]"), cert)) return true
+                    }
+                }
+            }
+        }
+
+        // CN fallback only for certificates without any DNS SAN entry.
+        if (sawDnsSan) return false
+        return cnValues(cert).any { cn ->
+            matchesDnsName(normalizedHost, cn.trim().lowercase(Locale.ROOT).trimEnd('.'))
+        }
+    }
+
+    private fun matchesDnsName(host: String, pattern: String): Boolean {
+        if (pattern.isEmpty() || host.isEmpty()) return false
+        if (pattern == host) return true
+        if (!pattern.startsWith("*.")) return false
+        // "*.example.com" matches exactly one left-most label: "a.example.com" yes,
+        // "example.com" / "a.b.example.com" no. The wildcard label itself must not be empty.
+        val suffix = pattern.substring(1) // ".example.com"
+        if (!host.endsWith(suffix)) return false
+        val label = host.substring(0, host.length - suffix.length)
+        return label.isNotEmpty() && !label.contains('.')
+    }
+
+    private fun matchesIpAddress(host: String, cert: X509Certificate): Boolean {
+        val sans = runCatching { cert.subjectAlternativeNames }.getOrNull() ?: return false
+        for (san in sans) {
+            if (san.getOrNull(0) != 7) continue
+            when (val value = san.getOrNull(1)) {
+                is ByteArray -> {
+                    val certAddr = bytesToIpAddressString(value) ?: continue
+                    if (certAddr == host) return true
+                }
+                is String -> {
+                    if (value.trim() == host) return true
+                }
+            }
+        }
+        return false
+    }
+
+    private fun bytesToIpAddressString(bytes: ByteArray): String? = when (bytes.size) {
+        4 -> bytes.joinToString(".") { (it.toInt() and 0xFF).toString() }
+        16 -> bytes.toList().chunked(2).joinToString(":") {
+            ((it[0].toInt() and 0xFF) shl 8 or (it[1].toInt() and 0xFF)).toString(16)
+        }
+        else -> null
+    }
+
+    private fun cnValues(cert: X509Certificate): List<String> = runCatching {
+        val name = X500Name.getInstance(cert.subjectX500Principal.encoded)
+        name.getRDNs(org.bouncycastle.asn1.x500.style.BCStyle.CN)
+            .mapNotNull { rdn -> rdn.first?.value?.toString() }
+    }.getOrDefault(emptyList())
+}

--- a/app/src/main/java/com/webtoapp/core/webview/CustomCaTrustStore.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/CustomCaTrustStore.kt
@@ -68,6 +68,9 @@ object CustomCaTrustStore {
 
     fun hasAnchors(): Boolean = validator?.hasAnchors() == true
 
+    /** The imported anchor certificates (e.g. for the TLS-fingerprint bridge's upstream trust). */
+    fun getAnchorCertificates(): List<X509Certificate> = validator?.getAnchorCertificates() ?: emptyList()
+
     /** True iff [leaf] cryptographically validates against an imported anchor. Fail-closed. */
     fun isServerCertTrusted(leaf: X509Certificate): Boolean =
         validator?.isServerCertTrusted(leaf) == true
@@ -101,6 +104,8 @@ class CustomCaValidator(private val anchors: List<X509Certificate>) {
     private val trustManager: X509TrustManager? = buildTrustManager()
 
     fun hasAnchors(): Boolean = anchors.isNotEmpty()
+
+    fun getAnchorCertificates(): List<X509Certificate> = anchors.toList()
 
     fun isServerCertTrusted(leaf: X509Certificate): Boolean {
         if (anchors.isEmpty()) return false

--- a/app/src/main/java/com/webtoapp/core/webview/MitmCaKeyStore.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/MitmCaKeyStore.kt
@@ -1,0 +1,60 @@
+package com.webtoapp.core.webview
+
+import java.io.File
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * At-rest wrapping for the TLS-MITM CA private key. The key blob used to be written as raw
+ * PKCS#8; anyone with file access (rooted device, extracted backup) got a CA trusted by the
+ * app for ten years. The blob is now AES-256-GCM encrypted with a device-local random key
+ * stored next to it in a separate file — still app-private storage (the Android Keystore
+ * cannot sign arbitrary leaf certs at the required rate here), but no longer a
+ * single-file-ready-to-use CA key. Legacy plaintext files are read transparently and
+ * rewritten wrapped on next generation.
+ */
+internal object MitmCaKeyStore {
+
+    private const val MAGIC = "WTAMITM1"
+    private const val GCM_TAG_BITS = 128
+    private const val KEY_FILE_HEADER = "WTA-CAWRAP1\n"
+
+    /** Reads a wrapped key, falling back to legacy raw PKCS#8 blobs. */
+    fun readKey(keyFile: File): ByteArray {
+        val bytes = keyFile.readBytes()
+        if (bytes.size > KEY_FILE_HEADER.length && bytes.copyOfRange(0, KEY_FILE_HEADER.length).contentEquals(KEY_FILE_HEADER.toByteArray())) {
+            val payload = bytes.copyOfRange(KEY_FILE_HEADER.length, bytes.size)
+            require(payload.size > 12 + (GCM_TAG_BITS / 8)) { "wrapped CA key too short" }
+            val iv = payload.copyOfRange(0, 12)
+            val wrapped = payload.copyOfRange(12, payload.size)
+            val wrapKey = loadOrCreateWrapKey(File(keyFile.parentFile, "mitm_ca_keywrap.bin"))
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.DECRYPT_MODE, wrapKey, GCMParameterSpec(GCM_TAG_BITS, iv))
+            return cipher.doFinal(wrapped)
+        }
+        // Legacy plaintext PKCS#8 (or anything else): try raw DER first.
+        return bytes
+    }
+
+    fun writeKey(keyFile: File, pkcs8Key: ByteArray) {
+        val wrapKey = loadOrCreateWrapKey(File(keyFile.parentFile, "mitm_ca_keywrap.bin"))
+        val iv = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, wrapKey, GCMParameterSpec(GCM_TAG_BITS, iv))
+        val wrapped = cipher.doFinal(pkcs8Key)
+        keyFile.writeBytes(KEY_FILE_HEADER.toByteArray() + iv + wrapped)
+    }
+
+    private fun loadOrCreateWrapKey(wrapKeyFile: File): SecretKey {
+        if (wrapKeyFile.exists()) {
+            val raw = wrapKeyFile.readBytes()
+            if (raw.size == 32) return SecretKeySpec(raw, "AES")
+        }
+        val raw = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        wrapKeyFile.writeBytes(raw)
+        return SecretKeySpec(raw, "AES")
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
@@ -65,7 +65,10 @@ class NativeBridge(
     private val downloadLocationMode: com.webtoapp.data.model.DownloadLocationMode =
         com.webtoapp.data.model.DownloadLocationMode.SYSTEM_DOWNLOAD,
 
-    private val customDownloadDirUri: String = ""
+    private val customDownloadDirUri: String = "",
+
+    /** The app's configured origin (target URL / local base) for CORS-bypass caller checks. */
+    private val appOriginUrl: String = ""
 ) {
     companion object {
         const val JS_INTERFACE_NAME = "NativeBridge"
@@ -439,6 +442,19 @@ if (NativeBridge.isFullscreen()) {
             val scheme = runCatching { URI(url).scheme }.getOrNull()?.lowercase(Locale.ROOT)
             return scheme == "http" || scheme == "https"
         }
+
+        /**
+         * Whether [pageUrl] belongs to the app's configured origin ([appOriginUrl] — the
+         * target URL, or the local server base for packaged/server app types). Same host
+         * or a subdomain counts; anything else is a foreign page riding the WebView.
+         */
+        internal fun isSameSiteOrSubdomain(pageHost: String, originHost: String): Boolean {
+            if (originHost.isBlank() || pageHost.isBlank()) return false
+            val p = pageHost.trim('[', ']').lowercase(Locale.ROOT).trimEnd('.')
+            val o = originHost.trim('[', ']').lowercase(Locale.ROOT).trimEnd('.')
+            if (p == o) return true
+            return p.endsWith(".$o")
+        }
     }
 
     private val privateNetworkHttpClient: OkHttpClient by lazy {
@@ -456,6 +472,13 @@ if (NativeBridge.isFullscreen()) {
             )
             .retryOnConnectionFailure(true)
             .build()
+    }
+
+    private fun isAppOriginCallerPage(pageUrl: String): Boolean {
+        val origin = appOriginUrl.takeIf { it.isNotBlank() } ?: return false
+        val pageHost = runCatching { URI(pageUrl).host }.getOrNull() ?: return false
+        val originHost = runCatching { URI(origin).host }.getOrNull() ?: return false
+        return isSameSiteOrSubdomain(pageHost, originHost)
     }
 
     @JavascriptInterface
@@ -1256,6 +1279,31 @@ if (NativeBridge.isFullscreen()) {
                     AppLogger.w("NativeBridge", "Blocked CORS-bypass request to non-HTTP(S) URL: $url")
                     return privateNetworkBridgeError("URL_NOT_ALLOWED", "Only HTTP(S) URLs are allowed")
                 }
+                // The CORS-bypass bridge is a full cross-origin reader — gate it on the
+                // calling page. Local pages (packaged files, local server apps) may reach
+                // anything; the app's own remote origin may bypass CORS for internet APIs
+                // but must not probe the phone's local services; anything else (random
+                // iframes / navigations) is rejected outright.
+                val pageUrl = webViewProvider()?.url.orEmpty()
+                val pageIsLocal = isPrivateNetworkUrl(pageUrl) ||
+                    pageUrl.startsWith("file:") ||
+                    pageUrl.startsWith("content://") ||
+                    pageUrl.startsWith("about:blank")
+                val pageIsAppOrigin = isAppOriginCallerPage(pageUrl)
+                if (!pageIsLocal && !pageIsAppOrigin) {
+                    AppLogger.w("NativeBridge", "Blocked CORS-bypass request from non-app page: $pageUrl -> $url")
+                    return privateNetworkBridgeError(
+                        "CALLER_NOT_ALLOWED",
+                        "Only the app's own pages can use the CORS-bypass bridge"
+                    )
+                }
+                if (!pageIsLocal && isPrivateNetworkUrl(url)) {
+                    AppLogger.w("NativeBridge", "Blocked CORS-bypass request to local network from remote page: $pageUrl -> $url")
+                    return privateNetworkBridgeError(
+                        "URL_NOT_ALLOWED",
+                        "CORS-bypass requests to local network addresses require a local page"
+                    )
+                }
             } else if (!isPrivateNetworkUrl(url)) {
                 AppLogger.w("NativeBridge", "Blocked private-network bridge request to non-private URL: $url")
                 return privateNetworkBridgeError("URL_NOT_ALLOWED", "Only private network HTTP(S) URLs are allowed")
@@ -1781,14 +1829,16 @@ class PrivateNetworkNativeBridgeAdapter(
     context: Context,
     scope: CoroutineScope,
     webViewProvider: () -> WebView? = { null },
-    corsBypass: Boolean = false
+    corsBypass: Boolean = false,
+    appOriginUrl: String = ""
 ) {
     private val delegate = NativeBridge(
         context = context,
         scope = scope,
         webViewProvider = webViewProvider,
         capabilities = privateNetworkOnlyCapabilities(),
-        corsBypass = corsBypass
+        corsBypass = corsBypass,
+        appOriginUrl = appOriginUrl
     )
 
     @JavascriptInterface

--- a/app/src/main/java/com/webtoapp/core/webview/TlsMitmBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/TlsMitmBridge.kt
@@ -42,8 +42,45 @@ object TlsMitmBridge {
     @Volatile private var listenPort: Int = 0
     @Volatile private var caDir: File? = null
 
+    /** User-imported CA anchors additionally trusted when verifying upstream certificates. */
+    @Volatile private var customCaAnchors: List<java.security.cert.X509Certificate> = emptyList()
+
+    /**
+     * Android loopback is shared by every app on the device, so the proxy must not be an
+     * open relay: only hosts the WebView actually navigated/requested may be tunneled, and
+     * leaf certificates are only minted for tunnelable hosts. WebViewManager feeds this
+     * set from onPageStarted / shouldInterceptRequest.
+     */
+    private val allowedHosts: MutableSet<String> = java.util.concurrent.ConcurrentHashMap.newKeySet()
+
+    /**
+     * Host-allowlist enforcement. Always on for the WebView engine (whose requests are
+     * observable via shouldInterceptRequest); disabled by the Gecko engine, which has no
+     * per-request callback to feed the set with.
+     */
+    @Volatile private var hostAllowlistEnforcement: Boolean = true
+
+    fun setHostAllowlistEnforcement(enabled: Boolean) {
+        hostAllowlistEnforcement = enabled
+    }
+
+    fun allowHost(host: String?) {
+        val normalized = host?.trim()?.trim('[', ']')?.lowercase(Locale.ROOT) ?: return
+        if (normalized.isNotEmpty()) allowedHosts.add(normalized)
+    }
+
+    fun isHostAllowed(host: String?): Boolean {
+        if (!hostAllowlistEnforcement) return true
+        val normalized = host?.trim()?.trim('[', ']')?.lowercase(Locale.ROOT) ?: return false
+        return allowedHosts.contains(normalized)
+    }
+
     @Synchronized
-    fun start(config: Config, caDir: File): Int {
+    fun start(
+        config: Config,
+        caDir: File,
+        customCaAnchors: List<java.security.cert.X509Certificate> = emptyList()
+    ): Int {
         TlsMitmCaManager.init(caDir)
         if (!TlsMitmCaManager.isCaInitialized()) {
             AppLogger.e(TAG, "CA manager failed to init, aborting TLS MITM bridge")
@@ -51,9 +88,11 @@ object TlsMitmBridge {
         }
 
         if (running && currentConfig == config && listenPort > 0) {
+            this.customCaAnchors = customCaAnchors
             return listenPort
         }
         stopInternal()
+        this.customCaAnchors = customCaAnchors
 
         try {
             val socket = ServerSocket(0, 64, InetAddress.getByName("127.0.0.1"))
@@ -107,6 +146,9 @@ object TlsMitmBridge {
         acceptThread = null
         listenPort = 0
         currentConfig = null
+        customCaAnchors = emptyList()
+        allowedHosts.clear()
+        hostAllowlistEnforcement = true
     }
 
     private fun acceptLoop(socket: ServerSocket) {
@@ -191,6 +233,15 @@ object TlsMitmBridge {
         val host = hostPort.substring(0, sep).trim().trim('[', ']')
         val port = hostPort.substring(sep + 1).toIntOrNull() ?: 443
 
+        if (!isHostAllowed(host)) {
+            // Another app on the device probing the shared loopback interface: without
+            // this check the bridge relays for anyone and mints locally-trusted leaf
+            // certificates for arbitrary domains.
+            AppLogger.w(TAG, "CONNECT rejected (host not requested by the WebView): $host")
+            sendStatus(clientOut, 403, "Forbidden")
+            safeClose(client); return
+        }
+
         val config = currentConfig
         if (config == null) {
             sendStatus(clientOut, 502, "Bad Gateway")
@@ -218,7 +269,8 @@ object TlsMitmBridge {
                 template = config.template,
                 customCipherSuites = config.customCipherSuites,
                 upstreamSocks = config.upstreamSocks,
-                restrictAlpnTo = clientProtocol
+                restrictAlpnTo = clientProtocol,
+                customCaAnchors = customCaAnchors
             ).sslSocket
         } catch (e: Exception) {
             AppLogger.w(TAG, "Upstream TLS connect failed for $host:$port: ${e.message}")
@@ -292,6 +344,11 @@ object TlsMitmBridge {
             requestUri?.port != null && requestUri.port > 0 -> requestUri.port
             hostHeader?.substringAfter(':', "")?.toIntOrNull() != null -> hostHeader.substringAfter(':').toInt()
             else -> 80
+        }
+        if (!isHostAllowed(host)) {
+            AppLogger.w(TAG, "Forward rejected (host not requested by the WebView): $host")
+            sendStatus(clientOut, 403, "Forbidden")
+            safeClose(client); return
         }
         val rawPath = requestUri?.rawPath
         val path = if (rawPath.isNullOrEmpty()) "/" else rawPath

--- a/app/src/main/java/com/webtoapp/core/webview/TlsMitmCaManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/TlsMitmCaManager.kt
@@ -63,7 +63,7 @@ object TlsMitmCaManager {
             val certFile = File(caDir, "mitm_ca_cert.cer")
 
             if (certFile.exists() && keyFile.exists()) {
-                val keyBytes = keyFile.readBytes()
+                val keyBytes = MitmCaKeyStore.readKey(keyFile)
                 val certBytes = certFile.readBytes()
                 val key = KeyFactory.getInstance("RSA")
                     .generatePrivate(PKCS8EncodedKeySpec(keyBytes))
@@ -130,8 +130,10 @@ object TlsMitmCaManager {
         )
         val cert = JcaX509CertificateConverter().getCertificate(holder)
 
-        File(caDir, "mitm_ca_key.bks").writeBytes(pair.private.encoded)
         File(caDir, "mitm_ca_cert.cer").writeBytes(cert.encoded)
+        // The CA key is written wrapped (see MitmCaKeyStore): a raw PKCS#8 blob readable
+        // for ten years is the single worst-compromise artifact this feature persists.
+        MitmCaKeyStore.writeKey(File(caDir, "mitm_ca_key.bks"), pair.private.encoded)
 
         caKeyPair = pair
         caCert = cert
@@ -146,8 +148,12 @@ object TlsMitmCaManager {
     fun isSignedByLocalCa(cert: X509Certificate?): Boolean {
         if (cert == null || !initialized) return false
         val ca = caCert ?: return false
+        val caKey = caKeyPair?.public ?: return false
         return try {
-            cert.issuerX500Principal == ca.subjectX500Principal
+            // Issuer DN alone is forgeable (the CA subject is public in every shipped APK);
+            // require an actual signature verification against the local CA key. Fail-closed.
+            cert.issuerX500Principal == ca.subjectX500Principal &&
+                runCatching { cert.verify(caKey); true }.getOrDefault(false)
         } catch (_: Exception) {
             false
         }

--- a/app/src/main/java/com/webtoapp/core/webview/TlsUpstreamConnector.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/TlsUpstreamConnector.kt
@@ -5,10 +5,14 @@ import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
+import java.security.KeyStore
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 
 object TlsUpstreamConnector {
@@ -28,7 +32,8 @@ object TlsUpstreamConnector {
         template: TlsFingerprintTemplate,
         customCipherSuites: List<String> = emptyList(),
         upstreamSocks: LocalHttpToSocksBridge.Upstream? = null,
-        restrictAlpnTo: String? = null
+        restrictAlpnTo: String? = null,
+        customCaAnchors: List<X509Certificate> = emptyList()
     ): TlsResult {
         val rawSocket = if (upstreamSocks != null) {
             LocalHttpToSocksBridge.Socks5Connector.connect(
@@ -47,8 +52,12 @@ object TlsUpstreamConnector {
             }
         }
 
+        // The bridge only spoofs the ClientHello (cipher/ALPN ordering); the trust decision
+        // stays with the platform: system CAs plus any anchors the user imported via the
+        // editor's custom-CA panel (corporate proxies). An accept-all manager here would
+        // turn the fingerprint feature into silent full MITM exposure.
         val sslContext = SSLContext.getInstance("TLS")
-        sslContext.init(null, arrayOf<TrustManager>(AcceptAllTrustManager()), null)
+        sslContext.init(null, arrayOf<TrustManager>(buildUpstreamTrustManager(customCaAnchors)), null)
 
         val factory = FingerprintSslSocketFactory(
             sslContext.socketFactory,
@@ -70,6 +79,15 @@ object TlsUpstreamConnector {
         }
         sslSocket.startHandshake()
 
+        // SSLSocket handshakes validate the chain but never the hostname — verify that the
+        // upstream certificate actually covers the host we dialed before tunneling anything.
+        val peerCert = sslSocket.session.peerCertificates
+            .firstOrNull { it is X509Certificate } as? X509Certificate
+        if (peerCert == null || !CertificateHostnameMatcher.matches(host, peerCert)) {
+            try { sslSocket.close() } catch (_: Exception) {}
+            throw IOException("TLS fingerprint bridge: upstream certificate does not match host '$host'")
+        }
+
         // The raw socket's connect-phase SO_TIMEOUT must not survive into tunnel
         // mode: an idle SSE/WebSocket stream would otherwise be dropped after 60s.
         try { sslSocket.soTimeout = 0 } catch (_: Exception) {}
@@ -82,6 +100,53 @@ object TlsUpstreamConnector {
 
         AppLogger.d(TAG, "TLS upstream connected to $host:$port, template=${template.id}, alpn=$negotiatedProtocol")
         return TlsResult(sslSocket, negotiatedProtocol)
+    }
+
+    private fun buildUpstreamTrustManager(anchors: List<X509Certificate>): X509TrustManager {
+        val system = defaultTrustManager()
+        if (anchors.isEmpty()) return system
+        val custom = trustManagerForAnchors(anchors) ?: return system
+        return CompositeTrustManager(listOf(custom, system))
+    }
+
+    private fun defaultTrustManager(): X509TrustManager {
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(null as KeyStore?)
+        return tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+
+    private fun trustManagerForAnchors(anchors: List<X509Certificate>): X509TrustManager? =
+        runCatching {
+            val ks = KeyStore.getInstance(KeyStore.getDefaultType())
+            ks.load(null, null)
+            anchors.forEachIndexed { i, cert -> ks.setCertificateEntry("wta_upstream_anchor_$i", cert) }
+            val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+            tmf.init(ks)
+            tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+        }.getOrNull()
+
+    /** Tries each delegate in order; the first one that accepts the chain wins. */
+    private class CompositeTrustManager(private val delegates: List<X509TrustManager>) : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+            delegates.first().checkClientTrusted(chain, authType)
+        }
+
+        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+            if (chain == null) throw CertificateException("null chain")
+            var last: CertificateException? = null
+            for (tm in delegates) {
+                try {
+                    tm.checkServerTrusted(chain, authType)
+                    return
+                } catch (e: CertificateException) {
+                    last = e
+                }
+            }
+            throw last ?: CertificateException("no delegate accepted the chain")
+        }
+
+        override fun getAcceptedIssuers(): Array<X509Certificate> =
+            delegates.flatMap { it.acceptedIssuers.toList() }.toTypedArray()
     }
 
     private class FingerprintSslSocketFactory(
@@ -149,11 +214,5 @@ object TlsUpstreamConnector {
             configure(socket)
             return socket
         }
-    }
-
-    private class AcceptAllTrustManager : X509TrustManager {
-        override fun checkClientTrusted(chain: Array<out java.security.cert.X509Certificate>?, authType: String?) {}
-        override fun checkServerTrusted(chain: Array<out java.security.cert.X509Certificate>?, authType: String?) {}
-        override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> = emptyArray()
     }
 }

--- a/app/src/main/java/com/webtoapp/core/webview/TranslateBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/TranslateBridge.kt
@@ -77,23 +77,26 @@ class TranslateBridge(
                     results.addAll(translated)
                 }
 
+                // JSONArray.toString() is a valid JS array literal — pass it unquoted so no
+                // hand-rolled string escaping is involved. callbackId comes from page JS:
+                // quote it, or a crafted id ('x');payload();//) executes in whatever page is
+                // loaded by the time the async translation call completes.
                 val resultsJson = JSONArray(results).toString()
-                    .replace("\\", "\\\\")
-                    .replace("'", "\\'")
-                    .replace("\n", "\\n")
-                    .replace("\r", "\\r")
+                val quotedCallbackId = com.webtoapp.util.JsStrings.quote(callbackId)
 
                 withContext(Dispatchers.Main) {
                     webView.evaluateJavascript(
-                        "window._translateCallback('$callbackId', '$resultsJson');",
+                        "window._translateCallback($quotedCallbackId, $resultsJson);",
                         null
                     )
                 }
             } catch (e: Exception) {
                 AppLogger.e(TAG, "翻译执行失败", e)
+                val quotedCallbackId = com.webtoapp.util.JsStrings.quote(callbackId)
+                val quotedError = com.webtoapp.util.JsStrings.quote(e.message ?: "translation failed")
                 withContext(Dispatchers.Main) {
                     webView.evaluateJavascript(
-                        "window._translateCallback('$callbackId', null, '${e.message?.replace("'", "\\'")}');",
+                        "window._translateCallback($quotedCallbackId, null, $quotedError);",
                         null
                     )
                 }

--- a/app/src/main/java/com/webtoapp/core/webview/WebMediaPlaybackService.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebMediaPlaybackService.kt
@@ -97,15 +97,23 @@ class WebMediaPlaybackService : Service() {
         val notification = MediaSessionCore.getForegroundNotification(this)
             ?: buildFallbackNotification()
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-            )
-        } else {
-            @Suppress("DEPRECATION")
-            startForeground(NOTIFICATION_ID, notification)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        } catch (e: Exception) {
+            // This service is driven from media-session PendingIntents and WebView JS, which
+            // can race the app going to the background — an Android 12+ background-start
+            // rejection must degrade to "no foreground notification", not crash the app.
+            com.webtoapp.core.logging.AppLogger.w("WebMediaPlaybackService", "startForeground failed: ${e.message}")
+            stopSelf()
         }
     }
 

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1368,7 +1368,11 @@ class WebViewManager(
                     },
                     upstreamSocks = upstreamSocks
                 ),
-                caDir = context.filesDir
+                caDir = context.filesDir,
+                customCaAnchors = runCatching {
+                    CustomCaTrustStore.init(context)
+                    CustomCaTrustStore.getAnchorCertificates()
+                }.getOrDefault(emptyList())
             )
 
             if (mitmPort > 0) {
@@ -1659,10 +1663,27 @@ class WebViewManager(
                 }
             }
 
+            // Register the GM bridge only when userscripts can actually run: the interface
+            // object is exposed to every frame of every page, so an unconditional
+            // registration hands a cross-origin HTTP client to apps with zero userscripts.
+            // Global-fallback mode keeps the bridge registered because its module set is
+            // resolved dynamically per page load and a late addJavascriptInterface would
+            // not reach already-loaded pages.
+            val hasUserscriptModules = runCatching {
+                resolveActiveExtensionModules().any {
+                    it.sourceType == com.webtoapp.core.extension.ModuleSourceType.USERSCRIPT ||
+                        it.sourceType == com.webtoapp.core.extension.ModuleSourceType.GREASYFORK
+                } || embeddedModules.any { it.enabled && it.isUserscript() }
+            }.getOrDefault(false)
             gmBridge?.destroy()
-            val bridge = com.webtoapp.core.extension.GreasemonkeyBridge(context) { webView }
-            gmBridge = bridge
-            addJavascriptInterface(bridge, com.webtoapp.core.extension.GreasemonkeyBridge.JS_INTERFACE_NAME)
+            gmBridge = null
+            if (hasUserscriptModules || allowGlobalModuleFallback) {
+                val bridge = com.webtoapp.core.extension.GreasemonkeyBridge(context) { webView }
+                gmBridge = bridge
+                addJavascriptInterface(bridge, com.webtoapp.core.extension.GreasemonkeyBridge.JS_INTERFACE_NAME)
+            } else {
+                removeJavascriptInterface(com.webtoapp.core.extension.GreasemonkeyBridge.JS_INTERFACE_NAME)
+            }
 
             initChromeExtensionRuntimes(webView)
 
@@ -1864,6 +1885,13 @@ class WebViewManager(
                 request?.let {
                     val url = it.url?.toString() ?: ""
                     diagRequestCount++
+
+                    // Feed the TLS-MITM bridge's host allowlist: every request the WebView
+                    // issues passes through here before its network stack CONNECTs through
+                    // the bridge, so this is the authoritative "host actually requested" set.
+                    if (TlsMitmBridge.isRunning()) {
+                        TlsMitmBridge.allowHost(runCatching { android.net.Uri.parse(url).host }.getOrNull())
+                    }
 
                     if (com.webtoapp.core.extension.ExtensionResourceInterceptor.isChromeExtensionUrl(url)) {
                         return com.webtoapp.core.extension.ExtensionResourceInterceptor.intercept(context, url)
@@ -2076,6 +2104,9 @@ class WebViewManager(
             override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                 super.onPageStarted(view, url, favicon)
                 currentMainFrameUrl = url
+                if (TlsMitmBridge.isRunning()) {
+                    TlsMitmBridge.allowHost(runCatching { android.net.Uri.parse(url ?: "").host }.getOrNull())
+                }
                 extensionPanelInjected = false
                 view?.let {
                     userscriptInjectionState.remove(it)
@@ -3186,16 +3217,11 @@ class WebViewManager(
 
     private fun isMitmSslError(error: android.net.http.SslError?): Boolean {
         if (error == null) return false
-        val cert = extractServerCert(error)
-        if (cert != null) {
-            return TlsMitmCaManager.isSignedByLocalCa(cert)
-        }
-        return TlsMitmBridge.isRunning() && (
-            error.primaryError == android.net.http.SslError.SSL_UNTRUSTED ||
-            error.primaryError == android.net.http.SslError.SSL_EXPIRED ||
-            error.primaryError == android.net.http.SslError.SSL_NOTYETVALID ||
-            error.primaryError == android.net.http.SslError.SSL_IDMISMATCH
-        )
+        if (!TlsMitmBridge.isRunning()) return false
+        // Only a certificate that cryptographically chains to the local MITM CA counts.
+        // Never fall back to error-type matching: any other SSL error (an attacker's
+        // self-signed cert on a non-tunneled connection) must surface to the user.
+        return TlsMitmCaManager.isSignedByLocalCa(extractServerCert(error))
     }
 
     private fun extractServerCert(error: android.net.http.SslError?): java.security.cert.X509Certificate? {
@@ -5643,8 +5669,11 @@ class WebViewManager(
                     extensionFileManager.getCachedResource(name, url) ?: url
                 }
 
+                // The polyfill carries a random storage alias, not the raw module id: the
+                // bridge object is reachable from every frame, so raw ids would let any
+                // embedded content read/write another script's GM storage.
                 val polyfill = com.webtoapp.core.extension.GreasemonkeyBridge.generatePolyfillScript(
-                    scriptId = module.id,
+                    scriptId = gmBridge?.storageAliasFor(module.id) ?: module.id,
                     grants = module.gmGrants,
                     scriptInfo = scriptInfo,
                     resources = resolvedResources
@@ -5819,7 +5848,7 @@ class WebViewManager(
                 )
 
                 val polyfill = com.webtoapp.core.extension.GreasemonkeyBridge.generatePolyfillScript(
-                    scriptId = module.id,
+                    scriptId = gmBridge?.storageAliasFor(module.id) ?: module.id,
                     grants = module.gmGrants,
                     scriptInfo = scriptInfo,
                     resources = module.resources

--- a/app/src/main/java/com/webtoapp/core/wordpress/WordPressDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/wordpress/WordPressDependencyManager.kt
@@ -452,7 +452,10 @@ object WordPressDependencyManager {
 
         var entry = tarIn.nextEntry
         while (entry != null) {
-            val outFile = File(destDir, entry.name)
+            val outFile = com.webtoapp.util.SafeZip.safeChild(destDir, entry.name) ?: run {
+                entry = tarIn.nextEntry
+                continue
+            }
             if (entry.isDirectory) {
                 outFile.mkdirs()
             } else {
@@ -474,7 +477,11 @@ object WordPressDependencyManager {
         val zipInputStream = java.util.zip.ZipInputStream(zipFile.inputStream().buffered())
         var entry = zipInputStream.nextEntry
         while (entry != null) {
-            val outFile = File(destDir, entry.name)
+            val outFile = com.webtoapp.util.SafeZip.safeChild(destDir, entry.name) ?: run {
+                zipInputStream.closeEntry()
+                entry = zipInputStream.nextEntry
+                continue
+            }
             if (entry.isDirectory) {
                 outFile.mkdirs()
             } else {

--- a/app/src/main/java/com/webtoapp/core/wordpress/WordPressManager.kt
+++ b/app/src/main/java/com/webtoapp/core/wordpress/WordPressManager.kt
@@ -3,6 +3,7 @@ package com.webtoapp.core.wordpress
 import android.content.Context
 import android.net.Uri
 import com.webtoapp.core.logging.AppLogger
+import com.webtoapp.util.destroyForciblyCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -355,6 +356,7 @@ object WordPressManager {
     }
 
     suspend fun applyRuntimeConfig(
+        context: android.content.Context,
         phpBinary: String,
         projectDir: File,
         siteTitle: String,
@@ -396,12 +398,31 @@ object WordPressManager {
                 appendLine("if (function_exists('flush_rewrite_rules')) { flush_rewrite_rules(false); }")
             }
             script.writeText(phpScript)
-            val process = ProcessBuilder(phpBinary, script.absolutePath)
-                .directory(projectDir)
-                .redirectErrorStream(true)
-                .start()
+            // Route through HostProcessLauncher (W^X hosts degrade instead of throwing)
+            // with a hard timeout: a hung PHP CLI (bad plugin script) must not park the
+            // calling coroutine forever.
+            val launch = com.webtoapp.core.linux.HostProcessLauncher.start(
+                context,
+                listOf(phpBinary, script.absolutePath),
+                emptyMap(),
+                projectDir,
+                runtimeLabel = "WordPress"
+            )
+            val process = launch.process
+            if (process == null) {
+                script.delete()
+                AppLogger.w(TAG, "WordPress runtime config skipped: ${launch.error}")
+                return@withContext false
+            }
             val output = process.inputStream.bufferedReader().readText()
-            val exitCode = process.waitFor()
+            val finished = process.waitFor(60, java.util.concurrent.TimeUnit.SECONDS)
+            if (!finished) {
+                process.destroyForciblyCompat()
+                script.delete()
+                AppLogger.w(TAG, "WordPress runtime config timed out (60s), killed")
+                return@withContext false
+            }
+            val exitCode = process.exitValue()
             script.delete()
             if (exitCode == 0) {
                 AppLogger.i(TAG, "WordPress runtime config applied")
@@ -629,7 +650,9 @@ require_once ABSPATH . 'wp-settings.php';
 
                 val outFile = File(destDir, entry.name)
 
-                if (!outFile.canonicalPath.startsWith(destDir.canonicalPath)) {
+                // + File.separator: a bare prefix match lets a sibling directory
+                // (/data/destEvil pass when destDir is /data/dest) through.
+                if (!outFile.canonicalPath.startsWith(destDir.canonicalPath + File.separator)) {
                     AppLogger.w(TAG, "Skipping unsafe zip entry: ${entry.name}")
                     zipInputStream.closeEntry()
                     entry = zipInputStream.nextEntry

--- a/app/src/main/java/com/webtoapp/core/wordpress/WordPressPhpRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/wordpress/WordPressPhpRuntime.kt
@@ -170,6 +170,9 @@ class WordPressPhpRuntime(private val context: Context) {
             }
         } catch (e: Exception) {
             AppLogger.e(TAG, "启动 PHP 服务器失败", e)
+            // Release the port allocation and DNS-bridge refcount taken before the failure;
+            // this runtime instance dies with the failed start, so nobody else would.
+            runCatching { stopServer() }
             _serverState.value = ServerState.Error("启动失败: ${e.message}")
             -1
         }

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -42,6 +42,14 @@ enum class AppType {
             GO_APP,
             WORDPRESS
         )
+
+        /**
+         * Parse a persisted app-type string (e.g. [MultiWebSite.appType]) into an [AppType],
+         * null for unknown values. The multi-web site type is stored as a raw string, so
+         * gating helpers need this bridge to reuse [requiresProcessExec].
+         */
+        fun fromPersistedName(name: String?): AppType? =
+            entries.firstOrNull { it.name.equals(name, ignoreCase = true) }
     }
 }
 
@@ -876,7 +884,18 @@ data class MultiWebConfig(
     val refreshInterval: Int = 30,
     val showSiteIcons: Boolean = true,
     val projectId: String = ""
-)
+) {
+    /**
+     * True when any enabled site sources from a server-runtime app (Node/PHP/Python/Go/
+     * WordPress). Such a multi-web app must keep `targetSdk <= 28` like a standalone
+     * server app: at runtime the site is routed into the matching `*ShellMode`, which
+     * fork+execs the bundled runtime binaries — blocked by W^X from targetSdk 29 on.
+     */
+    val anySiteRequiresProcessExec: Boolean
+        get() = sites.any { site ->
+            site.enabled && (AppType.fromPersistedName(site.appType)?.requiresProcessExec == true)
+        }
+}
 
 data class MultiWebSite(
     val id: String = "",

--- a/app/src/main/java/com/webtoapp/ui/gallery/GalleryPlayerScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/gallery/GalleryPlayerScreen.kt
@@ -29,8 +29,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -38,6 +40,8 @@ import coil.request.ImageRequest
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.*
 import com.webtoapp.ui.shared.AspectRatioSurface
+import com.webtoapp.ui.shared.ZoomableState
+import com.webtoapp.ui.shared.zoomable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.io.File
@@ -456,17 +460,45 @@ fun GalleryImageViewer(
 ) {
     val context = LocalContext.current
 
-    Box(
+    BoxWithConstraints(
         modifier = modifier,
         contentAlignment = Alignment.Center
     ) {
+        val density = LocalDensity.current
+        // Same pinch/pan/double-tap behavior as the exported shell viewer (#801): fresh
+        // zoom state per item, content size from the loaded painter.
+        val zoom = remember(item.path) { ZoomableState() }
+        var intrinsicSizePx by remember(item.path) { mutableStateOf<Size?>(null) }
+        val viewportPx = with(density) { Size(maxWidth.toPx(), maxHeight.toPx()) }
+
+        LaunchedEffect(viewportPx, intrinsicSizePx) {
+            intrinsicSizePx?.let { size ->
+                zoom.setLayout(viewportPx, size)
+            }
+        }
+
         AsyncImage(
             model = ImageRequest.Builder(context)
                 .data(File(item.path))
                 .crossfade(true)
                 .build(),
             contentDescription = item.name,
-            modifier = Modifier.fillMaxSize(),
+            onState = { state ->
+                val painterSize = (state as? coil.compose.AsyncImagePainter.State.Success)
+                    ?.painter?.intrinsicSize
+                if (painterSize != null && painterSize.width > 0f && painterSize.height > 0f) {
+                    // intrinsicSize is already in pixels — no density conversion.
+                    intrinsicSizePx = painterSize
+                }
+            },
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(item.path) {
+                    detectTapGestures(
+                        onDoubleTap = { tap -> zoom.toggleZoom(tap) }
+                    )
+                }
+                .zoomable(zoom),
             contentScale = ContentScale.Fit
         )
     }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateMultiWebAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateMultiWebAppScreen.kt
@@ -298,7 +298,13 @@ private fun ExistingAppPicker(
     onAddSelected: () -> Unit
 ) {
     val accentColor = MaterialTheme.colorScheme.onSurface
-    val eligibleApps = existingApps.filter { it.appType != com.webtoapp.data.model.AppType.MULTI_WEB }
+    // Nested multi-web and server-runtime apps (Node/PHP/Python/Go/WordPress) cannot be
+    // embedded as site sources: their runtimes are not packaged into a multi-web APK, so
+    // such sites would render a broken shell mode in the export. The build degrades
+    // legacy configs to URL sites; the picker hides them so new ones are never created.
+    val eligibleApps = existingApps.filter {
+        it.appType != com.webtoapp.data.model.AppType.MULTI_WEB && !it.appType.requiresProcessExec
+    }
     val availableTypes = remember(eligibleApps) {
         eligibleApps.map { it.appType.name }.distinct()
     }
@@ -535,7 +541,7 @@ private fun getFilteredAppIds(
     filterCategoryId: Long?
 ): Set<Long> {
     return existingApps
-        .filter { it.appType != com.webtoapp.data.model.AppType.MULTI_WEB }
+        .filter { it.appType != com.webtoapp.data.model.AppType.MULTI_WEB && !it.appType.requiresProcessExec }
         .filter { app ->
             val typeMatch = filterType == null || app.appType.name == filterType
             val categoryMatch = when {

--- a/app/src/main/java/com/webtoapp/ui/screens/create/runtime/PhpProjectSourceLoader.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/create/runtime/PhpProjectSourceLoader.kt
@@ -37,9 +37,13 @@ class PhpProjectSourceLoader {
                             !name.startsWith("__MACOSX/") &&
                             !name.substringAfterLast("/").startsWith("._")
                         ) {
-                            val outFile = File(tempDir, name)
-                            outFile.parentFile?.mkdirs()
-                            outFile.outputStream().use { output -> zipStream.copyTo(output) }
+                            // User-picked zip: entries are untrusted — a `../` name must not
+                            // write outside the temp dir.
+                            val outFile = com.webtoapp.util.SafeZip.safeChild(tempDir, name)
+                            if (outFile != null) {
+                                outFile.parentFile?.mkdirs()
+                                outFile.outputStream().use { output -> zipStream.copyTo(output) }
+                            }
                         }
                         zipStream.closeEntry()
                         entry = zipStream.nextEntry

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -534,13 +534,18 @@ class ShellActivity : AppCompatActivity() {
                         } catch (e: Exception) {
                             com.webtoapp.data.model.DownloadLocationMode.SYSTEM_DOWNLOAD
                         }
-                        val downloadBridge = com.webtoapp.core.webview.DownloadBridge(
-                            this@ShellActivity,
-                            lifecycleScope,
-                            downloadLocationMode,
-                            config.webViewConfig.customDownloadDirUri
-                        )
-                        wv.addJavascriptInterface(downloadBridge, com.webtoapp.core.webview.DownloadBridge.JS_INTERFACE_NAME)
+                        // Gate the JS-side download surface on the same flag that gates the
+                        // injected script: an always-registered bridge would let any page
+                        // (or embedded iframe) drop arbitrary content into public storage.
+                        if (config.webViewConfig.downloadEnabled) {
+                            val downloadBridge = com.webtoapp.core.webview.DownloadBridge(
+                                this@ShellActivity,
+                                lifecycleScope,
+                                downloadLocationMode,
+                                config.webViewConfig.customDownloadDirUri
+                            )
+                            wv.addJavascriptInterface(downloadBridge, com.webtoapp.core.webview.DownloadBridge.JS_INTERFACE_NAME)
+                        }
 
                         if (config.webViewConfig.enablePrintBridge) {
                             val printBridge = com.webtoapp.core.webview.PrintBridge(
@@ -611,7 +616,8 @@ class ShellActivity : AppCompatActivity() {
                                 capabilities = capabilities,
                                 corsBypass = config.webViewConfig.enableCorsBypass,
                                 downloadLocationMode = downloadLocationMode,
-                                customDownloadDirUri = config.webViewConfig.customDownloadDirUri
+                                customDownloadDirUri = config.webViewConfig.customDownloadDirUri,
+                                appOriginUrl = config.targetUrl
                             )
                             wv.addJavascriptInterface(nativeBridge, com.webtoapp.core.webview.NativeBridge.JS_INTERFACE_NAME)
                         } else if (config.webViewConfig.enablePrivateNetworkBridge || config.webViewConfig.enableCorsBypass) {
@@ -619,7 +625,8 @@ class ShellActivity : AppCompatActivity() {
                                 context = this@ShellActivity,
                                 scope = lifecycleScope,
                                 webViewProvider = { wv },
-                                corsBypass = config.webViewConfig.enableCorsBypass
+                                corsBypass = config.webViewConfig.enableCorsBypass,
+                                appOriginUrl = config.targetUrl
                             )
                             wv.addJavascriptInterface(privateNetworkBridge, com.webtoapp.core.webview.NativeBridge.JS_INTERFACE_NAME)
                         } else {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellServerModes.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellServerModes.kt
@@ -104,6 +104,7 @@ fun WordPressShellMode(
                     }
                     phase = "configuring"
                     com.webtoapp.core.wordpress.WordPressManager.applyRuntimeConfig(
+                        context = context,
                         phpBinary = phpRuntime.getPhpBinaryPath(),
                         projectDir = wpDir,
                         siteTitle = config.wordpressConfig.siteTitle,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellUtils.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellUtils.kt
@@ -97,7 +97,17 @@ internal fun buildPackagedHtmlFileSchemeEntryUrl(entryFile: String): String {
 }
 
 internal fun validateDeepLinkUrl(url: String, allowedHosts: List<String>, targetUrl: String): String {
-    if (allowedHosts.isEmpty()) return url
+    // No explicit allowlist configured: default to the app's own target host so an
+    // external app/link cannot steer this WebView to an arbitrary site. A target with
+    // no parsable host (local-content apps) keeps the previous all-allowed behavior.
+    val effectiveHosts = if (allowedHosts.isEmpty()) {
+        runCatching { java.net.URL(targetUrl).host?.lowercase() }.getOrNull()
+            ?.let { listOf(it) }
+            ?: emptyList()
+    } else {
+        allowedHosts
+    }
+    if (effectiveHosts.isEmpty()) return url
 
     val urlHost = try {
         java.net.URL(url).host?.lowercase()
@@ -116,7 +126,7 @@ internal fun validateDeepLinkUrl(url: String, allowedHosts: List<String>, target
     } catch (e: Exception) { null }
 
     val allAllowed = buildSet {
-        addAll(allowedHosts.map { it.lowercase() })
+        addAll(effectiveHosts.map { it.lowercase() })
         configHost?.let { add(it) }
     }
 

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -1719,6 +1719,7 @@ fun WebViewScreen(
                 siteLanguage = app.wordpressConfig?.siteLanguage?.takeIf { it.isNotBlank() } ?: "en_US"
             )
             WordPressManager.applyRuntimeConfig(
+                context = context,
                 phpBinary = phpRuntime.getPhpBinaryPath(),
                 projectDir = wpDir,
                 siteTitle = app.wordpressConfig?.siteTitle?.takeIf { it.isNotBlank() } ?: "My Site",
@@ -3288,7 +3289,8 @@ fun WebViewScreen(
                                                 capabilities = effectiveWebApp.webViewConfig.nativeBridgeCapabilities,
                                                 corsBypass = effectiveWebApp.webViewConfig.enableCorsBypass,
                                                 downloadLocationMode = effectiveWebApp.webViewConfig.downloadLocationMode,
-                                                customDownloadDirUri = effectiveWebApp.webViewConfig.customDownloadDirUri
+                                                customDownloadDirUri = effectiveWebApp.webViewConfig.customDownloadDirUri,
+                                                appOriginUrl = effectiveWebApp.url
                                             )
                                             addJavascriptInterface(
                                                 nb,
@@ -3299,7 +3301,8 @@ fun WebViewScreen(
                                                 context = context,
                                                 scope = scope,
                                                 webViewProvider = { this },
-                                                corsBypass = effectiveWebApp.webViewConfig.enableCorsBypass
+                                                corsBypass = effectiveWebApp.webViewConfig.enableCorsBypass,
+                                                appOriginUrl = effectiveWebApp.url
                                             )
                                             addJavascriptInterface(
                                                 privateNetworkBridge,

--- a/app/src/main/java/com/webtoapp/util/DownloadNotificationManager.kt
+++ b/app/src/main/java/com/webtoapp/util/DownloadNotificationManager.kt
@@ -67,17 +67,13 @@ class DownloadNotificationManager(private val context: Context) {
     }
 
     private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_LOW
-            ).apply {
-                description = Strings.notifDownloadChannelDesc
-                setShowBadge(false)
-            }
-            notificationManager.createNotificationChannel(channel)
-        }
+        SafeNotificationChannels.ensure(
+            context = context,
+            id = CHANNEL_ID,
+            name = CHANNEL_NAME,
+            importance = NotificationManager.IMPORTANCE_LOW,
+            description = Strings.notifDownloadChannelDesc
+        ) { setShowBadge(false) }
     }
 
     private fun registerDownloadReceiver() {

--- a/app/src/main/java/com/webtoapp/util/JsStrings.kt
+++ b/app/src/main/java/com/webtoapp/util/JsStrings.kt
@@ -1,0 +1,36 @@
+package com.webtoapp.util
+
+/**
+ * JS string-literal escaping without org.json — JSONObject.quote is an Android stub that
+ * throws "not mocked" under plain-JVM unit tests (Robolectric does not mock it either),
+ * and these escapes sit on hot paths that must stay unit-testable.
+ */
+object JsStrings {
+
+    /** Escape [s] for embedding inside a single- or double-quoted JS string (no quotes added). */
+    fun escape(s: String?): String {
+        if (s.isNullOrEmpty()) return ""
+        val sb = StringBuilder(s.length + 8)
+        for (ch in s) {
+            when (ch) {
+                '"', '\\', '\'' -> sb.append('\\').append(ch)
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                else -> {
+                    val code = ch.code
+                    when {
+                        code == 8 -> sb.append("\\b")   // backspace
+                        code == 12 -> sb.append("\\f")  // form feed
+                        code < 32 -> sb.append("\\u").append(String.format("%04x", code))
+                        else -> sb.append(ch)
+                    }
+                }
+            }
+        }
+        return sb.toString()
+    }
+
+    /** [escape] wrapped in double quotes — a complete JS string literal. */
+    fun quote(s: String?): String = "\"" + escape(s) + "\""
+}

--- a/app/src/main/java/com/webtoapp/util/MediaSaver.kt
+++ b/app/src/main/java/com/webtoapp/util/MediaSaver.kt
@@ -81,6 +81,15 @@ object MediaSaver {
         progressCallback: ProgressCallback? = null
     ): SaveResult = withContext(Dispatchers.IO) {
         try {
+            // Remote media only: a caller-supplied file:// / content:// URL would copy
+            // app-private files into public media storage (readable by every app with
+            // media permissions). The JS bridges and long-press handler only deal in
+            // web resources, so this guard changes nothing for them.
+            val scheme = runCatching { URL(url).protocol?.lowercase() }.getOrNull()
+            if (scheme != "http" && scheme != "https") {
+                return@withContext SaveResult.Error("Only HTTP(S) URLs can be saved to the gallery")
+            }
+
             val connection = URL(url).openConnection()
             connection.connectTimeout = 30000
             connection.readTimeout = 30000

--- a/app/src/main/java/com/webtoapp/util/SafeZip.kt
+++ b/app/src/main/java/com/webtoapp/util/SafeZip.kt
@@ -1,0 +1,43 @@
+package com.webtoapp.util
+
+import com.webtoapp.core.logging.AppLogger
+import java.io.File
+
+/**
+ * Shared Zip-Slip guard for archive extraction. Every place that unpacks a downloaded or
+ * user-picked archive must resolve entry names through [safeChild] — raw
+ * `File(destDir, entry.name)` lets a crafted `../../x` entry write outside the intended
+ * directory (mirrors the lexical + canonical rules of DataBackupManager.resolveSafeChild).
+ */
+object SafeZip {
+
+    private const val TAG = "SafeZip"
+
+    /**
+     * Resolve [entryName] under [baseDir], null when the entry tries to escape it.
+     * Absolute paths and `..` segments are rejected lexically; the result is additionally
+     * verified against the canonical base so symlinked/suffixed variants fail closed.
+     */
+    fun safeChild(baseDir: File, entryName: String): File? {
+        if (entryName.isBlank()) return null
+        val normalized = entryName.replace('\\', '/')
+        if (normalized.startsWith("/") || normalized.split('/').any { it == ".." }) {
+            AppLogger.w(TAG, "Skip unsafe archive entry: $entryName")
+            return null
+        }
+        val target = File(baseDir, normalized)
+        val baseCanonical = baseDir.canonicalFile
+        val targetCanonical = target.canonicalFile
+        // startsWith(base + separator) — a bare prefix match would allow sibling dirs
+        // (/data/baseEvil when base is /data/base) to pass.
+        return if (targetCanonical.path.startsWith(baseCanonical.path + File.separator)) {
+            targetCanonical
+        } else {
+            AppLogger.w(TAG, "Skip unsafe archive entry: $entryName")
+            null
+        }
+    }
+
+    /** `unTar`-style mode helper: entry mode's owner-exec bit. */
+    fun hasOwnerExecBit(mode: Long): Boolean = (mode and 0b001_000_000L) != 0L
+}

--- a/app/src/main/java/com/webtoapp/util/SvgIconMapper.kt
+++ b/app/src/main/java/com/webtoapp/util/SvgIconMapper.kt
@@ -114,41 +114,21 @@ object SvgIconMapper {
         "desktop_windows"     -> Icons.Outlined.DesktopWindows
         "visibility"          -> Icons.Outlined.Visibility
         "attachment", "📎"    -> Icons.Outlined.AttachFile
-        "pause", "⏸️"         -> Icons.Outlined.Pause
-        "thinking", "🤔"     -> Icons.Outlined.Psychology
-        "check", "✅"         -> Icons.Outlined.Check
-        "error", "❌"         -> Icons.Outlined.Error
+        "⏸️" -> Icons.Outlined.Pause
+        "❌" -> Icons.Outlined.Error
         "add_circle", "➕"   -> Icons.Outlined.AddCircle
-        "file", "📄"          -> Icons.Outlined.InsertDriveFile
-        "folder", "📁"        -> Icons.Outlined.Folder
-        "book", "📚"          -> Icons.Outlined.MenuBook
-        "help", "❓"           -> Icons.Outlined.HelpOutline
-        "warning", "⚠️"      -> Icons.Outlined.Warning
-        "heart", "❤️"         -> Icons.Outlined.Favorite
+        "📄" -> Icons.Outlined.InsertDriveFile
+        "📚" -> Icons.Outlined.MenuBook
         "home", "🏠"          -> Icons.Outlined.Home
-        "camera", "📷", "📸" -> Icons.Outlined.CameraAlt
-        "movie", "🎬"         -> Icons.Outlined.Movie
-        "lightbulb", "💡"    -> Icons.Outlined.Lightbulb
+        "📸" -> Icons.Outlined.CameraAlt
         "fast_forward", "⏩" -> Icons.Outlined.FastForward
-        "shield", "🛡️"      -> Icons.Outlined.Shield
-        "target", "🎯"       -> Icons.Outlined.GpsFixed
-        "gaming", "🎮"       -> Icons.Outlined.SportsEsports
         "phone_android", "📱" -> Icons.Outlined.PhoneAndroid
         "computer", "💻"     -> Icons.Outlined.Computer
-        "star", "⭐", "🌟"  -> Icons.Outlined.Star
-        "fire", "🔥"          -> Icons.Outlined.Whatshot
-        "diamond", "💎"      -> Icons.Outlined.Diamond
-        "gift", "🎁"          -> Icons.Outlined.CardGiftcard
+        "🌟" -> Icons.Outlined.Star
         "trophy", "🏆"       -> Icons.Outlined.EmojiEvents
         "festival", "🎪"    -> Icons.Outlined.Celebration
-        "mouse", "🖱️"        -> Icons.Outlined.Mouse
         "list", "📜"          -> Icons.Outlined.List
-        "settings", "⚙️"    -> Icons.Outlined.Settings
-        "html", "🌐"          -> Icons.Outlined.Language
-        "golang", "🔷"       -> Icons.Outlined.Code
-        "python", "🐍"       -> Icons.Outlined.Code
-        "clipboard", "📋"    -> Icons.Outlined.Assignment
-        "edit_note", "📝"    -> Icons.Outlined.EditNote
+        "⚙️" -> Icons.Outlined.Settings
         "build", "🩹"        -> Icons.Outlined.Build
 
         "tv", "📺"            -> Icons.Outlined.Tv
@@ -167,10 +147,6 @@ object SvgIconMapper {
         "translate"           -> Icons.Outlined.Translate
         "picture_in_picture"  -> Icons.Outlined.PictureInPicture
         "repeat", "🔁"       -> Icons.Outlined.Repeat
-        "block"               -> Icons.Outlined.Block
-        "radio_button"        -> Icons.Outlined.RadioButtonChecked
-        "bolt"                -> Icons.Outlined.Bolt
-        "package"             -> Icons.Outlined.Inventory2
 
         else                  -> Icons.Outlined.HelpOutline
     }

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuildCacheTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuildCacheTest.kt
@@ -19,6 +19,13 @@ class ApkBuildCacheTest {
         assertThat(cache.isContentReplaceableEntry("assets/html/index.html")).isTrue()
         assertThat(cache.isContentReplaceableEntry("assets/nodejs_app/server.js")).isTrue()
         assertThat(cache.isContentReplaceableEntry("assets/splash_media.png")).isTrue()
+        // Stale-content hazards: these are written conditionally at build time, so a cached
+        // copy must be dropped even when the new build does not rewrite them (removed CA,
+        // disabled dark status-bar image, cleared announcement icon...).
+        assertThat(cache.isContentReplaceableEntry("assets/wta_custom_ca/1.cer")).isTrue()
+        assertThat(cache.isContentReplaceableEntry("assets/statusbar_background_dark.png")).isTrue()
+        assertThat(cache.isContentReplaceableEntry("assets/announcement_icon.png")).isTrue()
+        assertThat(cache.isContentReplaceableEntry("assets/python/arm64-v8a/python3")).isTrue()
         assertThat(cache.isContentReplaceableEntry("AndroidManifest.xml")).isFalse()
         assertThat(cache.isContentReplaceableEntry("resources.arsc")).isFalse()
         assertThat(cache.isContentReplaceableEntry("lib/arm64-v8a/libnode.so")).isFalse()

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebSiteShellMappingTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/MultiWebSiteShellMappingTest.kt
@@ -46,6 +46,21 @@ class MultiWebSiteShellMappingTest {
     }
 
     @Test
+    fun `server runtime site sources degrade to null instead of a broken embed`() {
+        // Node/PHP/Python/Go/WordPress sources cannot be packaged inside a multi-web APK
+        // (no interpreter, no project assets): the resolver must refuse them so the site
+        // falls back to a plain URL entry, exactly like nested multi-web sources.
+        val serverSource = WebApp(id = 21, name = "php-src", url = "http://localhost:8080", appType = AppType.PHP_APP)
+        assertThat(resolveMultiWebSiteSource(serverSource, parentAppId = 1, siteName = "s")).isNull()
+
+        val nodeSource = WebApp(id = 22, name = "node-src", url = "http://localhost:3000", appType = AppType.NODEJS_APP)
+        assertThat(resolveMultiWebSiteSource(nodeSource, parentAppId = 1, siteName = "s")).isNull()
+
+        val webSource = WebApp(id = 23, name = "web-src", url = "https://example.com", appType = AppType.WEB)
+        assertThat(resolveMultiWebSiteSource(webSource, parentAppId = 1, siteName = "s")).isEqualTo(webSource)
+    }
+
+    @Test
     fun `export maps gallery site items to the site asset prefix`() {
         val dir = File(context.cacheDir, "mwmap-${System.nanoTime()}").also { it.mkdirs() }
         try {

--- a/app/src/test/java/com/webtoapp/core/extension/ChromeHostPermissionsTest.kt
+++ b/app/src/test/java/com/webtoapp/core/extension/ChromeHostPermissionsTest.kt
@@ -1,0 +1,65 @@
+package com.webtoapp.core.extension
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ChromeHostPermissionsTest {
+
+    @Test
+    fun `all urls pattern matches everything`() {
+        assertThat(ChromeHostPermissions.matches("<all_urls>", "https://any.example.com/path")).isTrue()
+        assertThat(ChromeHostPermissions.matches("<all_urls>", "http://127.0.0.1:8080/x")).isTrue()
+    }
+
+    @Test
+    fun `wildcard host and path match any host under the pattern`() {
+        assertThat(ChromeHostPermissions.matches("https://*/*", "https://example.com/")).isTrue()
+        assertThat(ChromeHostPermissions.matches("https://*.example.com/*", "https://a.example.com/x")).isTrue()
+        assertThat(ChromeHostPermissions.matches("https://*.example.com/*", "https://example.com/x")).isTrue()
+        // Only one level of subdomain for the explicit non-wildcard prefix is NOT how
+        // Chrome treats `*.example.com` for host permissions (it includes the bare domain
+        // and any depth), but deep subdomains must match too.
+        assertThat(ChromeHostPermissions.matches("https://*.example.com/*", "https://a.b.example.com/x")).isTrue()
+    }
+
+    @Test
+    fun `non-matching hosts schemes and paths are rejected`() {
+        assertThat(ChromeHostPermissions.matches("https://*.example.com/*", "https://evil.com/")).isFalse()
+        assertThat(ChromeHostPermissions.matches("https://example.com/*", "https://other.com/")).isFalse()
+        assertThat(ChromeHostPermissions.matches("https://example.com/*", "http://example.com/")).isFalse()
+        assertThat(ChromeHostPermissions.matches("https://example.com/exact/*", "https://example.com/other/x")).isFalse()
+    }
+
+    @Test
+    fun `star scheme matches both http and https`() {
+        assertThat(ChromeHostPermissions.matches("*://example.com/*", "http://example.com/")).isTrue()
+        assertThat(ChromeHostPermissions.matches("*://example.com/*", "https://example.com/")).isTrue()
+    }
+
+    @Test
+    fun `declared patterns read host permissions and url entries in permissions`() {
+        val manifest = """
+            {
+              "permissions": ["storage", "https://api.example.com/*"],
+              "host_permissions": ["*://*.service.io/*", "https://strict.site/allow/*"]
+            }
+        """.trimIndent()
+        val patterns = ChromeHostPermissions.declaredPatterns(manifest)
+        assertThat(patterns).containsExactly(
+            "https://api.example.com/*",
+            "*://*.service.io/*",
+            "https://strict.site/allow/*"
+        )
+        // API-only strings (no scheme, no <all_urls>) are not host patterns.
+        assertThat(patterns).doesNotContain("storage")
+    }
+
+    @Test
+    fun `declared patterns tolerate broken manifests`() {
+        assertThat(ChromeHostPermissions.declaredPatterns("not json")).isEmpty()
+        assertThat(ChromeHostPermissions.declaredPatterns("{}")).isEmpty()
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/webview/CertificateHostnameMatcherTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/CertificateHostnameMatcherTest.kt
@@ -1,0 +1,92 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.GeneralName
+import org.bouncycastle.asn1.x509.GeneralNames
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.Test
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.cert.X509Certificate
+import java.util.Date
+
+class CertificateHostnameMatcherTest {
+
+    @Test
+    fun `exact dns san matches`() {
+        val cert = newCert(sans = listOf("api.example.com"))
+        assertThat(CertificateHostnameMatcher.matches("api.example.com", cert)).isTrue()
+        assertThat(CertificateHostnameMatcher.matches("other.example.com", cert)).isFalse()
+    }
+
+    @Test
+    fun `wildcard san matches exactly one label`() {
+        val cert = newCert(sans = listOf("*.example.com"))
+        assertThat(CertificateHostnameMatcher.matches("a.example.com", cert)).isTrue()
+        assertThat(CertificateHostnameMatcher.matches("example.com", cert)).isFalse()
+        assertThat(CertificateHostnameMatcher.matches("a.b.example.com", cert)).isFalse()
+    }
+
+    @Test
+    fun `dns san suppresses cn fallback`() {
+        val cert = newCert(cn = "evil.example", sans = listOf("good.example"))
+        assertThat(CertificateHostnameMatcher.matches("good.example", cert)).isTrue()
+        assertThat(CertificateHostnameMatcher.matches("evil.example", cert)).isFalse()
+    }
+
+    @Test
+    fun `cn fallback only when no dns san present`() {
+        val cert = newCert(cn = "legacy.example")
+        assertThat(CertificateHostnameMatcher.matches("legacy.example", cert)).isTrue()
+        assertThat(CertificateHostnameMatcher.matches("other.example", cert)).isFalse()
+    }
+
+    @Test
+    fun `ipv4 address matches only via ip san`() {
+        val cert = newCert(ipSans = listOf("203.0.113.7"))
+        assertThat(CertificateHostnameMatcher.matches("203.0.113.7", cert)).isTrue()
+        assertThat(CertificateHostnameMatcher.matches("203.0.113.8", cert)).isFalse()
+    }
+
+    @Test
+    fun `case and trailing dot are normalized`() {
+        val cert = newCert(sans = listOf("API.Example.COM"))
+        assertThat(CertificateHostnameMatcher.matches("api.example.com.", cert)).isTrue()
+    }
+
+    private fun newCert(cn: String = "localhost", sans: List<String> = emptyList(), ipSans: List<String> = emptyList()): X509Certificate {
+        val keyPair: KeyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+        val issuer = X500Name("CN=$cn")
+        val builder = JcaX509v3CertificateBuilder(
+            issuer,
+            BigInteger.valueOf(System.currentTimeMillis()),
+            Date(System.currentTimeMillis() - 60_000L),
+            Date(System.currentTimeMillis() + 3_600_000L),
+            issuer,
+            keyPair.public
+        )
+        val generalNames = mutableListOf<GeneralName>()
+        sans.forEach { generalNames += GeneralName(GeneralName.dNSName, it) }
+        ipSans.forEach {
+            generalNames += GeneralName(
+                GeneralName.iPAddress,
+                org.bouncycastle.asn1.DEROctetString(java.net.InetAddress.getByName(it).address)
+            )
+        }
+        if (generalNames.isNotEmpty()) {
+            builder.addExtension(
+                Extension.subjectAlternativeName,
+                false,
+                GeneralNames(generalNames.toTypedArray())
+            )
+        }
+        return JcaX509CertificateConverter().getCertificate(
+            builder.build(JcaContentSignerBuilder("SHA256withRSA").build(keyPair.private))
+        )
+    }
+}

--- a/modules/README.md
+++ b/modules/README.md
@@ -236,10 +236,10 @@ The publish workflow:
 3. Asks `GET /repos/{owner}/{repo}/commits/{sha}/pulls` whether that
    commit was part of a merged PR. If yes → records PR number, URL,
    `merged_at`, and the PR author's GitHub login + avatar.
-4. Otherwise treats it as a maintainer direct-push and records the
-   commit author — but only when the GitHub login matches the
-   `MAINTAINERS` allow-list in the workflow. Anything else is left out
-   on purpose.
+4. Otherwise treats it as a direct push and records the commit author's
+   resolved GitHub login. Every human author is recorded (modules only
+   reach `main` through review or a maintainer push); only bot
+   identities are excluded.
 5. For every module, walks its full commit history, resolves each
    distinct author's GitHub login via the commit API, and records
    everyone except the original submitter (and bots) under
@@ -446,8 +446,8 @@ App 打开市场时同时拉 `registry.json` 和 `submissions.json`，**只渲�
 3. 调用 `GET /repos/{owner}/{repo}/commits/{sha}/pulls` 看这个提交是不是
    某个已合并 PR 的一部分。是的话记录 PR 编号、URL、`merged_at`、PR 作者
    的 GitHub login + 头像。
-4. 否则当作维护者直推处理，记录提交作者——但**只有当 GitHub login 在
-   workflow 的 `MAINTAINERS` 白名单里**才会被记录。其他直推故意不进。
+4. 否则当作直推处理，记录提交作者解析出的 GitHub login。任何真实作者都会
+   被记录（模块只能经评审或维护者推送进入 `main`）；只有 bot 身份被排除。
 5. 针对每个模块，遍历其完整提交历史，用 commit API 解析出每位作者的 GitHub
    login，把除原始提交者（以及 bot）之外的人都记到 `contributors` 里。
 6. 把生成的文件 commit 回 `main`。


### PR DESCRIPTION
Closes #814.

A full-repo audit found one P0 (the TLS fingerprint bridge verified upstream servers with an accept-all trust manager while the WebView trusted the bridge's forged leaf — silent full MITM) plus a batch of P1/P2 findings across the export pipeline, JS bridge surface, server runtimes, and CI/repo hygiene. This PR implements all of them. The full finding-by-finding list lives in #814; the shape of the fix:

**TLS MITM bridge (P0)** — upstream connections now validate against the system trust store plus user-imported CA anchors, with post-handshake hostname verification (new `CertificateHostnameMatcher`, unit-tested). Local-CA detection verifies the leaf signature instead of comparing a forgeable issuer DN. The accept-any-SSL-error fallback in the WebView error handler is removed.

**Export pipeline** — overlay rebuilds no longer duplicate injected native libs; stale custom-CA/announcement/dark-statusbar/python copies no longer resurrect removed content (a deleted CA stays deleted); PHP/WP/Python interpreter embed failures abort the build instead of shipping APKs that crash on launch; builds serialize per package (process-wide Mutex) with per-package work dirs and cleanup on every exit path.

**Multi-web / AAB** — server-runtime site sources degrade to URL sites with appType normalization (the per-site embedder cannot package their runtimes, so exports were broken), the site picker filters them, and `AabExportCoordinator` asserts `!requiresProcessExec` before the targetSdk-36 rewrite for programmatic callers.

**JS bridge surface (ships in every generated APK)** — CORS-bypass `httpRequest` is caller-gated across all five bridge construction sites; the GM bridge registers only when userscripts can run, namespaces its storage behind unguessable aliases, filters `openInTab` schemes, quotes callback ids, and limits `GM_xmlhttpRequest` to http(s); MV3 `nativeFetch`/`getCookies`/`setCookieValue`/`startDownload` enforce declared `host_permissions` (new `ChromeHostPermissions`, match-pattern semantics, unit-tested); error-page `failedUrl` and `TranslateBridge` callback ids are escaped via the new `JsStrings` helper (which also avoids `JSONObject.quote` — not mocked under Robolectric).

**Runtime lifecycle** — remaining raw `NotificationChannel` creations in FGS paths route through `SafeNotificationChannels`; `startForeground` calls are fail-soft; a Node stop that cannot break the native V8 loop escalates to an engine kill; PHP/WP/Go/Python start failures release their port and DNS-bridge refcount; Python server + pip wire through `LocalDnsBridgeProxy`.

**Hardening extras** — archive extraction routed through `util/SafeZip` (zip slip, 4 sites + 2 canonical checks); MITM proxy enforces a WebView-fed host allowlist and stores its CA key AES-GCM wrapped at rest; keystore password sidecars excluded from backups; `MediaSaver` http(s)-only; deep links default to the target host; download bridge gated on `downloadEnabled`; 206-without-Content-Length resumes no longer delete the temp; WordPress CLI via `HostProcessLauncher` + timeout; Node stop handler no longer joins 5s on the main thread; gallery pinch-zoom ported to the preview viewer.

**Repo hygiene** — `.gitignore` corrupted line split; `checkConfigFieldDrift` configuration-cache safe; `SvgIconMapper` dead duplicate branches removed; docs-deploy Pages/OIDC permissions scoped to the deploy job; MAINTAINERS docs aligned with the generator's actual behavior; module validator enforces kebab-case ids; `modules-publish.yml` secrets out of inline shell interpolation.

## Verification

- `:app:compileStandardDebugKotlin` + `:shell:compileDebugKotlin` + `:app:checkConfigFieldDrift` clean on the PR tree (isolated worktree, no uncommitted side files)
- `:shell:assembleRelease` (R8) + `syncShellTemplateApk` clean on the dev tree — the rebuilt template carries the shell-synced fixes
- Full unit suite green for this change set (Robolectric / JVM); new tests: `CertificateHostnameMatcherTest`, `ChromeHostPermissionsTest`, plus extended `ApkBuildCacheTest` (stale-content entries) and `MultiWebSiteShellMappingTest` (server-source degradation)
- `validate_modules.py` passes