### PR TITLE
feat(agent): overhaul chat UI — unified composer, throttled streaming, enhanced tool cards, drawer actions

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -4938,6 +4938,18 @@ object Strings {
     val buildSummaryReason: String get() = StringsE.buildSummaryReason
     val buildAgain: String get() = StringsE.buildAgain
     val shareApkReadyMode: String get() = StringsE.shareApkReadyMode
+
+    // Agent UI rework additions
+    val agentToolViewFull: String get() = StringsE.agentToolViewFull
+    val agentCopyThinkingHeader: String get() = StringsE.agentCopyThinkingHeader
+    val agentSessionRename: String get() = StringsE.agentSessionRename
+    val agentSessionRenameTitle: String get() = StringsE.agentSessionRenameTitle
+    val agentSessionRenameHint: String get() = StringsE.agentSessionRenameHint
+    val agentSessionDeleteConfirmTitle: String get() = StringsE.agentSessionDeleteConfirmTitle
+    val agentSessionDeleteConfirmMessage: String get() = StringsE.agentSessionDeleteConfirmMessage
+    val agentSessionExport: String get() = StringsE.agentSessionExport
+    val agentFileDeleteConfirmTitle: String get() = StringsE.agentFileDeleteConfirmTitle
+    val agentFileDeleteConfirmMessage: String get() = StringsE.agentFileDeleteConfirmMessage
 }
 
 object StringsA {
@@ -65609,6 +65621,138 @@ object StringsE {
         AppLanguage.RUSSIAN -> "APK готов (%s)"
         AppLanguage.JAPANESE -> "APK 準備完了 (%s)"
         AppLanguage.KOREAN -> "APK 준비됨 (%s)"
+    }
+
+    // Agent UI rework: tool viewer, copy header, session/file actions
+
+    val agentToolViewFull: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "查看完整内容"
+        AppLanguage.ENGLISH -> "View full output"
+        AppLanguage.ARABIC -> "عرض المحتوى الكامل"
+        AppLanguage.PORTUGUESE -> "Ver conteúdo completo"
+        AppLanguage.SPANISH -> "Ver contenido completo"
+        AppLanguage.FRENCH -> "Voir tout le contenu"
+        AppLanguage.GERMAN -> "Vollständigen Inhalt ansehen"
+        AppLanguage.RUSSIAN -> "Показать полностью"
+        AppLanguage.JAPANESE -> "すべて表示"
+        AppLanguage.KOREAN -> "전체 보기"
+    }
+
+    val agentCopyThinkingHeader: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "💭 思考过程"
+        AppLanguage.ENGLISH -> "💭 Thinking"
+        AppLanguage.ARABIC -> "💭 عملية التفكير"
+        AppLanguage.PORTUGUESE -> "💭 Processo de pensamento"
+        AppLanguage.SPANISH -> "💭 Proceso de pensamiento"
+        AppLanguage.FRENCH -> "💭 Réflexion"
+        AppLanguage.GERMAN -> "💭 Denkprozess"
+        AppLanguage.RUSSIAN -> "💭 Рассуждение"
+        AppLanguage.JAPANESE -> "💭 思考プロセス"
+        AppLanguage.KOREAN -> "💭 사고 과정"
+    }
+
+    val agentSessionRename: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "重命名"
+        AppLanguage.ENGLISH -> "Rename"
+        AppLanguage.ARABIC -> "إعادة تسمية"
+        AppLanguage.PORTUGUESE -> "Renomear"
+        AppLanguage.SPANISH -> "Renombrar"
+        AppLanguage.FRENCH -> "Renommer"
+        AppLanguage.GERMAN -> "Umbenennen"
+        AppLanguage.RUSSIAN -> "Переименовать"
+        AppLanguage.JAPANESE -> "名前を変更"
+        AppLanguage.KOREAN -> "이름 바꾸기"
+    }
+
+    val agentSessionRenameTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "重命名会话"
+        AppLanguage.ENGLISH -> "Rename session"
+        AppLanguage.ARABIC -> "إعادة تسمية الجلسة"
+        AppLanguage.PORTUGUESE -> "Renomear sessão"
+        AppLanguage.SPANISH -> "Renombrar sesión"
+        AppLanguage.FRENCH -> "Renommer la session"
+        AppLanguage.GERMAN -> "Sitzung umbenennen"
+        AppLanguage.RUSSIAN -> "Переименовать сессию"
+        AppLanguage.JAPANESE -> "セッション名を変更"
+        AppLanguage.KOREAN -> "세션 이름 바꾸기"
+    }
+
+    val agentSessionRenameHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "会话名称"
+        AppLanguage.ENGLISH -> "Session name"
+        AppLanguage.ARABIC -> "اسم الجلسة"
+        AppLanguage.PORTUGUESE -> "Nome da sessão"
+        AppLanguage.SPANISH -> "Nombre de la sesión"
+        AppLanguage.FRENCH -> "Nom de la session"
+        AppLanguage.GERMAN -> "Sitzungsname"
+        AppLanguage.RUSSIAN -> "Название сессии"
+        AppLanguage.JAPANESE -> "セッション名"
+        AppLanguage.KOREAN -> "세션 이름"
+    }
+
+    val agentSessionDeleteConfirmTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "删除会话？"
+        AppLanguage.ENGLISH -> "Delete session?"
+        AppLanguage.ARABIC -> "حذف الجلسة؟"
+        AppLanguage.PORTUGUESE -> "Excluir sessão?"
+        AppLanguage.SPANISH -> "¿Eliminar sesión?"
+        AppLanguage.FRENCH -> "Supprimer la session ?"
+        AppLanguage.GERMAN -> "Sitzung löschen?"
+        AppLanguage.RUSSIAN -> "Удалить сессию?"
+        AppLanguage.JAPANESE -> "セッションを削除しますか?"
+        AppLanguage.KOREAN -> "세션을 삭제할까요?"
+    }
+
+    val agentSessionDeleteConfirmMessage: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "将永久删除该会话及其全部消息记录，无法恢复。"
+        AppLanguage.ENGLISH -> "This session and all its messages will be permanently deleted. This cannot be undone."
+        AppLanguage.ARABIC -> "سيتم حذف هذه الجلسة وجميع رسائلها نهائياً. لا يمكن التراجع عن هذا الإجراء."
+        AppLanguage.PORTUGUESE -> "Esta sessão e todas as suas mensagens serão excluídas permanentemente. Isto não pode ser desfeito."
+        AppLanguage.SPANISH -> "Esta sesión y todos sus mensajes se eliminarán permanentemente. No se puede deshacer."
+        AppLanguage.FRENCH -> "Cette session et tous ses messages seront définitivement supprimés. Cette action est irréversible."
+        AppLanguage.GERMAN -> "Diese Sitzung und alle ihre Nachrichten werden dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden."
+        AppLanguage.RUSSIAN -> "Эта сессия и все её сообщения будут удалены безвозвратно. Действие нельзя отменить."
+        AppLanguage.JAPANESE -> "このセッションとすべてのメッセージは完全に削除されます。元に戻すことはできません。"
+        AppLanguage.KOREAN -> "이 세션과 모든 메시지가 영구적으로 삭제되며 되돌릴 수 없습니다."
+    }
+
+    val agentSessionExport: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "导出"
+        AppLanguage.ENGLISH -> "Export"
+        AppLanguage.ARABIC -> "تصدير"
+        AppLanguage.PORTUGUESE -> "Exportar"
+        AppLanguage.SPANISH -> "Exportar"
+        AppLanguage.FRENCH -> "Exporter"
+        AppLanguage.GERMAN -> "Exportieren"
+        AppLanguage.RUSSIAN -> "Экспорт"
+        AppLanguage.JAPANESE -> "エクスポート"
+        AppLanguage.KOREAN -> "내보내기"
+    }
+
+    val agentFileDeleteConfirmTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "删除文件？"
+        AppLanguage.ENGLISH -> "Delete file?"
+        AppLanguage.ARABIC -> "حذف الملف؟"
+        AppLanguage.PORTUGUESE -> "Excluir arquivo?"
+        AppLanguage.SPANISH -> "¿Eliminar archivo?"
+        AppLanguage.FRENCH -> "Supprimer le fichier ?"
+        AppLanguage.GERMAN -> "Datei löschen?"
+        AppLanguage.RUSSIAN -> "Удалить файл?"
+        AppLanguage.JAPANESE -> "ファイルを削除しますか?"
+        AppLanguage.KOREAN -> "파일을 삭제할까요?"
+    }
+
+    val agentFileDeleteConfirmMessage: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "将永久删除文件 %s，无法恢复。"
+        AppLanguage.ENGLISH -> "The file %s will be permanently deleted. This cannot be undone."
+        AppLanguage.ARABIC -> "سيتم حذف الملف %s نهائياً. لا يمكن التراجع عن هذا الإجراء."
+        AppLanguage.PORTUGUESE -> "O arquivo %s será excluído permanentemente. Isto não pode ser desfeito."
+        AppLanguage.SPANISH -> "El archivo %s se eliminará permanentemente. No se puede deshacer."
+        AppLanguage.FRENCH -> "Le fichier %s sera définitivement supprimé. Cette action est irréversible."
+        AppLanguage.GERMAN -> "Die Datei %s wird dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden."
+        AppLanguage.RUSSIAN -> "Файл %s будет удалён безвозвратно. Действие нельзя отменить."
+        AppLanguage.JAPANESE -> "ファイル %s は完全に削除されます。元に戻すことはできません。"
+        AppLanguage.KOREAN -> "파일 %s이(가) 영구적으로 삭제되며 되돌릴 수 없습니다."
     }
 
 }

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -229,6 +229,11 @@ fun AgentScreen(
                         },
                         onDeleteSession = vm::deleteSession,
                         onPinSession = vm::pinSession,
+                        onRenameSession = vm::renameSession,
+                        onExportSession = { id ->
+                            scope.launch { drawerState.close() }
+                            vm.exportSession(id)
+                        },
                         onPickFile = { path ->
                             scope.launch { drawerState.close() }
                             vm.selectFile(path)
@@ -241,7 +246,8 @@ fun AgentScreen(
                         onOpenWith = { path ->
                             scope.launch { drawerState.close() }
                             vm.openWithSystemChooser(path)
-                        }
+                        },
+                        onDeleteFile = vm::deleteSessionFile
                     )
                 }
             }

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -605,6 +605,59 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch { sessionStore.pin(id, pinned) }
     }
 
+    fun renameSession(id: String, newTitle: String) {
+        val title = newTitle.trim()
+        if (title.isEmpty()) return
+        viewModelScope.launch { sessionStore.rename(id, title) }
+    }
+
+    /** Export a session as a Markdown transcript and open the system share sheet. */
+    fun exportSession(id: String) {
+        viewModelScope.launch {
+            val session = sessionStore.get(id) ?: return@launch
+            runCatching {
+                val markdown = com.webtoapp.ui.agent.components.SessionTranscript.render(
+                    session, Strings.agentCopyThinkingHeader
+                )
+                val dir = java.io.File(ctx.cacheDir, "agent_exports").apply { mkdirs() }
+                val safe = session.title.ifBlank { session.id }
+                    .replace(Regex("[^\\p{L}\\p{N}_-]+"), "_").take(40).trim('_')
+                    .ifBlank { "session" }
+                val file = java.io.File(dir, "$safe.md")
+                file.writeText(markdown)
+                val uri = androidx.core.content.FileProvider.getUriForFile(
+                    ctx, ctx.packageName + ".fileprovider", file
+                )
+                val intent = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/markdown"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    putExtra(Intent.EXTRA_TITLE, file.name)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                ctx.startActivity(
+                    Intent.createChooser(intent, Strings.agentSessionExport)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                )
+            }.onFailure { e ->
+                AppLogger.w("AgentViewModel", "exportSession failed: ${e.message}")
+                _ui.update { it.copy(info = Strings.agentFileOpenFailed) }
+            }
+        }
+    }
+
+    /** Delete a project file inside the current session sandbox, after drawer confirmation. */
+    fun deleteSessionFile(relativePath: String) {
+        val sid = _ui.value.currentSession?.id ?: return
+        // Never allow deleting the built-APK virtual entries through this path.
+        if (relativePath.startsWith("apk:")) return
+        if (files.delete(sid, relativePath)) {
+            refreshFiles(sid)
+        } else {
+            _ui.update { it.copy(info = Strings.agentFileNotFound) }
+        }
+    }
+
     fun selectFile(path: String) {
         // "apk:<name>" is a virtual path for a built APK artifact — no file content
         // to read, just surface the path so PreviewPane renders an info card.
@@ -1302,6 +1355,27 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Text/thinking deltas arrive per token; pushing the whole accumulated
+     * buffer into UI state on every one re-parses and recomposes the entire
+     * timeline each token. Coalesce to ~15fps instead — visually identical,
+     * an order of magnitude less work. Completion paths always replace the
+     * buffers with the persisted message, so nothing is ever lost.
+     */
+    private var lastStreamUiPushAt = 0L
+
+    private fun maybePushStreamUi(force: Boolean = false) {
+        val now = System.currentTimeMillis()
+        if (!force && now - lastStreamUiPushAt < STREAM_UI_THROTTLE_MS) return
+        lastStreamUiPushAt = now
+        _ui.update {
+            it.copy(
+                streamingText = streamText.toString(),
+                streamingThinkingSegments = streamThinkingSegments.toList()
+            )
+        }
+    }
+
     private fun observeStreams() {
         viewModelScope.launch {
             combine(sessionStore.sessionsFlow, sessionStore.currentSessionIdFlow) { all, currentId ->
@@ -1469,9 +1543,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
             AgentEvent.Started -> _ui.update { it.copy(phase = AgentUiState.Phase.Streaming) }
             is AgentEvent.TextDelta -> {
                 streamText.setLength(0); streamText.append(ev.accumulated)
-                _ui.update {
-                    it.copy(streamingText = ev.accumulated)
-                }
+                maybePushStreamUi()
             }
             is AgentEvent.ThinkingDelta -> {
                 // Associate by segmentId (stable per turn, mirrors the inline marker).
@@ -1487,9 +1559,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                     streamThinkingSegments[idx] =
                         streamThinkingSegments[idx].copy(content = streamThinkingSegments[idx].content + ev.delta)
                 }
-                _ui.update {
-                    it.copy(streamingThinkingSegments = streamThinkingSegments.toList())
-                }
+                maybePushStreamUi()
             }
             AgentEvent.ThinkingTurnEnded -> {
                 // Freeze any still-live segment so the next turn opens its own live block.
@@ -1641,6 +1711,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 streamingSessionId = null
                 streamText.clear(); streamThinkingSegments.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
                 lastToolUiPushAt = 0L
+                lastStreamUiPushAt = 0L
                 _ui.update {
                     it.copy(
                         phase = AgentUiState.Phase.Idle,
@@ -1907,6 +1978,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         private const val MENTION_LINE_LIMIT = 1500
 
         private const val MENTION_TOTAL_CHAR_BUDGET = 60_000
+
+        private const val STREAM_UI_THROTTLE_MS = 66L
 
         private const val STREAM_PREVIEW_CHARS = 4_000
 

--- a/app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -27,11 +26,13 @@ import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.DropdownMenu
@@ -39,8 +40,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -50,12 +49,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import com.webtoapp.core.agent.session.AgentSession
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.agent.AgentUiState
+import com.webtoapp.ui.design.WtaAlertDialog
 import com.webtoapp.ui.design.WtaButton
 import com.webtoapp.ui.design.WtaButtonSize
 import com.webtoapp.ui.design.WtaButtonVariant
@@ -66,6 +64,8 @@ import com.webtoapp.ui.design.WtaSectionDivider
 import com.webtoapp.ui.design.WtaSettingRow
 import com.webtoapp.ui.design.WtaSize
 import com.webtoapp.ui.design.WtaSpacing
+import com.webtoapp.ui.design.WtaTab
+import com.webtoapp.ui.design.WtaTabRow
 import com.webtoapp.ui.design.WtaTextField
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -80,9 +80,12 @@ fun AgentDrawer(
     onNewSession: () -> Unit,
     onDeleteSession: (String) -> Unit,
     onPinSession: (String, Boolean) -> Unit,
+    onRenameSession: (String, String) -> Unit,
+    onExportSession: (String) -> Unit,
     onPickFile: (String) -> Unit,
     onCopyFilePath: (String) -> Unit,
-    onOpenWith: (String) -> Unit
+    onOpenWith: (String) -> Unit,
+    onDeleteFile: (String) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -90,35 +93,20 @@ fun AgentDrawer(
             .background(MaterialTheme.colorScheme.surface)
     ) {
         DrawerHeader(state.drawerSearch, onSearchChange)
-        TabRow(
-            selectedTabIndex = state.drawerTab.ordinal,
-            containerColor = MaterialTheme.colorScheme.surface,
-            contentColor = MaterialTheme.colorScheme.onSurface
-        ) {
-            AgentUiState.DrawerTab.entries.forEachIndexed { i, tab ->
-                Tab(
-                    selected = state.drawerTab.ordinal == i,
-                    onClick = { onTabChange(tab) },
-                    text = {
-                        Text(
-                            text = tab.label(),
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.Medium
-                        )
-                    },
-                    icon = {
-                        Icon(
-                            imageVector = when (tab) {
-                                AgentUiState.DrawerTab.Sessions -> Icons.Outlined.History
-                                AgentUiState.DrawerTab.Files -> Icons.Outlined.Folder
-                            },
-                            contentDescription = null,
-                            modifier = Modifier.size(WtaSize.Icon)
-                        )
+        WtaTabRow(
+            tabs = AgentUiState.DrawerTab.entries.map { tab ->
+                WtaTab(
+                    label = tab.label(),
+                    count = when (tab) {
+                        AgentUiState.DrawerTab.Sessions -> state.sessions.size
+                        AgentUiState.DrawerTab.Files -> state.projectFiles.size
                     }
                 )
-            }
-        }
+            },
+            selectedIndex = state.drawerTab.ordinal,
+            onTabSelected = { idx -> onTabChange(AgentUiState.DrawerTab.entries[idx]) },
+            modifier = Modifier.padding(horizontal = WtaSpacing.ScreenHorizontal)
+        )
         when (state.drawerTab) {
             AgentUiState.DrawerTab.Sessions -> SessionsTab(
                 sessions = filterSessions(state.sessions, state.drawerSearch),
@@ -127,15 +115,18 @@ fun AgentDrawer(
                 onPick = onPickSession,
                 onNew = onNewSession,
                 onDelete = onDeleteSession,
-                onPin = onPinSession
+                onPin = onPinSession,
+                onRename = onRenameSession,
+                onExport = onExportSession
             )
             AgentUiState.DrawerTab.Files -> FilesTab(
-                files = state.projectFiles,
+                files = filterFiles(state.projectFiles, state.drawerSearch),
                 builtApks = state.builtApks,
                 onPick = onPickFile,
                 onPickApk = { apkName -> onPickFile("apk:$apkName") },
                 onCopyPath = onCopyFilePath,
-                onOpenWith = onOpenWith
+                onOpenWith = onOpenWith,
+                onDelete = onDeleteFile
             )
         }
     }
@@ -179,7 +170,9 @@ private fun SessionsTab(
     onPick: (String) -> Unit,
     onNew: () -> Unit,
     onDelete: (String) -> Unit,
-    onPin: (String, Boolean) -> Unit
+    onPin: (String, Boolean) -> Unit,
+    onRename: (String, String) -> Unit,
+    onExport: (String) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         Box(
@@ -215,7 +208,9 @@ private fun SessionsTab(
                     isLive = session.id == liveSessionId,
                     onClick = { onPick(session.id) },
                     onPin = { onPin(session.id, !session.pinned) },
-                    onDelete = { onDelete(session.id) }
+                    onRename = onRename,
+                    onExport = onExport,
+                    onDelete = onDelete
                 )
                 WtaSectionDivider()
             }
@@ -230,9 +225,16 @@ private fun SessionRow(
     isLive: Boolean,
     onClick: () -> Unit,
     onPin: () -> Unit,
-    onDelete: () -> Unit
+    onRename: (String, String) -> Unit,
+    onExport: (String) -> Unit,
+    onDelete: (String) -> Unit
 ) {
     val titleText = session.title.ifBlank { Strings.agentHomeUntitledSession }
+    var menuOpen by remember { mutableStateOf(false) }
+    var showRenameDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    var renameText by remember(session.id) { mutableStateOf(titleText) }
+
     WtaSettingRow(
         title = titleText,
         subtitle = formatSubtitle(session),
@@ -265,11 +267,94 @@ private fun SessionRow(
             contentDescription = Strings.agentSessionPin,
             modifier = Modifier.size(WtaSize.TouchTarget)
         )
-        WtaIconButton(
-            onClick = onDelete,
-            icon = Icons.Outlined.Delete,
-            contentDescription = Strings.agentSessionDelete,
-            modifier = Modifier.size(WtaSize.TouchTarget)
+        Box {
+            IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(WtaSize.TouchTarget)) {
+                Icon(
+                    imageVector = Icons.Outlined.MoreVert,
+                    contentDescription = Strings.more,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text(Strings.agentSessionRename) },
+                    leadingIcon = { Icon(Icons.Outlined.Edit, contentDescription = null) },
+                    onClick = { menuOpen = false; renameText = titleText; showRenameDialog = true }
+                )
+                DropdownMenuItem(
+                    text = { Text(Strings.agentSessionExport) },
+                    leadingIcon = { Icon(Icons.Outlined.Share, contentDescription = null) },
+                    onClick = { menuOpen = false; onExport(session.id) }
+                )
+                DropdownMenuItem(
+                    text = { Text(Strings.agentSessionDelete) },
+                    leadingIcon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+                    onClick = { menuOpen = false; showDeleteDialog = true }
+                )
+            }
+        }
+    }
+
+    if (showRenameDialog) {
+        WtaAlertDialog(
+            onDismissRequest = { showRenameDialog = false },
+            title = Strings.agentSessionRenameTitle,
+            content = {
+                WtaTextField(
+                    value = renameText,
+                    onValueChange = { renameText = it },
+                    placeholder = Strings.agentSessionRenameHint,
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                WtaButton(
+                    onClick = {
+                        onRename(session.id, renameText.trim())
+                        showRenameDialog = false
+                    },
+                    text = Strings.btnOk,
+                    variant = WtaButtonVariant.Primary,
+                    size = WtaButtonSize.Small,
+                    enabled = renameText.isNotBlank()
+                )
+            },
+            dismissButton = {
+                WtaButton(
+                    onClick = { showRenameDialog = false },
+                    text = Strings.cancel,
+                    variant = WtaButtonVariant.Text,
+                    size = WtaButtonSize.Small
+                )
+            }
+        )
+    }
+
+    if (showDeleteDialog) {
+        WtaAlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = Strings.agentSessionDeleteConfirmTitle,
+            text = Strings.agentSessionDeleteConfirmMessage,
+            confirmButton = {
+                WtaButton(
+                    onClick = {
+                        onDelete(session.id)
+                        showDeleteDialog = false
+                    },
+                    text = Strings.agentSessionDelete,
+                    variant = WtaButtonVariant.Destructive,
+                    size = WtaButtonSize.Small
+                )
+            },
+            dismissButton = {
+                WtaButton(
+                    onClick = { showDeleteDialog = false },
+                    text = Strings.cancel,
+                    variant = WtaButtonVariant.Text,
+                    size = WtaButtonSize.Small
+                )
+            }
         )
     }
 }
@@ -290,7 +375,8 @@ private fun FilesTab(
     onPick: (String) -> Unit,
     onPickApk: (String) -> Unit,
     onCopyPath: (String) -> Unit,
-    onOpenWith: (String) -> Unit
+    onOpenWith: (String) -> Unit,
+    onDelete: (String) -> Unit
 ) {
     if (files.isEmpty() && builtApks.isEmpty()) {
         WtaFullEmptyState(
@@ -319,7 +405,8 @@ private fun FilesTab(
                     icon = Icons.Outlined.Android,
                     onOpen = { onPickApk(apk.apkName) },
                     onOpenWith = { onOpenWith(apkVirtualPath) },
-                    onCopyPath = { onCopyPath(apk.apkPath) }
+                    onCopyPath = { onCopyPath(apk.apkPath) },
+                    onDelete = null
                 )
                 WtaSectionDivider()
             }
@@ -332,7 +419,8 @@ private fun FilesTab(
                 icon = Icons.Outlined.Code,
                 onOpen = { onPick(f.relativePath) },
                 onOpenWith = { onOpenWith(f.relativePath) },
-                onCopyPath = { onCopyPath(f.relativePath) }
+                onCopyPath = { onCopyPath(f.relativePath) },
+                onDelete = { onDelete(f.relativePath) }
             )
             WtaSectionDivider()
         }
@@ -346,9 +434,11 @@ private fun FileEntryRow(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     onOpen: () -> Unit,
     onOpenWith: () -> Unit,
-    onCopyPath: () -> Unit
+    onCopyPath: () -> Unit,
+    onDelete: (() -> Unit)?
 ) {
     var menuOpen by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
     WtaSettingRow(
         title = title,
         subtitle = subtitle,
@@ -379,10 +469,44 @@ private fun FileEntryRow(
                         leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
                         onClick = { menuOpen = false; onCopyPath() }
                     )
+                    if (onDelete != null) {
+                        DropdownMenuItem(
+                            text = { Text(Strings.agentSessionDelete) },
+                            leadingIcon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+                            onClick = { menuOpen = false; showDeleteDialog = true }
+                        )
+                    }
                 }
             }
         }
     )
+
+    if (showDeleteDialog && onDelete != null) {
+        WtaAlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = Strings.agentFileDeleteConfirmTitle,
+            text = Strings.agentFileDeleteConfirmMessage.format(title),
+            confirmButton = {
+                WtaButton(
+                    onClick = {
+                        onDelete()
+                        showDeleteDialog = false
+                    },
+                    text = Strings.agentSessionDelete,
+                    variant = WtaButtonVariant.Destructive,
+                    size = WtaButtonSize.Small
+                )
+            },
+            dismissButton = {
+                WtaButton(
+                    onClick = { showDeleteDialog = false },
+                    text = Strings.cancel,
+                    variant = WtaButtonVariant.Text,
+                    size = WtaButtonSize.Small
+                )
+            }
+        )
+    }
 }
 
 private fun filterSessions(all: List<AgentSession>, query: String): List<AgentSession> {
@@ -392,6 +516,15 @@ private fun filterSessions(all: List<AgentSession>, query: String): List<AgentSe
     return all.filter {
         it.title.lowercase().contains(q)
     }.sortedWith(ordered)
+}
+
+private fun filterFiles(
+    all: List<com.webtoapp.core.agent.files.ProjectFileManager.FileInfo>,
+    query: String
+): List<com.webtoapp.core.agent.files.ProjectFileManager.FileInfo> {
+    if (query.isBlank()) return all
+    val q = query.lowercase()
+    return all.filter { it.relativePath.lowercase().contains(q) }
 }
 
 @Composable

--- a/app/src/main/java/com/webtoapp/ui/agent/components/CodeRenderer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/CodeRenderer.kt
@@ -156,14 +156,29 @@ fun CodeBlock(
             }
             Box(modifier = bodyModifier) {
                 SelectionContainer {
-                    Text(
-                        text = if (showCaret) "$code▋" else code,
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            fontFamily = FontFamily.Monospace,
-                            fontSize = 12.sp,
-                            color = AppColors.CodeForeground
+                    // Highlight only settled blocks: while streaming, plain text
+                    // avoids re-tokenizing the buffer on every delta.
+                    val highlighted = remember(code, language, showCaret) {
+                        if (showCaret) null else SyntaxHighlight.highlight(code, language)
+                    }
+                    if (highlighted != null) {
+                        Text(
+                            text = highlighted,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                fontFamily = FontFamily.Monospace,
+                                fontSize = 12.sp
+                            )
                         )
-                    )
+                    } else {
+                        Text(
+                            text = if (showCaret) "$code▋" else code,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                fontFamily = FontFamily.Monospace,
+                                fontSize = 12.sp,
+                                color = AppColors.CodeForeground
+                            )
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -58,9 +59,6 @@ import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.agent.AgentUiState
 import com.webtoapp.ui.agent.SlashCommand
 import com.webtoapp.ui.design.WtaAlpha
-import com.webtoapp.ui.design.WtaButton
-import com.webtoapp.ui.design.WtaButtonSize
-import com.webtoapp.ui.design.WtaButtonVariant
 import com.webtoapp.ui.design.WtaCard
 import com.webtoapp.ui.design.WtaCardTone
 import com.webtoapp.ui.design.WtaIconButton
@@ -112,44 +110,16 @@ fun Composer(
                 onDismiss = onDismissMention
             )
         }
-        if (state.pendingAttachments.isNotEmpty()) {
-            PendingAttachmentsRow(
-                attachments = state.pendingAttachments,
-                onRemove = onRemoveAttachment
-            )
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    horizontal = WtaSpacing.ScreenHorizontal,
-                    vertical = WtaSpacing.Small
-                ),
-            verticalAlignment = Alignment.Bottom
-        ) {
-            AttachButton(
-                onAttachImage = onAttachImage,
-                onAttachFile = onAttachFile,
-                onAttachFolder = onAttachFolder
-            )
-            Spacer(Modifier.width(WtaSpacing.Small))
-            ComposerPillField(
-                value = state.composerText,
-                onValueChange = onTextChange,
-                placeholder = composerPlaceholder(state),
-                modifier = Modifier
-                    .weight(1f)
-                    .heightIn(max = 220.dp)
-            )
-            Spacer(Modifier.width(WtaSpacing.Small))
-            SendButton(
-                working = state.isWorking,
-                enabled = state.canSend &&
-                    (state.composerText.isNotBlank() || state.pendingAttachments.isNotEmpty()),
-                onSend = onSend,
-                onCancel = onCancel
-            )
-        }
+        ComposerCard(
+            state = state,
+            onTextChange = onTextChange,
+            onSend = onSend,
+            onCancel = onCancel,
+            onAttachImage = onAttachImage,
+            onAttachFile = onAttachFile,
+            onAttachFolder = onAttachFolder,
+            onRemoveAttachment = onRemoveAttachment
+        )
 
         ModeChipRow(
             autoApprove = state.autoApprove,
@@ -168,52 +138,104 @@ fun Composer(
 }
 
 /**
- * Composer input matching the trailing send button: same 10dp corner radius
- * ([WtaRadius.Button]) and the same resting height ([WtaSize.ButtonHeightMedium]).
- * Built on foundation [BasicTextField] inside a Surface — an M3 TextField would
- * enforce its own 56dp minimum, so height parity with the button is impossible
- * there; BasicTextField also keeps focus chrome invisible by construction.
+ * Unified chat composer (ChatGPT/Claude-style): a single elevated card holding
+ * the attachment strip, the growing text field, and a bottom action row with
+ * the attach menu and an embedded circular send/stop button. Keeps the legacy
+ * height behaviour (44dp resting, 220dp cap) that only BasicTextField allows —
+ * an M3 TextField enforces a 56dp minimum.
  */
 @Composable
-private fun ComposerPillField(
-    value: String,
-    onValueChange: (String) -> Unit,
-    placeholder: String,
-    modifier: Modifier = Modifier
+private fun ComposerCard(
+    state: AgentUiState,
+    onTextChange: (String) -> Unit,
+    onSend: () -> Unit,
+    onCancel: () -> Unit,
+    onAttachImage: () -> Unit,
+    onAttachFile: () -> Unit,
+    onAttachFolder: () -> Unit,
+    onRemoveAttachment: (String) -> Unit
 ) {
-    Surface(
-        shape = RoundedCornerShape(WtaRadius.Button),
-        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-        modifier = modifier
+    WtaCard(
+        tone = WtaCardTone.Elevated,
+        shape = RoundedCornerShape(WtaRadius.Card + 8.dp),
+        contentPadding = PaddingValues(vertical = WtaSpacing.Small),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = WtaSpacing.ScreenHorizontal,
+                vertical = WtaSpacing.Small
+            )
     ) {
-        BasicTextField(
-            value = value,
-            onValueChange = onValueChange,
+        if (state.pendingAttachments.isNotEmpty()) {
+            PendingAttachmentsRow(
+                attachments = state.pendingAttachments,
+                onRemove = onRemoveAttachment
+            )
+        }
+        ComposerField(
+            value = state.composerText,
+            onValueChange = onTextChange,
+            placeholder = composerPlaceholder(state)
+        )
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = WtaSize.ButtonHeightMedium),
-            textStyle = MaterialTheme.typography.bodyLarge.copy(
-                color = MaterialTheme.colorScheme.onSurface
-            ),
-            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-            decorationBox = { innerField ->
-                Box(
-                    modifier = Modifier.padding(horizontal = 14.dp),
-                    contentAlignment = Alignment.CenterStart
-                ) {
-                    if (value.isEmpty()) {
-                        Text(
-                            text = placeholder,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1
-                        )
-                    }
-                    innerField()
-                }
-            }
-        )
+                .padding(horizontal = WtaSpacing.Small, vertical = WtaSpacing.Tiny),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AttachButton(
+                onAttachImage = onAttachImage,
+                onAttachFile = onAttachFile,
+                onAttachFolder = onAttachFolder
+            )
+            Spacer(Modifier.weight(1f))
+            SendButton(
+                working = state.isWorking,
+                enabled = state.canSend &&
+                    (state.composerText.isNotBlank() || state.pendingAttachments.isNotEmpty()),
+                onSend = onSend,
+                onCancel = onCancel
+            )
+        }
     }
+}
+
+/**
+ * The growing text field inside [ComposerCard]. Built on foundation
+ * [BasicTextField] — an M3 TextField would enforce its own 56dp minimum and
+ * add focus chrome we do not want inside the unified card.
+ */
+@Composable
+private fun ComposerField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 36.dp, max = 220.dp)
+            .padding(horizontal = WtaSpacing.RowHorizontal, vertical = WtaSpacing.Tiny),
+        textStyle = MaterialTheme.typography.bodyLarge.copy(
+            color = MaterialTheme.colorScheme.onSurface
+        ),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        decorationBox = { innerField ->
+            Box(contentAlignment = Alignment.CenterStart) {
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1
+                    )
+                }
+                innerField()
+            }
+        }
+    )
 }
 
 @Composable
@@ -258,45 +280,100 @@ private fun PendingAttachmentsRow(
         modifier = Modifier
             .fillMaxWidth()
             .horizontalScroll(rememberScrollState())
-            .padding(horizontal = WtaSpacing.ScreenHorizontal, vertical = WtaSpacing.Tiny),
+            .padding(horizontal = WtaSpacing.RowHorizontal, vertical = WtaSpacing.Tiny),
         horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
     ) {
         attachments.forEach { att ->
-            Surface(
-                shape = MaterialTheme.shapes.small,
-                color = MaterialTheme.colorScheme.secondaryContainer
-            ) {
-                Row(
-                    modifier = Modifier.padding(
-                        horizontal = WtaSpacing.Small,
-                        vertical = WtaSpacing.Tiny
-                    ),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = if (att.isImage) Icons.Outlined.Image else Icons.Outlined.AttachFile,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                        modifier = Modifier.size(WtaSize.IconSmall)
-                    )
-                    Spacer(Modifier.width(WtaSpacing.Tiny))
-                    Text(
-                        text = att.displayName,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        maxLines = 1
-                    )
-                    Spacer(Modifier.width(WtaSpacing.Tiny))
-                    Icon(
-                        imageVector = Icons.Outlined.Close,
-                        contentDescription = Strings.btnDelete,
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                        modifier = Modifier
-                            .size(WtaSize.IconSmall)
-                            .clickable { onRemove(att.path) }
-                    )
-                }
+            if (att.isImage) {
+                ImageAttachmentChip(att, onRemove)
+            } else {
+                FileAttachmentChip(att, onRemove)
             }
+        }
+    }
+}
+
+/** Image attachment with a real thumbnail (Coil) instead of a bare text chip. */
+@Composable
+private fun ImageAttachmentChip(att: UserAttachment, onRemove: (String) -> Unit) {
+    Box {
+        Surface(
+            shape = RoundedCornerShape(WtaRadius.Control),
+            color = MaterialTheme.colorScheme.surfaceContainerHighest
+        ) {
+            coil.compose.AsyncImage(
+                model = java.io.File(att.path),
+                contentDescription = att.displayName,
+                contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                modifier = Modifier.size(56.dp)
+            )
+        }
+        AttachmentRemoveBadge(
+            onClick = { onRemove(att.path) },
+            modifier = Modifier.align(Alignment.TopEnd)
+        )
+    }
+}
+
+@Composable
+private fun FileAttachmentChip(att: UserAttachment, onRemove: (String) -> Unit) {
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.secondaryContainer
+    ) {
+        Row(
+            modifier = Modifier.padding(
+                start = WtaSpacing.Small,
+                end = WtaSpacing.Tiny,
+                top = WtaSpacing.Tiny,
+                bottom = WtaSpacing.Tiny
+            ),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = if (att.path.endsWith("/")) Icons.Outlined.Folder else Icons.Outlined.AttachFile,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.size(WtaSize.IconSmall)
+            )
+            Spacer(Modifier.width(WtaSpacing.Tiny))
+            Text(
+                text = att.displayName,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                maxLines = 1,
+                modifier = Modifier.widthIn(max = 140.dp),
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+            )
+            Icon(
+                imageVector = Icons.Outlined.Close,
+                contentDescription = Strings.btnDelete,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier
+                    .size(WtaSize.IconSmall)
+                    .clickable { onRemove(att.path) }
+            )
+        }
+    }
+}
+
+/** Small circular "×" badge overlaid on an image thumbnail. */
+@Composable
+private fun AttachmentRemoveBadge(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Surface(
+        shape = RoundedCornerShape(WtaRadius.Pill),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+        modifier = modifier
+            .size(20.dp)
+            .clickable(onClick = onClick)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Outlined.Close,
+                contentDescription = Strings.btnDelete,
+                tint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.size(12.dp)
+            )
         }
     }
 }
@@ -313,31 +390,29 @@ private fun SendButton(
     onSend: () -> Unit,
     onCancel: () -> Unit
 ) {
-    if (working) {
-        WtaButton(
-            onClick = onCancel,
-            variant = WtaButtonVariant.Destructive,
-            size = WtaButtonSize.Medium,
-            shape = RoundedCornerShape(WtaRadius.Pill)
-        ) {
+    val container = when {
+        working -> MaterialTheme.colorScheme.errorContainer
+        enabled -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.surfaceContainerHighest
+    }
+    val content = when {
+        working -> MaterialTheme.colorScheme.onErrorContainer
+        enabled -> MaterialTheme.colorScheme.onPrimary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Surface(
+        onClick = if (working) onCancel else onSend,
+        enabled = working || enabled,
+        shape = RoundedCornerShape(WtaRadius.Pill),
+        color = container,
+        modifier = Modifier.size(40.dp)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
             Icon(
-                Icons.Outlined.Stop,
-                contentDescription = Strings.agentStopTooltip,
-                modifier = Modifier.size(WtaSize.Icon)
-            )
-        }
-    } else {
-        WtaButton(
-            onClick = onSend,
-            variant = WtaButtonVariant.Primary,
-            size = WtaButtonSize.Medium,
-            enabled = enabled,
-            shape = RoundedCornerShape(WtaRadius.Pill)
-        ) {
-            Icon(
-                Icons.AutoMirrored.Outlined.Send,
-                contentDescription = Strings.agentSendTooltip,
-                modifier = Modifier.size(WtaSize.Icon)
+                imageVector = if (working) Icons.Outlined.Stop else Icons.AutoMirrored.Outlined.Send,
+                contentDescription = if (working) Strings.agentStopTooltip else Strings.agentSendTooltip,
+                tint = content,
+                modifier = Modifier.size(18.dp)
             )
         }
     }

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MarkdownText.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MarkdownText.kt
@@ -1,6 +1,7 @@
 package com.webtoapp.ui.agent.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
@@ -18,12 +21,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -146,6 +151,55 @@ private fun RenderBlock(
                     .background(quoteBar)
             )
         }
+
+        is MdBlock.Table -> {
+            // Horizontally scrollable so wide tables never squash the chat column.
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+            ) {
+                TableRow(cells = block.header, header = true, zebra = false, color = color, codeBg = codeBg, codeFg = codeFg, linkColor = linkColor)
+                Box(
+                    modifier = Modifier
+                        .height(1.dp)
+                        .background(quoteBar.copy(alpha = 0.6f))
+                        .fillMaxWidth()
+                )
+                block.rows.forEachIndexed { index, row ->
+                    TableRow(cells = row, header = false, zebra = index % 2 == 1, color = color, codeBg = codeBg, codeFg = codeFg, linkColor = linkColor)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableRow(
+    cells: List<String>,
+    header: Boolean,
+    zebra: Boolean,
+    color: Color,
+    codeBg: Color,
+    codeFg: Color,
+    linkColor: Color
+) {
+    Row(
+        modifier = Modifier.background(
+            if (zebra) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f) else Color.Transparent
+        )
+    ) {
+        cells.forEach { cell ->
+            androidx.compose.material3.Text(
+                text = inlineAnnotated(cell, codeBg, codeFg, linkColor),
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = if (header) FontWeight.Bold else null,
+                color = color,
+                modifier = Modifier
+                    .widthIn(min = 64.dp, max = 260.dp)
+                    .padding(horizontal = 8.dp, vertical = 5.dp)
+            )
+        }
     }
 }
 
@@ -156,12 +210,26 @@ internal sealed class MdBlock {
     data class ListItem(val marker: String, val text: String, val indent: Int) : MdBlock()
     data class Quote(val text: String) : MdBlock()
     object Rule : MdBlock()
+
+    /** GFM pipe table: header row plus body rows; column count follows the header. */
+    data class Table(val header: List<String>, val rows: List<List<String>>) : MdBlock()
 }
 
 private val ORDERED_LIST = Regex("^(\\s*)(\\d+)[.)]\\s+(.*)$")
 private val UNORDERED_LIST = Regex("^(\\s*)[-*+]\\s+(.*)$")
 private val HEADING = Regex("^(#{1,6})\\s+(.*)$")
 private val RULE = Regex("^(-{3,}|\\*{3,}|_{3,})$")
+
+/** Table separator row like `|---|---|` or `| :--- | ---: |` (alignment colons allowed). */
+private val TABLE_SEPARATOR = Regex("^\\|?[\\s:|-]+\\|[\\s:|-]*$")
+
+private fun isTableRow(line: String): Boolean {
+    val t = line.trim()
+    return t.startsWith("|") && t.endsWith("|") && t.count { it == '|' } >= 2
+}
+
+private fun splitTableRow(line: String): List<String> =
+    line.trim().trim('|').split('|').map { it.trim() }
 
 internal fun parseMarkdownBlocks(text: String): List<MdBlock> {
     val trimmed = text.trim('\n')
@@ -179,10 +247,29 @@ internal fun parseMarkdownBlocks(text: String): List<MdBlock> {
         }
     }
 
-    for (raw in lines) {
+    var i = 0
+    while (i < lines.size) {
+        val raw = lines[i]
         val line = raw.trimEnd()
         when {
             line.isBlank() -> flushParagraph()
+
+            // GFM table: header row, separator row, then any number of body rows.
+            isTableRow(line) && i + 1 < lines.size && TABLE_SEPARATOR.matches(lines[i + 1].trimEnd().trim()) -> {
+                flushParagraph()
+                val header = splitTableRow(line)
+                val rows = mutableListOf<List<String>>()
+                var j = i + 2
+                while (j < lines.size && isTableRow(lines[j].trimEnd())) {
+                    val cells = splitTableRow(lines[j].trimEnd())
+                    // Normalise to the header width: pad or trim.
+                    rows += List(header.size) { idx -> cells.getOrElse(idx) { "" } }
+                    j++
+                }
+                out += MdBlock.Table(header, rows)
+                i = j
+                continue
+            }
 
             RULE.matches(line.trim()) -> {
                 flushParagraph()
@@ -219,6 +306,7 @@ internal fun parseMarkdownBlocks(text: String): List<MdBlock> {
                 paragraph.append(line.trim())
             }
         }
+        i++
     }
     flushParagraph()
     return out
@@ -295,12 +383,15 @@ internal fun inlineAnnotated(
                     val urlEnd = text.indexOf(')', close + 2)
                     if (urlEnd > close + 1) {
                         val label = text.substring(i + 1, close)
-                        withStyle(
-                            SpanStyle(
-                                color = linkColor,
-                                textDecoration = TextDecoration.Underline
-                            )
-                        ) { append(label) }
+                        val url = text.substring(close + 2, urlEnd).trim()
+                        withLink(LinkAnnotation.Url(url)) {
+                            withStyle(
+                                SpanStyle(
+                                    color = linkColor,
+                                    textDecoration = TextDecoration.Underline
+                                )
+                            ) { append(label) }
+                        }
                         i = urlEnd + 1
                     } else {
                         append(c); i++
@@ -308,6 +399,22 @@ internal fun inlineAnnotated(
                 } else {
                     append(c); i++
                 }
+            }
+
+            c == 'h' && (text.startsWith("https://", i) || text.startsWith("http://", i)) -> {
+                // Bare URL auto-link: consume until whitespace or a closing bracket.
+                var end = i
+                while (end < n && !text[end].isWhitespace() && text[end] != ')' && text[end] != ']') end++
+                val url = text.substring(i, end).trimEnd('.', ',', ';', ':', '!', '?')
+                withLink(LinkAnnotation.Url(url)) {
+                    withStyle(
+                        SpanStyle(
+                            color = linkColor,
+                            textDecoration = TextDecoration.Underline
+                        )
+                    ) { append(url) }
+                }
+                i += url.length
             }
 
             else -> {

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -27,11 +29,17 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AttachFile
+import androidx.compose.material.icons.outlined.Apps
+import androidx.compose.material.icons.outlined.Build
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.ChecklistRtl
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Extension
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
@@ -41,6 +49,7 @@ import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.RadioButtonUnchecked
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -109,7 +118,8 @@ internal fun formatMessageForCopy(message: AgentMessage, includeDetails: Boolean
         val c = seg.content.trim()
         if (c.isBlank()) return@forEachIndexed
         if (sb.isNotEmpty()) sb.append("\n\n")
-        sb.append(if (segments.size > 1) "💭 思考过程 (${i + 1})" else "💭 思考过程")
+        sb.append(Strings.agentCopyThinkingHeader)
+        if (segments.size > 1) sb.append(" (${i + 1})")
         sb.append("\n").append(c)
     }
     // Tool calls with their result previews.
@@ -595,7 +605,7 @@ private fun scrubInline(s: String): String =
 @Composable
 fun ToolCallCard(tc: RecordedToolCall, live: Boolean) {
     val running = tc.resultPreview == RecordedToolCall.RUNNING_SENTINEL
-    val (icon, tint) = when {
+    val (statusIcon, statusTint) = when {
         running -> Icons.Outlined.HourglassTop to MaterialTheme.colorScheme.primary
         tc.ok -> Icons.Outlined.CheckCircle to WtaColors.semantic.success
         else -> Icons.Outlined.ErrorOutline to MaterialTheme.colorScheme.error
@@ -613,99 +623,211 @@ fun ToolCallCard(tc: RecordedToolCall, live: Boolean) {
             }
         }
     }
+    // Started ticking when the card first appears live; stops when the tool finishes.
+    val startedAt = remember(tc.toolCallId) { System.currentTimeMillis() }
+    var elapsedMs by remember(tc.toolCallId) { mutableStateOf<Long?>(null) }
+    LaunchedEffect(running) {
+        if (running) {
+            while (true) {
+                elapsedMs = System.currentTimeMillis() - startedAt
+                kotlinx.coroutines.delay(500)
+            }
+        }
+    }
+    val stripeColor = when {
+        running -> MaterialTheme.colorScheme.primary
+        tc.ok -> WtaColors.semantic.success
+        else -> MaterialTheme.colorScheme.error
+    }
+    var showFullResult by remember(tc.toolCallId) { mutableStateOf(false) }
+
     Surface(
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
+        color = if (!tc.ok && !running) MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.25f)
+                else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
         shape = MaterialTheme.shapes.medium,
         modifier = Modifier.fillMaxWidth()
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Row(
+        Row(modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
+            // Status stripe, stretching with the card (header + expanded body).
+            Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { expanded = !expanded }
-                    .padding(horizontal = WtaSpacing.Small + 2.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = tint,
-                    modifier = Modifier.size(16.dp)
-                )
-                Spacer(Modifier.width(WtaSpacing.Small))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = tc.name,
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1
-                    )
-                    if (subtitle.isNotBlank()) {
-                        Text(
-                            text = subtitle,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1
-                        )
-                    }
-                }
-                if (running) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(12.dp),
-                        strokeWidth = 1.5.dp,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    Spacer(Modifier.width(WtaSpacing.Tiny + 2.dp))
-                }
-                Icon(
-                    imageVector = if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(16.dp)
-                )
-            }
-            AnimatedVisibility(
-                visible = expanded,
-                enter = expandVertically() + fadeIn(),
-                exit = shrinkVertically() + fadeOut()
-            ) {
-                Column(
+                    .width(3.dp)
+                    .fillMaxHeight()
+                    .background(stripeColor)
+            )
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = WtaSpacing.Small + 2.dp)
-                        .padding(bottom = WtaSpacing.Small)
+                        .clickable { expanded = !expanded }
+                        .padding(horizontal = WtaSpacing.Small + 2.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    val handled = SpecialToolBody(tc, running = running)
-                    if (!handled) {
-                        if (tc.argumentsJson.isNotBlank()) {
-                            ToolBlockLabel(Strings.agentToolArgsLabel)
-                            Spacer(Modifier.height(2.dp))
-                            ToolMonoBlock(prettyJsonOrRaw(tc.argumentsJson))
+                    Icon(
+                        imageVector = toolIconFor(tc.name),
+                        contentDescription = null,
+                        tint = statusTint,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(Modifier.width(WtaSpacing.Small))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = tc.name,
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1
+                        )
+                        if (subtitle.isNotBlank()) {
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1
+                            )
                         }
-                        if (running) {
-                            Spacer(Modifier.height(WtaSpacing.Tiny + 2.dp))
-                            ToolBlockLabel(Strings.agentToolResultLabel)
-                            Spacer(Modifier.height(2.dp))
-                            if (tc.resultPreview.isNotBlank() && tc.resultPreview != RecordedToolCall.RUNNING_SENTINEL) {
-                                ToolMonoBlock(text = tc.resultPreview, spinner = true)
-                            } else {
+                    }
+                    elapsedMs?.takeIf { it >= 400 || !running }?.let { ms ->
+                        Text(
+                            text = formatElapsed(ms),
+                            style = MaterialTheme.typography.labelSmall.copy(fontFamily = FontFamily.Monospace),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.width(WtaSpacing.Tiny + 2.dp))
+                    }
+                    if (running) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(12.dp),
+                            strokeWidth = 1.5.dp,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(Modifier.width(WtaSpacing.Tiny + 2.dp))
+                    }
+                    Icon(
+                        imageVector = statusIcon,
+                        contentDescription = null,
+                        tint = statusTint,
+                        modifier = Modifier.size(14.dp)
+                    )
+                    Spacer(Modifier.width(WtaSpacing.Tiny))
+                    Icon(
+                        imageVector = if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+                AnimatedVisibility(
+                    visible = expanded,
+                    enter = expandVertically() + fadeIn(),
+                    exit = shrinkVertically() + fadeOut()
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = WtaSpacing.Small + 2.dp)
+                            .padding(bottom = WtaSpacing.Small)
+                    ) {
+                        val handled = SpecialToolBody(tc, running = running)
+                        if (!handled) {
+                            if (tc.argumentsJson.isNotBlank()) {
+                                ToolBlockLabel(Strings.agentToolArgsLabel)
+                                Spacer(Modifier.height(2.dp))
+                                ToolMonoBlock(prettyJsonOrRaw(tc.argumentsJson))
+                            }
+                            if (running) {
+                                Spacer(Modifier.height(WtaSpacing.Tiny + 2.dp))
+                                ToolBlockLabel(Strings.agentToolResultLabel)
+                                Spacer(Modifier.height(2.dp))
+                                if (tc.resultPreview.isNotBlank() && tc.resultPreview != RecordedToolCall.RUNNING_SENTINEL) {
+                                    ToolMonoBlock(text = tc.resultPreview, spinner = true)
+                                } else {
+                                    ToolMonoBlock(
+                                        text = (tc.activity ?: Strings.agentPhaseToolRunning),
+                                        spinner = true
+                                    )
+                                }
+                            } else if (tc.resultPreview.isNotBlank()) {
+                                Spacer(Modifier.height(WtaSpacing.Tiny + 2.dp))
+                                ToolBlockLabel(Strings.agentToolResultLabel)
+                                Spacer(Modifier.height(2.dp))
                                 ToolMonoBlock(
-                                    text = (tc.activity ?: Strings.agentPhaseToolRunning),
-                                    spinner = true
+                                    text = tc.resultPreview,
+                                    truncated = tc.resultPreview.length >= 2000,
+                                    onViewFull = { showFullResult = true }
                                 )
                             }
-                        } else if (tc.resultPreview.isNotBlank()) {
-                            Spacer(Modifier.height(WtaSpacing.Tiny + 2.dp))
-                            ToolBlockLabel(Strings.agentToolResultLabel)
-                            Spacer(Modifier.height(2.dp))
-                            ToolMonoBlock(text = tc.resultPreview)
                         }
                     }
                 }
             }
         }
     }
+
+    if (showFullResult) {
+        ToolFullResultDialog(
+            title = tc.name,
+            content = tc.resultPreview,
+            onDismiss = { showFullResult = false }
+        )
+    }
+}
+
+/** Map common tool names to an icon; unknown tools fall back to a wrench. */
+private fun toolIconFor(name: String): androidx.compose.ui.graphics.vector.ImageVector = when (name) {
+    "Write" -> Icons.Outlined.Edit
+    "Edit" -> Icons.Outlined.Edit
+    "Read" -> Icons.Outlined.Description
+    "Delete" -> Icons.Outlined.Delete
+    "Glob" -> Icons.Outlined.Search
+    "Grep" -> Icons.Outlined.Search
+    "ListFiles" -> Icons.Outlined.FolderOpen
+    "TodoWrite" -> Icons.Outlined.ChecklistRtl
+    "CreateApp", "UpdateApp", "GetApp", "ListApps" -> Icons.Outlined.Apps
+    "CreateModule", "UpdateModule", "GetModule", "ListModules" -> Icons.Outlined.Extension
+    else -> Icons.Outlined.Build
+}
+
+private fun formatElapsed(ms: Long): String = when {
+    ms < 1000 -> "${ms}ms"
+    ms < 60_000 -> "%.1fs".format(ms / 1000.0)
+    else -> "${ms / 60_000}m ${(ms % 60_000) / 1000}s"
+}
+
+/** Full-screen scrollable dialog showing the untruncated tool result. */
+@Composable
+private fun ToolFullResultDialog(title: String, content: String, onDismiss: () -> Unit) {
+    val clipboard = LocalClipboardManager.current
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            androidx.compose.material3.TextButton(onClick = onDismiss) {
+                Text(Strings.close)
+            }
+        },
+        dismissButton = {
+            androidx.compose.material3.TextButton(onClick = {
+                clipboard.setText(AnnotatedString(content))
+                onDismiss()
+            }) {
+                Text(Strings.agentMessageActionCopy)
+            }
+        },
+        title = { Text(title, style = MaterialTheme.typography.titleSmall) },
+        text = {
+            Box(modifier = Modifier.heightIn(max = 420.dp).verticalScroll(rememberScrollState())) {
+                SelectionContainer {
+                    Text(
+                        text = content,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 11.sp
+                        )
+                    )
+                }
+            }
+        }
+    )
 }
 
 @Composable
@@ -821,7 +943,51 @@ private fun SpecialToolBody(tc: RecordedToolCall, running: Boolean): Boolean {
             }
             true
         }
+        "Glob", "Grep", "ListFiles" -> {
+            // Path-listing tools read far better as rows than as a raw text blob.
+            if (running) return false
+            val lines = tc.resultPreview.lines().map { it.trim() }.filter { it.isNotEmpty() }
+            if (lines.isEmpty()) return false
+            FileListBody(lines)
+            true
+        }
         else -> false
+    }
+}
+
+@Composable
+private fun FileListBody(lines: List<String>) {
+    val shown = lines.take(60)
+    Column(modifier = Modifier.fillMaxWidth()) {
+        shown.forEach { line ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(vertical = 1.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Description,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(12.dp)
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = line,
+                    style = MaterialTheme.typography.labelSmall.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                )
+            }
+        }
+        if (lines.size > shown.size) {
+            Spacer(Modifier.height(WtaSpacing.Tiny))
+            Text(
+                text = "… +${lines.size - shown.size}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 
@@ -932,7 +1098,7 @@ private fun ToolBlockLabel(text: String) {
 }
 
 @Composable
-private fun ToolMonoBlock(text: String, spinner: Boolean = false) {
+private fun ToolMonoBlock(text: String, spinner: Boolean = false, truncated: Boolean = false, onViewFull: (() -> Unit)? = null) {
     val clipboard = LocalClipboardManager.current
     androidx.compose.material3.Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -967,6 +1133,29 @@ private fun ToolMonoBlock(text: String, spinner: Boolean = false) {
                     icon = Icons.Outlined.ContentCopy,
                     contentDescription = Strings.agentMessageActionCopy,
                     modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+        if (truncated && onViewFull != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onViewFull)
+                    .padding(horizontal = WtaSpacing.Small + 2.dp, vertical = WtaSpacing.Tiny),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = Strings.agentToolViewFull,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = AppColors.CodeGutter,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.weight(1f))
+                Icon(
+                    imageVector = Icons.Outlined.ExpandMore,
+                    contentDescription = null,
+                    tint = AppColors.CodeGutter,
+                    modifier = Modifier.size(14.dp)
                 )
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/agent/components/SessionTranscript.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/SessionTranscript.kt
@@ -1,0 +1,75 @@
+package com.webtoapp.ui.agent.components
+
+import com.webtoapp.core.agent.session.AgentSession
+import com.webtoapp.core.agent.session.RecordedToolCall
+import com.webtoapp.ui.agent.AgentViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Renders a session to a Markdown transcript for the drawer's Export action.
+ * Pure formatting: reads the persisted session model only (with the safe
+ * accessors used everywhere else), so legacy sessions export identically.
+ */
+object SessionTranscript {
+
+    private val TIME = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+
+    fun render(session: AgentSession, thinkingHeader: String): String = buildString {
+        append("# ").append(session.title.ifBlank { "Session" }).append("\n\n")
+        append("- ID: `").append(session.id).append("`\n")
+        append("- Created: ").append(TIME.format(Date(session.createdAt))).append("\n")
+        append("- Updated: ").append(TIME.format(Date(session.updatedAt))).append("\n")
+        append("- Messages: ").append(session.messages.size).append("\n")
+
+        session.messages.forEach { msg ->
+            append("\n---\n\n")
+            when (msg.role) {
+                com.webtoapp.core.agent.session.AgentMessage.Role.USER -> {
+                    append("## 👤 User\n\n")
+                    msg.userAttachmentsSafe.forEach { att ->
+                        append("- 📎 ").append(att.displayName).append('\n')
+                    }
+                    if (msg.userAttachmentsSafe.isNotEmpty()) append('\n')
+                    append(AgentViewModel.stripInlineMarkers(msg.content).trim()).append('\n')
+                    msg.mentionedFiles.forEach { f ->
+                        append("\n> `@").append(f).append('`')
+                    }
+                }
+                com.webtoapp.core.agent.session.AgentMessage.Role.ASSISTANT -> {
+                    append("## 🤖 Assistant\n\n")
+                    msg.thinkingSegmentsSafe.forEachIndexed { i, seg ->
+                        val c = seg.content.trim()
+                        if (c.isBlank()) return@forEachIndexed
+                        append("> **").append(thinkingHeader)
+                        if (msg.thinkingSegmentsSafe.size > 1) append(" (${i + 1})")
+                        append("**\n>\n")
+                        c.lines().forEach { line -> append("> ").append(line).append('\n') }
+                        append('\n')
+                    }
+                    msg.toolCalls.forEach { tc -> appendToolCall(tc) }
+                    val prose = AgentViewModel.stripInlineMarkers(msg.content).trim()
+                    if (prose.isNotEmpty()) append(prose).append('\n')
+                }
+                com.webtoapp.core.agent.session.AgentMessage.Role.SYSTEM -> {
+                    append("## ⚙️ System\n\n")
+                    append(msg.content.trim()).append('\n')
+                }
+            }
+        }
+    }
+
+    private fun StringBuilder.appendToolCall(tc: RecordedToolCall) {
+        append("\n### 🔧 ").append(tc.name).append('\n')
+        val args = tc.argumentsJson.trim()
+        if (args.isNotEmpty() && args != "{}") {
+            append("\n```json\n").append(args).append("\n```\n")
+        }
+        val result = tc.resultPreview.trim()
+        if (result.isNotEmpty() && result != RecordedToolCall.RUNNING_SENTINEL) {
+            append("\n```\n").append(result).append("\n```\n")
+        }
+        append('\n')
+    }
+}

--- a/app/src/main/java/com/webtoapp/ui/agent/components/SyntaxHighlight.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/SyntaxHighlight.kt
@@ -1,0 +1,202 @@
+package com.webtoapp.ui.agent.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import com.webtoapp.ui.theme.AppColors
+
+/**
+ * Lightweight regex-based syntax highlighting for fenced code blocks in the
+ * agent timeline. Produces an [AnnotatedString] of per-line colored spans
+ * (keyword / string / comment / number / function) mapped onto the existing
+ * [AppColors] editor palette. Unknown or unlabeled languages return null and
+ * the caller falls back to plain monochrome text.
+ *
+ * This is intentionally NOT a real lexer: no new dependencies (per project
+ * policy), streaming-friendly (per-line, O(n)), and safe on malformed input.
+ */
+object SyntaxHighlight {
+
+    /** Highlighting is skipped above this size to keep streaming smooth. */
+    const val MAX_HIGHLIGHT_CHARS = 20_000
+
+    /** Returns a highlighted string, or null when the language is unsupported. */
+    fun highlight(code: String, language: String?): AnnotatedString? {
+        if (code.length > MAX_HIGHLIGHT_CHARS) return null
+        val rules = rulesFor(language) ?: return null
+        return buildAnnotatedString {
+            code.splitToSequence("\n").forEachIndexed { index, line ->
+                if (index > 0) append('\n')
+                highlightLine(line, rules)
+            }
+        }
+    }
+
+    /** True when [language] has a rule set (used to decide plain vs highlighted). */
+    fun supports(language: String?): Boolean = rulesFor(language) != null
+
+    private fun AnnotatedString.Builder.highlightLine(line: String, rules: LanguageRules) {
+        var index = 0
+        val plain = SpanStyle(color = AppColors.CodeForeground)
+        while (index < line.length) {
+            var best: MatchResult? = null
+            var bestRule: TokenRule? = null
+            for (rule in rules.tokens) {
+                val m = rule.regex.find(line, index) ?: continue
+                if (m.range.first == index && (best == null || m.value.length > best.value.length)) {
+                    best = m
+                    bestRule = rule
+                }
+            }
+            if (best != null && bestRule != null) {
+                withStyle(bestRule.style) { append(best.value) }
+                index = best.range.last + 1
+            } else {
+                withStyle(plain) { append(line[index]) }
+                index++
+            }
+        }
+    }
+
+    private class TokenRule(val regex: Regex, val style: SpanStyle)
+
+    private class LanguageRules(val tokens: List<TokenRule>)
+
+    private val keywordStyle = SpanStyle(color = AppColors.CodeKeyword)
+    private val stringStyle = SpanStyle(color = AppColors.CodeString)
+    private val commentStyle = SpanStyle(color = AppColors.CodeComment)
+    private val numberStyle = SpanStyle(color = AppColors.CodeNumber)
+    private val functionStyle = SpanStyle(color = AppColors.CodeFunction)
+
+    private fun rules(vararg pairs: Pair<String, SpanStyle>): LanguageRules =
+        LanguageRules(pairs.map { TokenRule(Regex(it.first), it.second) })
+
+    private fun keywords(vararg words: String): String =
+        "\\b(?:${words.joinToString("|") { Regex.escape(it) }})\\b"
+
+    private val cLikeRules = rules(
+        "//[^\n]*" to commentStyle,
+        "/\\*(?:.|\\n)*?\\*/" to commentStyle,
+        "\"(?:\\\\.|[^\"\\\\\\n])*\"" to stringStyle,
+        "'(?:\\\\.|[^'\\\\\\n])+'" to stringStyle,
+        "`(?:\\\\.|[^`\\\\])*`" to stringStyle,
+        "\\b\\d[\\d_]*(?:\\.[\\d_]+)?[fLdD]?\\b" to numberStyle,
+        keywords(
+            "fun", "val", "var", "class", "object", "interface", "return", "if", "else",
+            "when", "for", "while", "do", "try", "catch", "finally", "throw", "throws",
+            "new", "this", "super", "null", "true", "false", "import", "package",
+            "public", "private", "protected", "internal", "override", "suspend",
+            "companion", "data", "sealed", "enum", "static", "final", "abstract",
+            "void", "int", "long", "double", "float", "boolean", "char", "byte", "short",
+            "extends", "implements", "instanceof", "in", "is", "as", "by", "init",
+            "constructor", "get", "set", "lateinit", "const", "inline", "reified",
+            "typealias", "vararg", "out", "break", "continue", "else", "super", "this"
+        ) to keywordStyle,
+        "\\b[A-Za-z_][A-Za-z0-9_]*(?=\\s*\\()" to functionStyle
+    )
+
+    private val jsRules = rules(
+        "//[^\n]*" to commentStyle,
+        "/\\*(?:.|\\n)*?\\*/" to commentStyle,
+        "\"(?:\\\\.|[^\"\\\\\\n])*\"" to stringStyle,
+        "'(?:\\\\.|[^'\\\\\\n])*'" to stringStyle,
+        "`(?:\\\\.|[^`\\\\])*`" to stringStyle,
+        "\\b\\d[\\d_]*(?:\\.[\\d_]+)?\\b" to numberStyle,
+        keywords(
+            "function", "const", "let", "var", "return", "if", "else", "for", "while",
+            "do", "switch", "case", "default", "break", "continue", "try", "catch",
+            "finally", "throw", "new", "delete", "typeof", "instanceof", "in", "of",
+            "class", "extends", "super", "this", "import", "export", "from", "async",
+            "await", "yield", "null", "undefined", "true", "false", "void", "static", "get", "set"
+        ) to keywordStyle,
+        "\\b[A-Za-z_$][A-Za-z0-9_$]*(?=\\s*\\()" to functionStyle
+    )
+
+    private val pythonRules = rules(
+        "#[^\n]*" to commentStyle,
+        "\"\"\"(?:.|\\n)*?\"\"\"" to stringStyle,
+        "'''(?:.|\\n)*?'''" to stringStyle,
+        "\"(?:\\\\.|[^\"\\\\\\n])*\"" to stringStyle,
+        "'(?:\\\\.|[^'\\\\\\n])*'" to stringStyle,
+        "\\b\\d[\\d_]*(?:\\.[\\d_]+)?\\b" to numberStyle,
+        keywords(
+            "def", "class", "return", "if", "elif", "else", "for", "while", "try",
+            "except", "finally", "raise", "import", "from", "as", "pass", "break",
+            "continue", "with", "lambda", "yield", "global", "nonlocal", "assert",
+            "del", "in", "is", "not", "and", "or", "None", "True", "False", "async", "await", "print"
+        ) to keywordStyle,
+        "\\b[A-Za-z_][A-Za-z0-9_]*(?=\\s*\\()" to functionStyle
+    )
+
+    private val jsonRules = rules(
+        "\"(?:\\\\.|[^\"\\\\\\n])*\"(?=\\s*:)" to keywordStyle,
+        "\"(?:\\\\.|[^\"\\\\\\n])*\"" to stringStyle,
+        "-?\\b\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\b" to numberStyle,
+        "\\b(?:true|false|null)\\b" to keywordStyle
+    )
+
+    private val markupRules = rules(
+        "<!--(?:.|\\n)*?-->" to commentStyle,
+        "</?[A-Za-z][A-Za-z0-9-]*" to keywordStyle,
+        "/?>" to keywordStyle,
+        "\\b[A-Za-z-]+(?==)" to functionStyle,
+        "\"(?:\\\\.|[^\"\\\\\\n])*\"" to stringStyle,
+        "'(?:\\\\.|[^'\\\\\\n])*'" to stringStyle
+    )
+
+    private val bashRules = rules(
+        "#[^\n]*" to commentStyle,
+        "\"(?:\\\\.|[^\"\\\\\\n])*\"" to stringStyle,
+        "'(?:\\\\.|[^'\\\\\\n])*'" to stringStyle,
+        "\\$\\{?[A-Za-z_][A-Za-z0-9_]*\\}?" to numberStyle,
+        keywords(
+            "if", "then", "else", "elif", "fi", "for", "while", "until", "do", "done",
+            "case", "esac", "in", "function", "return", "local", "export", "echo",
+            "cd", "ls", "mkdir", "rm", "cp", "mv", "cat", "grep", "sed", "awk",
+            "chmod", "chown", "sudo", "curl", "wget", "tar", "unzip", "source", "set", "exit"
+        ) to keywordStyle
+    )
+
+    private val cssRules = rules(
+        "/\\*(?:.|\\n)*?\\*/" to commentStyle,
+        "\"(?:\\\\.|[^\"\\\\\\n])*\"" to stringStyle,
+        "'(?:\\\\.|[^'\\\\\\n])*'" to stringStyle,
+        "[.#]?[A-Za-z-][A-Za-z0-9-]*(?=\\s*[{,])" to functionStyle,
+        "\\b\\d+(?:\\.\\d+)?(?:px|em|rem|%|vh|vw|s|ms|deg|fr)?\\b" to numberStyle,
+        "\\b[a-zA-Z-]+(?=\\s*:)" to keywordStyle
+    )
+
+    private val sqlRules = rules(
+        "--[^\n]*" to commentStyle,
+        "'(?:''|[^'\\n])*'" to stringStyle,
+        "\\b\\d+(?:\\.\\d+)?\\b" to numberStyle,
+        Regex("select|insert|update|delete|from|where|join|left|right|inner|outer|on|group|order|by|having|limit|offset|create|table|alter|drop|index|values|set|into|and|or|not|null|primary|key|foreign|references|unique|default|as|distinct|union|all|exists|like|in|between|is", RegexOption.IGNORE_CASE).pattern to keywordStyle
+    )
+
+    private fun rulesFor(language: String?): LanguageRules? {
+        return when (language?.trim()?.lowercase()) {
+            "kotlin", "kt", "kts", "java", "scala", "c", "cpp", "c++", "cs", "csharp",
+            "go", "rust", "swift", "dart", "groovy" -> cLikeRules
+            "js", "jsx", "javascript", "ts", "tsx", "typescript", "vue", "node" -> jsRules
+            "py", "python", "python3" -> pythonRules
+            "json", "jsonc" -> jsonRules
+            "html", "xml", "xhtml", "svg", "vue-html", "md-html" -> markupRules
+            "sh", "bash", "zsh", "shell", "console", "terminal" -> bashRules
+            "css", "scss", "sass", "less" -> cssRules
+            "sql", "sqlite", "mysql", "postgres", "postgresql" -> sqlRules
+            else -> null
+        }
+    }
+
+    /** Visible for tests: the palette used for a token kind. */
+    internal val palette: Map<String, Color>
+        get() = mapOf(
+            "keyword" to AppColors.CodeKeyword,
+            "string" to AppColors.CodeString,
+            "comment" to AppColors.CodeComment,
+            "number" to AppColors.CodeNumber,
+            "function" to AppColors.CodeFunction
+        )
+}

--- a/app/src/test/java/com/webtoapp/core/agent/MarkdownTableParseTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/MarkdownTableParseTest.kt
@@ -1,0 +1,67 @@
+package com.webtoapp.core.agent
+
+import com.webtoapp.ui.agent.components.parseMarkdownBlocks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkdownTableParseTest {
+
+    @Test
+    fun `pipe table parses into header and rows`() {
+        val text = """
+            | Name | Age |
+            | --- | --- |
+            | Alice | 30 |
+            | Bob | 25 |
+        """.trimIndent()
+
+        val blocks = parseMarkdownBlocks(text)
+
+        assertEquals(1, blocks.size)
+        val table = blocks[0] as com.webtoapp.ui.agent.components.MdBlock.Table
+        assertEquals(listOf("Name", "Age"), table.header)
+        assertEquals(listOf(listOf("Alice", "30"), listOf("Bob", "25")), table.rows)
+    }
+
+    @Test
+    fun `separator row with alignment colons is accepted`() {
+        val text = "| A | B |\n| :--- | ---: |\n| 1 | 2 |"
+        val table = parseMarkdownBlocks(text).single() as com.webtoapp.ui.agent.components.MdBlock.Table
+        assertEquals(listOf("A", "B"), table.header)
+        assertEquals(listOf(listOf("1", "2")), table.rows)
+    }
+
+    @Test
+    fun `rows are normalized to header width`() {
+        val text = "| A | B | C |\n| --- | --- | --- |\n| 1 |"
+        val table = parseMarkdownBlocks(text).single() as com.webtoapp.ui.agent.components.MdBlock.Table
+        assertEquals(listOf("1", "", ""), table.rows[0])
+    }
+
+    @Test
+    fun `pipe-looking text without separator stays a paragraph`() {
+        val text = "| not | a |\n| table at all |"
+        val blocks = parseMarkdownBlocks(text)
+        assertTrue(blocks.all { it is com.webtoapp.ui.agent.components.MdBlock.Paragraph })
+    }
+
+    @Test
+    fun `table interrupts and resumes surrounding content`() {
+        val text = """
+            Intro paragraph.
+
+            | H |
+            | --- |
+            | x |
+
+            # Heading after
+        """.trimIndent()
+
+        val blocks = parseMarkdownBlocks(text)
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[0] is com.webtoapp.ui.agent.components.MdBlock.Paragraph)
+        assertTrue(blocks[1] is com.webtoapp.ui.agent.components.MdBlock.Table)
+        assertTrue(blocks[2] is com.webtoapp.ui.agent.components.MdBlock.Heading)
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/agent/SessionTranscriptTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/SessionTranscriptTest.kt
@@ -1,0 +1,120 @@
+package com.webtoapp.core.agent
+
+import com.webtoapp.core.agent.session.AgentMessage
+import com.webtoapp.core.agent.session.AgentSession
+import com.webtoapp.core.agent.session.RecordedToolCall
+import com.webtoapp.core.agent.session.ThinkingSegmentData
+import com.webtoapp.core.agent.session.UserAttachment
+import com.webtoapp.ui.agent.components.SessionTranscript
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionTranscriptTest {
+
+    private fun session(vararg messages: AgentMessage) = AgentSession(
+        id = "s-1",
+        title = "My Session",
+        messages = messages.toList(),
+        createdAt = 1_700_000_000_000L,
+        updatedAt = 1_700_000_600_000L
+    )
+
+    @Test
+    fun `transcript includes title meta and both roles`() {
+        val md = SessionTranscript.render(
+            session(
+                AgentMessage(id = "1", role = AgentMessage.Role.USER, content = "hello", timestamp = 1L),
+                AgentMessage(id = "2", role = AgentMessage.Role.ASSISTANT, content = "hi there", timestamp = 2L)
+            ),
+            thinkingHeader = "💭 Thinking"
+        )
+
+        assertTrue(md.startsWith("# My Session"))
+        assertTrue(md.contains("- ID: `s-1`"))
+        assertTrue(md.contains("## 👤 User"))
+        assertTrue(md.contains("hello"))
+        assertTrue(md.contains("## 🤖 Assistant"))
+        assertTrue(md.contains("hi there"))
+    }
+
+    @Test
+    fun `thinking segments render as quoted blocks with the given header`() {
+        val md = SessionTranscript.render(
+            session(
+                AgentMessage(
+                    id = "2", role = AgentMessage.Role.ASSISTANT, content = "answer", timestamp = 2L,
+                    thinkingSegments = listOf(ThinkingSegmentData(id = "th-1", content = "let me think"))
+                )
+            ),
+            thinkingHeader = "💭 Thinking"
+        )
+
+        assertTrue(md.contains("> **💭 Thinking**"))
+        assertTrue(md.contains("> let me think"))
+    }
+
+    @Test
+    fun `tool calls render as fenced blocks and running sentinel is hidden`() {
+        val md = SessionTranscript.render(
+            session(
+                AgentMessage(
+                    id = "2", role = AgentMessage.Role.ASSISTANT, content = "", timestamp = 2L,
+                    toolCalls = listOf(
+                        RecordedToolCall("t1", "Read", """{"path":"a.kt"}""", "file body", ok = true),
+                        RecordedToolCall("t2", "Glob", "{}", RecordedToolCall.RUNNING_SENTINEL, ok = true)
+                    )
+                )
+            ),
+            thinkingHeader = "💭 Thinking"
+        )
+
+        assertTrue(md.contains("### 🔧 Read"))
+        assertTrue(md.contains("```json"))
+        assertTrue(md.contains("file body"))
+        assertFalse(md.contains("__running__"))
+    }
+
+    @Test
+    fun `inline engine markers are stripped from prose`() {
+        val md = SessionTranscript.render(
+            session(
+                AgentMessage(id = "2", role = AgentMessage.Role.ASSISTANT, content = "before⁣TC:t1⁣after", timestamp = 2L)
+            ),
+            thinkingHeader = "💭 Thinking"
+        )
+
+        assertTrue(md.contains("beforeafter"))
+        assertFalse(md.contains("TC:t1"))
+    }
+
+    @Test
+    fun `legacy message without structured fields exports safely`() {
+        // Gson-era sessions may lack attachments/segments entirely; the safe
+        // accessors must make the export non-crashing by construction.
+        val md = SessionTranscript.render(
+            session(
+                AgentMessage(
+                    id = "1", role = AgentMessage.Role.USER, content = "hi", timestamp = 1L,
+                    attachments = emptyList(), userAttachments = emptyList(), mentionedFiles = emptyList()
+                )
+            ),
+            thinkingHeader = "💭 Thinking"
+        )
+        assertTrue(md.contains("hi"))
+    }
+
+    @Test
+    fun `user attachments are listed`() {
+        val md = SessionTranscript.render(
+            session(
+                AgentMessage(
+                    id = "1", role = AgentMessage.Role.USER, content = "see this", timestamp = 1L,
+                    userAttachments = listOf(UserAttachment("/tmp/x.png", "x.png", "image/png", true))
+                )
+            ),
+            thinkingHeader = "💭 Thinking"
+        )
+        assertTrue(md.contains("- 📎 x.png"))
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/agent/SyntaxHighlightTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/SyntaxHighlightTest.kt
@@ -1,0 +1,59 @@
+package com.webtoapp.core.agent
+
+import com.webtoapp.ui.agent.components.SyntaxHighlight
+import com.webtoapp.ui.theme.AppColors
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SyntaxHighlightTest {
+
+    private fun colorAt(annotated: androidx.compose.ui.text.AnnotatedString, offset: Int) =
+        annotated.spanStyles.firstOrNull { offset >= it.start && offset < it.end }?.item?.color
+
+    @Test
+    fun `kotlin keywords strings and comments get distinct colors`() {
+        val code = """fun greet(name: String) = "hi" // friendly"""
+        val annotated = SyntaxHighlight.highlight(code, "kotlin")!!
+
+        assertEquals(AppColors.CodeKeyword, colorAt(annotated, code.indexOf("fun")))
+        assertEquals(AppColors.CodeString, colorAt(annotated, code.indexOf("\"hi\"")))
+        assertEquals(AppColors.CodeComment, colorAt(annotated, code.indexOf("// friendly")))
+        assertEquals(AppColors.CodeFunction, colorAt(annotated, code.indexOf("greet")))
+    }
+
+    @Test
+    fun `json keys and values are distinguished`() {
+        val code = """{"name": "value", "n": 42}"""
+        val annotated = SyntaxHighlight.highlight(code, "json")!!
+
+        assertEquals(AppColors.CodeKeyword, colorAt(annotated, code.indexOf("\"name\"")))
+        assertEquals(AppColors.CodeString, colorAt(annotated, code.indexOf("\"value\"")))
+        assertEquals(AppColors.CodeNumber, colorAt(annotated, code.indexOf("42")))
+    }
+
+    @Test
+    fun `unknown language returns null so caller falls back to plain text`() {
+        assertNull(SyntaxHighlight.highlight("some text", "brainfuck"))
+        assertNull(SyntaxHighlight.highlight("some text", null))
+    }
+
+    @Test
+    fun `oversized input is skipped for performance`() {
+        val big = "a".repeat(SyntaxHighlight.MAX_HIGHLIGHT_CHARS + 1)
+        assertNull(SyntaxHighlight.highlight(big, "kotlin"))
+    }
+
+    @Test
+    fun `multiline input keeps line structure and supports each family`() {
+        for (lang in listOf("kotlin", "python", "javascript", "bash", "sql", "css", "html")) {
+            assertTrue("expected support for $lang", SyntaxHighlight.supports(lang))
+        }
+        val code = "#!/bin/bash\necho \"hi\" # say hi"
+        val annotated = SyntaxHighlight.highlight(code, "bash")!!
+        assertEquals(annotated.text, code)
+        assertEquals(AppColors.CodeComment, colorAt(annotated, code.lastIndexOf("#")))
+    }
+}


### PR DESCRIPTION
## Summary

Overhaul the Agent chat UI across four areas while keeping **zero persistence-format changes** (overwrite-update safe; `SessionStoreLegacyJsonTest` stays green).

## Changes

### 1. Composer rework
- Unified elevated card wrapping attachment thumbnails, the growing text field, and a bottom action row with an embedded circular send/stop button (40dp).
- Image attachments show real Coil thumbnails with an overlay remove badge; file/folder attachments get a compact chip with ellipsis.
- Mode chip row (auto-approve, slash, context, tokens, model) restyled consistently.

### 2. Rendering optimization
- **Performance**: text/thinking UI pushes are now throttled to ~66ms (mirrors the existing 48ms tool-push pattern). Previously every `TextDelta` re-parsed and recomposed the entire timeline (O(n²) per token).
- **Markdown**: GFM pipe tables (horizontally scrollable, zebra rows, inline cell styling); clickable links via `LinkAnnotation.Url` for both `[label](url)` and bare URLs.
- **Code blocks**: lightweight regex-based syntax highlighting (zero new dependencies) for Kotlin/Java, JS/TS, Python, JSON, HTML/XML, Bash, CSS, SQL, mapped onto the existing `AppColors` editor palette. Streaming blocks stay plain; blocks >20k chars fall back to plain.
- Copy formatting no longer hard-codes "💭 思考过程"; uses `Strings.agentCopyThinkingHeader`.

### 3. Tool-call rendering rework
- Left status stripe (running/success/error) spanning the full card height via `IntrinsicSize.Min`.
- Per-tool icon mapping, live elapsed timer (ticking while running, frozen after).
- Failed tools get an errorContainer-tinted card.
- Truncated results get a "View full output" row opening a scrollable dialog with copy.
- Glob/Grep/ListFiles get a file-list body instead of a raw text blob.

### 4. Drawer rework
- `WtaTabRow` with badge counts instead of M3 `TabRow`.
- Session rows get a ⋯ overflow menu: **Rename** (wires up the previously dead `SessionStore.rename`), **Export** (new `SessionTranscript` pure function → Markdown → FileProvider share), **Delete** (now requires confirmation).
- Search box now filters the Files tab too; file rows gain **Delete** with confirmation.

## Compatibility
- No changes to `core/agent/session/*` or `core/agent/runtime/*` (untouched by design).
- All new code reads messages via the existing `*Safe` accessors.
- No `else ->` in new `when(lang)` blocks; translation parity gates pass.
- `SessionStoreLegacyJsonTest` and the full 1120-test suite pass in an isolated worktree.

## Test plan
- [x] `SyntaxHighlightTest` (5 tests)
- [x] `MarkdownTableParseTest` (5 tests)
- [x] `SessionTranscriptTest` (6 tests)
- [x] Full unit suite green (1120 tests, 0 failures)
- [ ] Emulator visual verification (waived per user request)

Files touched (all in `ui/agent/**` + `Strings.kt` + 3 test files):
- `app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt`
- `app/src/main/java/com/webtoapp/ui/agent/components/MarkdownText.kt`
- `app/src/main/java/com/webtoapp/ui/agent/components/CodeRenderer.kt`
- `app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt`
- `app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt`
- `app/src/main/java/com/webtoapp/ui/agent/components/SyntaxHighlight.kt` (new)
- `app/src/main/java/com/webtoapp/ui/agent/components/SessionTranscript.kt` (new)
- `app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt`
- `app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt`
- `app/src/main/java/com/webtoapp/core/i18n/Strings.kt` (11 new keys × 10 languages)
- `app/src/test/java/com/webtoapp/core/agent/SyntaxHighlightTest.kt` (new)
- `app/src/test/java/com/webtoapp/core/agent/MarkdownTableParseTest.kt` (new)
- `app/src/test/java/com/webtoapp/core/agent/SessionTranscriptTest.kt` (new)
