### PR TITLE
fix(agent): repair turn pipeline, follow behavior, and surface app changes

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -80,6 +80,9 @@ class AgentEngine(
                 val pending = LinkedHashMap<String, Pair<String, StringBuilder>>()
                 // Index in accText where this attempt's output begins; a recoverable-error
                 // retry rewrites from here instead of appending a duplicate attempt.
+                // RETRY-PATH ONLY: inside the event handlers accText is append-only —
+                // rebuilding per event truncated the accumulated buffer to the turn start
+                // and left `accumulated` holding just the newest fragment (#749 regression).
                 var attemptStartedIndex = accText.length
                 fun rebuildAccFromPrefix() {
                     if (accText.length > attemptStartedIndex) {
@@ -130,8 +133,13 @@ class AgentEngine(
                         when (ev) {
                             is LlmEvent.Started -> Unit
                             is LlmEvent.TextDelta -> {
+                                // Append-only within an attempt. Calling rebuildAccFromPrefix()
+                                // here (as #749 briefly did) truncated accText back to the
+                                // turn start on EVERY delta, so `accumulated` held only the
+                                // newest fragment: the live timeline rendered the body in
+                                // replacing chunks and the persisted message ended up as the
+                                // last delta alone.
                                 turnText.append(ev.delta)
-                                rebuildAccFromPrefix()
                                 accText.append(ev.delta)
                                 send(AgentEvent.TextDelta(ev.delta, accText.toString()))
                             }
@@ -143,7 +151,6 @@ class AgentEngine(
                                 if (turnThinking.isEmpty()) {
                                     val segmentId = "th-turn-$turn"
                                     val marker = "⁣TH:$segmentId⁣"
-                                    rebuildAccFromPrefix()
                                     accText.append(marker)
                                     send(AgentEvent.TextDelta(marker, accText.toString()))
                                 }
@@ -154,7 +161,6 @@ class AgentEngine(
                                 pending[ev.id] = ev.name to StringBuilder()
 
                                 val marker = "⁣TC:${ev.id}⁣"
-                                rebuildAccFromPrefix()
                                 accText.append(marker)
                                 send(AgentEvent.TextDelta(marker, accText.toString()))
                                 send(AgentEvent.ToolCallStarted(ev.id, ev.name))
@@ -238,8 +244,14 @@ class AgentEngine(
                 )
 
                 if (assistantToolCalls.isEmpty()) {
+                    // Zero text and zero tool calls is a real outcome (some gateways
+                    // open the stream, emit Done, and close without any delta). An
+                    // empty summary made the turn LOOK successful while persisting
+                    // nothing — surface a distinct, diagnosable message instead.
                     send(AgentEvent.Completed(
-                        summary = turnText.toString().trim().ifEmpty { accText.toString().trim() },
+                        summary = turnText.toString().trim()
+                            .ifEmpty { accText.toString().trim() }
+                            .ifEmpty { Strings.agentEmptyResponse },
                         toolCallCount = totalToolCalls
                     ))
                     return@channelFlow
@@ -318,6 +330,7 @@ class AgentEngine(
     ) {
         out.send(AgentEvent.ToolFinished(call.id, call.name, call.argumentsJson, result))
         result.fileChange?.let { out.send(AgentEvent.FileChanged(it)) }
+        result.appChange?.let { out.send(AgentEvent.AppChanged(it)) }
         result.builtApk?.let { out.send(AgentEvent.ApkBuilt(it)) }
     }
 

--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEvent.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEvent.kt
@@ -1,5 +1,6 @@
 package com.webtoapp.core.agent.engine
 
+import com.webtoapp.core.agent.tool.AppChange
 import com.webtoapp.core.agent.tool.BuiltApkInfo
 import com.webtoapp.core.agent.tool.FileChange
 import com.webtoapp.core.agent.tool.ToolResult
@@ -40,6 +41,9 @@ sealed class AgentEvent {
     ) : AgentEvent()
 
     data class FileChanged(val change: FileChange) : AgentEvent()
+
+    /** An app was created or updated by a tool; surfaced as a review card below the chat. */
+    data class AppChanged(val change: AppChange) : AgentEvent()
 
     /** An APK was built by a tool; surfaced as a virtual file in the Files sidebar. */
     data class ApkBuilt(val info: BuiltApkInfo) : AgentEvent()

--- a/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
@@ -65,7 +65,9 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
                     try { Thread.sleep(1000) } catch (_: InterruptedException) {}
                     executeCall(req, isRetry = true, inFlight = inFlight)
                 } else {
-                    trySend(LlmEvent.Error(e.message ?: "Network error")); close()
+                    // Include the endpoint so a connection-level failure is
+                    // attributable to a specific base URL, not just "network error".
+                    trySend(LlmEvent.Error("Network error: ${e.message ?: "connection failed"} [$url]")); close()
                 }
             }
             override fun onResponse(call: Call, response: Response) {

--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -292,7 +292,7 @@ class AgentService : Service() {
                 _activeTurn.value = null
             }
             is AgentEvent.PermissionDenied, is AgentEvent.Usage, is AgentEvent.Notice,
-            is AgentEvent.ApkBuilt,
+            is AgentEvent.ApkBuilt, is AgentEvent.AppChanged,
             AgentEvent.Started -> {
                 // No persistence impact.
             }
@@ -460,7 +460,7 @@ class AgentService : Service() {
  * persisted as a draft (and finalized) independently of any UI scope. Mirrors the
  * ViewModel's in-memory buffers but is purely data-oriented and persistence-driven.
  */
-private class TurnAccumulator(private val sessionId: String) {
+internal class TurnAccumulator(private val sessionId: String) {
     private val text = StringBuilder()
     private val thinkingSegments = mutableListOf<ThinkingSegment>()
     private val tools = LinkedHashMap<String, RecordedToolCall>()
@@ -613,8 +613,15 @@ private class TurnAccumulator(private val sessionId: String) {
         val raw = text.toString().trim()
         val joined = joinedThinking()
         val segs = buildThinkingSegmentData()
-        val hasSubstance = stripAllMarkers(raw).isNotBlank() || !joined.isNullOrBlank() || tools.isNotEmpty()
-        if (!hasSubstance) return null
+        val fallbackText = stripAllMarkers(summaryFallback.orEmpty()).trim()
+        // A turn that produced no streamed substance still owes a durable record when
+        // it ended abnormally (errorSuffix) or completed with an explicit summary
+        // (the engine's empty-response notice): returning null here is what made a
+        // fast request failure look like a silent empty response. Only a substance-less
+        // ABORT may still be dropped — the user cancelled deliberately.
+        val hasSubstance = stripAllMarkers(raw).isNotBlank() || !joined.isNullOrBlank() ||
+            tools.isNotEmpty() || fallbackText.isNotBlank()
+        if (!hasSubstance && errorSuffix == null) return null
 
         val baseText = if (stripAllMarkers(raw).isNotBlank()) raw
                        else stripAllMarkers(summaryFallback.orEmpty()).trim()

--- a/app/src/main/java/com/webtoapp/core/agent/tool/ToolResult.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/ToolResult.kt
@@ -6,7 +6,8 @@ data class ToolResult(
     val images: List<ImageAttachment> = emptyList(),
     val fileChange: FileChange? = null,
     val planReviewPath: String? = null,
-    val builtApk: BuiltApkInfo? = null
+    val builtApk: BuiltApkInfo? = null,
+    val appChange: AppChange? = null
 ) {
     val isMultimodal: Boolean get() = images.isNotEmpty()
 
@@ -82,4 +83,21 @@ data class FileChange(
     val newContent: String? = null
 ) {
     enum class Kind { WRITE, EDIT, DELETE }
+}
+
+/**
+ * Metadata about an app created or modified by [com.webtoapp.core.agent.tool.builtin.CreateAppTool]
+ * or [com.webtoapp.core.agent.tool.builtin.UpdateAppTool]. Surfaced as an "app changes" review
+ * card below the conversation so the user sees WHAT changed after a turn and can jump straight
+ * to the app's editor — mirroring how [FileChange] powers the file-changes review card.
+ */
+data class AppChange(
+    val appId: Long,
+    val appName: String,
+    val appType: String,
+    val kind: Kind,
+    /** For UPDATE: the top-level manifest keys the patch touched, in patch order. */
+    val changedFields: List<String> = emptyList()
+) {
+    enum class Kind { CREATE, UPDATE }
 }

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/CreateAppTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/CreateAppTool.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.webtoapp.core.agent.export.DetectedArtifact
 import com.webtoapp.core.agent.export.SaveSessionAsAppUseCase
+import com.webtoapp.core.agent.tool.AppChange
 import com.webtoapp.core.agent.tool.Tool
 import com.webtoapp.core.agent.tool.ToolContext
 import com.webtoapp.core.agent.tool.ToolResult
@@ -93,7 +94,15 @@ class CreateAppTool : Tool {
             updatedAt = now
         )
         val id = ctx.appRepository.createWebApp(app)
-        return ToolResult.ok("Created $appType app id=$id name=\"$name\".")
+        return ToolResult(
+            text = "Created $appType app id=$id name=\"$name\".",
+            appChange = AppChange(
+                appId = id,
+                appName = name,
+                appType = appType.name,
+                kind = AppChange.Kind.CREATE
+            )
+        )
     }
 
     private suspend fun createFromSource(
@@ -145,7 +154,15 @@ class CreateAppTool : Tool {
                         ctx.appRepository.updateWebApp(app.copy(iconPath = iconPath))
                     }
                 }
-                ToolResult.ok("Created $appType app id=${result.appId} name=\"${result.name}\".")
+                ToolResult(
+                    text = "Created $appType app id=${result.appId} name=\"${result.name}\".",
+                    appChange = AppChange(
+                        appId = result.appId,
+                        appName = result.name,
+                        appType = appType.name,
+                        kind = AppChange.Kind.CREATE
+                    )
+                )
             }
             is SaveSessionAsAppUseCase.Result.Failure ->
                 ToolResult.error("CreateApp failed: ${result.message}")
@@ -189,7 +206,15 @@ class CreateAppTool : Tool {
             themeType = DEFAULT_THEME
         )
         val id = ctx.appRepository.createWebApp(app)
-        return ToolResult.ok("Created WORDPRESS app id=$id name=\"$name\" (project $projectId).")
+        return ToolResult(
+            text = "Created WORDPRESS app id=$id name=\"$name\" (project $projectId).",
+            appChange = AppChange(
+                appId = id,
+                appName = name,
+                appType = AppType.WORDPRESS.name,
+                kind = AppChange.Kind.CREATE
+            )
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/UpdateAppTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/UpdateAppTool.kt
@@ -3,6 +3,7 @@ package com.webtoapp.core.agent.tool.builtin
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.webtoapp.core.agent.tool.AppChange
 import com.webtoapp.core.agent.tool.Tool
 import com.webtoapp.core.agent.tool.ToolContext
 import com.webtoapp.core.agent.tool.ToolResult
@@ -48,6 +49,18 @@ class UpdateAppTool : Tool {
             updatedAt = System.currentTimeMillis()
         )
         ctx.appRepository.updateWebApp(safe)
-        return ToolResult.ok("Updated app id=${safe.id} name=\"${safe.name}\" (type ${safe.appType}).")
+        // The patch's top-level keys are exactly what the caller asked to change —
+        // they drive the "what changed" line on the app-changes review card.
+        val changedFields = patch.takeIf { it.isJsonObject }?.asJsonObject?.keySet()?.toList().orEmpty()
+        return ToolResult(
+            text = "Updated app id=${safe.id} name=\"${safe.name}\" (type ${safe.appType}).",
+            appChange = AppChange(
+                appId = safe.id,
+                appName = safe.name,
+                appType = safe.appType.name,
+                kind = AppChange.Kind.UPDATE,
+                changedFields = changedFields
+            )
+        )
     }
 }

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1543,6 +1543,11 @@ object Strings {
     val agentChangesReviewExpand: String get() = StringsB.agentChangesReviewExpand
     val agentChangesReviewCollapse: String get() = StringsB.agentChangesReviewCollapse
     val agentChangesUndoneToast: String get() = StringsB.agentChangesUndoneToast
+    val agentAppChangesHeader: String get() = StringsB.agentAppChangesHeader
+    val agentAppChangesKindCreate: String get() = StringsB.agentAppChangesKindCreate
+    val agentAppChangesKindUpdate: String get() = StringsB.agentAppChangesKindUpdate
+    val agentAppChangesOpen: String get() = StringsB.agentAppChangesOpen
+    val agentAppChangesFields: String get() = StringsB.agentAppChangesFields
     val agentPlanModeBadge: String get() = StringsB.agentPlanModeBadge
     val agentPlanModeNoPath: String get() = StringsB.agentPlanModeNoPath
     val agentPlanModeExitTooltip: String get() = StringsB.agentPlanModeExitTooltip
@@ -1601,6 +1606,7 @@ object Strings {
     val agentCodeCopy: String get() = StringsB.agentCodeCopy
     val agentTodoListHeader: String get() = StringsB.agentTodoListHeader
     val agentNoOutput: String get() = StringsB.agentNoOutput
+    val agentEmptyResponse: String get() = StringsB.agentEmptyResponse
     val agentAbortedHint: String get() = StringsB.agentAbortedHint
     val agentMissingTextModel: String get() = StringsB.agentMissingTextModel
     val agentMissingApiKey: String get() = StringsB.agentMissingApiKey
@@ -24593,6 +24599,66 @@ object StringsB {
         AppLanguage.JAPANESE -> "%d件の変更を元に戻しました"
         AppLanguage.KOREAN -> "%d개 변경 실행 취소됨"
     }
+    val agentAppChangesHeader: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "%d 个应用变更"
+        AppLanguage.ENGLISH -> "%d app changes"
+        AppLanguage.ARABIC -> "%d تغييرات على التطبيقات"
+        AppLanguage.PORTUGUESE -> "%d alterações em apps"
+        AppLanguage.SPANISH -> "%d cambios de apps"
+        AppLanguage.FRENCH -> "%d modifications d'apps"
+        AppLanguage.GERMAN -> "%d App-Änderungen"
+        AppLanguage.RUSSIAN -> "%d изменений приложений"
+        AppLanguage.JAPANESE -> "%d件のアプリ変更"
+        AppLanguage.KOREAN -> "%d개 앱 변경"
+    }
+    val agentAppChangesKindCreate: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "新建"
+        AppLanguage.ENGLISH -> "Created"
+        AppLanguage.ARABIC -> "إنشاء"
+        AppLanguage.PORTUGUESE -> "Criado"
+        AppLanguage.SPANISH -> "Creado"
+        AppLanguage.FRENCH -> "Créé"
+        AppLanguage.GERMAN -> "Erstellt"
+        AppLanguage.RUSSIAN -> "Создано"
+        AppLanguage.JAPANESE -> "作成"
+        AppLanguage.KOREAN -> "생성"
+    }
+    val agentAppChangesKindUpdate: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "更新"
+        AppLanguage.ENGLISH -> "Updated"
+        AppLanguage.ARABIC -> "تحديث"
+        AppLanguage.PORTUGUESE -> "Atualizado"
+        AppLanguage.SPANISH -> "Actualizado"
+        AppLanguage.FRENCH -> "Mis à jour"
+        AppLanguage.GERMAN -> "Aktualisiert"
+        AppLanguage.RUSSIAN -> "Обновлено"
+        AppLanguage.JAPANESE -> "更新"
+        AppLanguage.KOREAN -> "업데이트"
+    }
+    val agentAppChangesOpen: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "打开应用"
+        AppLanguage.ENGLISH -> "Open app"
+        AppLanguage.ARABIC -> "فتح التطبيق"
+        AppLanguage.PORTUGUESE -> "Abrir app"
+        AppLanguage.SPANISH -> "Abrir app"
+        AppLanguage.FRENCH -> "Ouvrir l'app"
+        AppLanguage.GERMAN -> "App öffnen"
+        AppLanguage.RUSSIAN -> "Открыть приложение"
+        AppLanguage.JAPANESE -> "アプリを開く"
+        AppLanguage.KOREAN -> "앱 열기"
+    }
+    val agentAppChangesFields: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "变更字段：%s"
+        AppLanguage.ENGLISH -> "Fields: %s"
+        AppLanguage.ARABIC -> "الحقول: %s"
+        AppLanguage.PORTUGUESE -> "Campos: %s"
+        AppLanguage.SPANISH -> "Campos: %s"
+        AppLanguage.FRENCH -> "Champs : %s"
+        AppLanguage.GERMAN -> "Felder: %s"
+        AppLanguage.RUSSIAN -> "Поля: %s"
+        AppLanguage.JAPANESE -> "フィールド: %s"
+        AppLanguage.KOREAN -> "필드: %s"
+    }
     val agentPlanModeBadge: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "Plan 模式"
         AppLanguage.ENGLISH -> "Plan Mode"
@@ -25292,6 +25358,18 @@ object StringsB {
         AppLanguage.RUSSIAN -> "(нет вывода)"
         AppLanguage.JAPANESE -> "(出力なし)"
         AppLanguage.KOREAN -> "(출력 없음)"
+    }
+    val agentEmptyResponse: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "模型返回了空响应（无文本、未调用工具）。若持续出现，请检查接口地址与模型名称是否匹配。"
+        AppLanguage.ENGLISH -> "The model returned an empty response (no text, no tool calls). If this persists, check that the endpoint and model name match."
+        AppLanguage.ARABIC -> "أعاد النموذج استجابة فارغة (لا نص ولا استدعاءات أدوات). إذا تكرر ذلك، تحقق من تطابق نقطة النهاية واسم النموذج."
+        AppLanguage.PORTUGUESE -> "O modelo retornou uma resposta vazia (sem texto e sem chamadas de ferramentas). Se persistir, verifique se o endpoint e o nome do modelo correspondem."
+        AppLanguage.SPANISH -> "El modelo devolvió una respuesta vacía (sin texto ni llamadas a herramientas). Si persiste, comprueba que el endpoint y el nombre del modelo coincidan."
+        AppLanguage.FRENCH -> "Le modèle a renvoyé une réponse vide (aucun texte, aucun appel d'outil). Si cela persiste, vérifiez que l'endpoint et le nom du modèle correspondent."
+        AppLanguage.GERMAN -> "Das Modell lieferte eine leere Antwort (kein Text, keine Tool-Aufrufe). Falls dies bestehen bleibt, prüfe, ob Endpunkt und Modellname zusammenpassen."
+        AppLanguage.RUSSIAN -> "Модель вернула пустой ответ (ни текста, ни вызовов инструментов). Если это повторяется, проверьте соответствие адреса endpoint и имени модели."
+        AppLanguage.JAPANESE -> "モデルが空の応答を返しました（テキストなし、ツール呼び出しなし）。続く場合は、エンドポイントとモデル名が一致しているか確認してください。"
+        AppLanguage.KOREAN -> "모델이 빈 응답을 반환했습니다(텍스트 없음, 도구 호출 없음). 계속되면 엔드포인트와 모델 이름이 일치하는지 확인하세요."
     }
     val agentAbortedHint: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "[已中断]"

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -117,7 +117,8 @@ import java.util.Locale
 @Composable
 fun AgentScreen(
     onBack: () -> Unit,
-    onOpenAiSettings: () -> Unit
+    onOpenAiSettings: () -> Unit,
+    onOpenApp: (Long) -> Unit = {}
 ) {
     val context = LocalContext.current
     val app = context.applicationContext as Application
@@ -338,6 +339,14 @@ fun AgentScreen(
                     onUndoOne = vm::undoChange,
                     onUndoAll = vm::undoAllChanges,
                     onClear = vm::clearChangesReview
+                )
+
+                com.webtoapp.ui.agent.components.AppChangesReviewCard(
+                    changes = state.pendingAppChanges,
+                    expanded = state.appChangesExpanded,
+                    onToggle = vm::toggleAppChangesReview,
+                    onClear = vm::clearAppChanges,
+                    onOpenApp = onOpenApp
                 )
                 if (state.editingMessageId != null) {
                     EditingHint(onCancel = vm::cancelEditing)
@@ -561,6 +570,24 @@ private fun Conversation(
         if (atBottom) followBottom = true
     }
 
+    // A fresh turn (Idle → Connecting) always re-attaches to the newest content.
+    // Without this, a followBottom left false from earlier history reading keeps
+    // the just-sent user message AND the whole streaming output off-screen —
+    // sending is an explicit action, so the view must jump to it. Manual scroll-up
+    // only detaches within a turn; the next send snaps back.
+    var wasWorking by remember { mutableStateOf(false) }
+    LaunchedEffect(state.isWorking) {
+        val working = state.isWorking
+        if (working && !wasWorking) {
+            followBottom = true
+            val target = totalContentItems - 1
+            if (target >= 0) {
+                runCatching { listState.scrollToItem(target) }
+            }
+        }
+        wasWorking = working
+    }
+
     val streamingTextLen = state.streamingText.length
     val streamingThinkingLen = state.streamingThinkingSegments.sumOf { it.content.length }
     LaunchedEffect(
@@ -579,12 +606,17 @@ private fun Conversation(
             val info = listState.layoutInfo
             val viewportBottom = info.viewportEndOffset - info.afterContentPadding
             val last = info.visibleItemsInfo.lastOrNull()
-            if (last != null) {
-                val lastBottom = last.offset + last.size
-                val gap = lastBottom - viewportBottom
+            if (last != null && last.index == info.totalItemsCount - 1) {
+                // The newest item is on screen — align its bottom edge with the viewport.
+                val gap = (last.offset + last.size) - viewportBottom
                 if (gap > 0) {
                     listState.scrollBy(gap.toFloat())
                 }
+            } else if (info.totalItemsCount > 0) {
+                // The newest item is entirely below the fold (a burst of output
+                // outgrew the viewport between pushes) — jump straight to it so
+                // following never stalls.
+                listState.scrollToItem(info.totalItemsCount - 1)
             }
 
             kotlinx.coroutines.yield()

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
@@ -83,6 +83,10 @@ data class AgentUiState(
 
     val changesReviewExpanded: Boolean = false,
 
+    val pendingAppChanges: List<PendingAppChange> = emptyList(),
+
+    val appChangesExpanded: Boolean = false,
+
     val error: String? = null,
     val info: String? = null,
 
@@ -152,6 +156,20 @@ data class PendingChange(
 ) {
     enum class Kind { Write, Edit, Delete }
 }
+
+/**
+ * An app created or updated by an agent tool this turn, pending review. Mirrors
+ * [PendingChange] for the app-changes review card: shown below the conversation
+ * after the turn ends, with what changed and a jump to the app's editor.
+ */
+data class PendingAppChange(
+    val appId: Long,
+    val appName: String,
+    val appType: String,
+    val created: Boolean,
+    val changedFields: List<String>,
+    val changedAt: Long
+)
 
 data class SlashCommand(
     val id: String,

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -244,6 +244,14 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         _ui.update { it.copy(changesReviewExpanded = !it.changesReviewExpanded) }
     }
 
+    fun toggleAppChangesReview() {
+        _ui.update { it.copy(appChangesExpanded = !it.appChangesExpanded) }
+    }
+
+    fun clearAppChanges() {
+        _ui.update { it.copy(pendingAppChanges = emptyList(), appChangesExpanded = false) }
+    }
+
     fun clearChangesReview() {
         val sid = _ui.value.currentSession?.id
         if (sid != null) {
@@ -1668,6 +1676,24 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                     )
                 }
             }
+            is AgentEvent.AppChanged -> {
+                // Same shape as FileChanged but for apps created/updated by tools:
+                // one review-card entry per app, newest first; a later change to the
+                // same app replaces its earlier entry instead of piling up duplicates.
+                _ui.update { state ->
+                    val ch = ev.change
+                    val entry = PendingAppChange(
+                        appId = ch.appId,
+                        appName = ch.appName,
+                        appType = ch.appType,
+                        created = ch.kind == com.webtoapp.core.agent.tool.AppChange.Kind.CREATE,
+                        changedFields = ch.changedFields,
+                        changedAt = System.currentTimeMillis()
+                    )
+                    val rest = state.pendingAppChanges.filterNot { it.appId == ch.appId }
+                    state.copy(pendingAppChanges = listOf(entry) + rest)
+                }
+            }
             is AgentEvent.ApkBuilt -> {
                 _ui.update { state ->
                     // Replace any previous build for the same appId, keep others.
@@ -1757,7 +1783,10 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 }
             }
             is AgentEvent.Failed -> {
-                // Error message is persisted by AgentService; just reset UI state.
+                // The service persists an error bubble into the session, but a request
+                // that dies before the first delta would otherwise leave NO visible
+                // trace at all (spinner stops, nothing rendered, nothing shown) —
+                // surface the reason here too so every failure is locatable.
                 streamingSessionId = null
                 streamText.clear(); streamThinkingSegments.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
                 _ui.update {
@@ -1766,7 +1795,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                         streamingText = "",
                         streamingThinkingSegments = emptyList(),
                         pendingToolCalls = emptyList(),
-                        currentActivity = null
+                        currentActivity = null,
+                        error = ev.message
                     )
                 }
             }
@@ -1950,6 +1980,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 pendingChanges = if (sessionChanged) emptyList() else it.pendingChanges,
                 builtApks = restoredApks,
                 changesReviewExpanded = if (sessionChanged) false else it.changesReviewExpanded,
+                pendingAppChanges = if (sessionChanged) emptyList() else it.pendingAppChanges,
+                appChangesExpanded = if (sessionChanged) false else it.appChangesExpanded,
 
                 previewFilePath = if (sessionChanged) null else it.previewFilePath,
                 drawerOpen = if (sessionChanged) false else it.drawerOpen

--- a/app/src/main/java/com/webtoapp/ui/agent/components/AppChangesReviewCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/AppChangesReviewCard.kt
@@ -1,0 +1,227 @@
+package com.webtoapp.ui.agent.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material.icons.outlined.AddCircle
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.webtoapp.core.i18n.Strings
+import com.webtoapp.ui.agent.PendingAppChange
+import com.webtoapp.ui.design.WtaAlpha
+import com.webtoapp.ui.design.WtaButton
+import com.webtoapp.ui.design.WtaButtonSize
+import com.webtoapp.ui.design.WtaButtonVariant
+import com.webtoapp.ui.design.WtaCard
+import com.webtoapp.ui.design.WtaCardTone
+import com.webtoapp.ui.design.WtaColors
+import com.webtoapp.ui.design.WtaInfoChip
+import com.webtoapp.ui.design.WtaSize
+import com.webtoapp.ui.design.WtaSpacing
+
+/**
+ * Review card for apps created/updated by agent tools during a turn — the app-facing
+ * counterpart of [ChangesReviewCard]. Shows what changed (name, type, patched fields)
+ * and jumps to the app's editor on tap.
+ */
+@Composable
+fun AppChangesReviewCard(
+    changes: List<PendingAppChange>,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    onClear: () -> Unit,
+    onOpenApp: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (changes.isEmpty()) return
+    Box(
+        modifier = modifier.padding(
+            horizontal = WtaSpacing.ScreenHorizontal,
+            vertical = WtaSpacing.Tiny + 2.dp
+        )
+    ) {
+        WtaCard(
+            tone = WtaCardTone.Elevated,
+            contentPadding = PaddingValues(0.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            HeaderRow(
+                count = changes.size,
+                expanded = expanded,
+                onToggle = onToggle,
+                onClear = onClear
+            )
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                Column {
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant
+                            .copy(alpha = WtaAlpha.Divider)
+                    )
+                    changes.forEach { change ->
+                        AppChangeRow(
+                            change = change,
+                            onOpen = { onOpenApp(change.appId) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderRow(
+    count: Int,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    onClear: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(
+                horizontal = WtaSpacing.Medium,
+                vertical = WtaSpacing.Small + 2.dp
+            ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+            contentDescription = if (expanded) Strings.agentChangesReviewCollapse
+            else Strings.agentChangesReviewExpand,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(WtaSize.IconSmall)
+        )
+        Spacer(Modifier.width(WtaSpacing.Small))
+        Text(
+            text = Strings.agentAppChangesHeader.format(count),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+        WtaButton(
+            onClick = onClear,
+            text = Strings.agentChangesReviewClear,
+            variant = WtaButtonVariant.Tonal,
+            size = WtaButtonSize.Small
+        )
+    }
+}
+
+@Composable
+private fun AppChangeRow(
+    change: PendingAppChange,
+    onOpen: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onOpen)
+            .padding(
+                horizontal = WtaSpacing.Medium,
+                vertical = WtaSpacing.Small
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+    ) {
+        KindBadge(created = change.created)
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = change.appName,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1
+            )
+            if (change.changedFields.isEmpty()) {
+                Text(
+                    text = change.appType,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1
+                )
+            } else {
+                Text(
+                    text = Strings.agentAppChangesFields.format(
+                        change.changedFields.take(6).joinToString(", ") +
+                            if (change.changedFields.size > 6) " …" else ""
+                    ),
+                    style = MaterialTheme.typography.labelSmall.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2
+                )
+            }
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+            contentDescription = Strings.agentAppChangesOpen,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(WtaSize.IconSmall)
+        )
+    }
+}
+
+@Composable
+private fun KindBadge(created: Boolean) {
+    val (label, container, content, icon) = if (created) {
+        BadgeStyle(
+            label = Strings.agentAppChangesKindCreate,
+            container = WtaColors.semantic.successContainer,
+            content = WtaColors.semantic.onSuccessContainer,
+            icon = Icons.Outlined.AddCircle
+        )
+    } else {
+        BadgeStyle(
+            label = Strings.agentAppChangesKindUpdate,
+            container = WtaColors.semantic.warningContainer,
+            content = WtaColors.semantic.onWarningContainer,
+            icon = Icons.Outlined.Edit
+        )
+    }
+    WtaInfoChip(
+        label = label,
+        icon = icon,
+        containerColor = container,
+        contentColor = content
+    )
+}
+
+private data class BadgeStyle(
+    val label: String,
+    val container: androidx.compose.ui.graphics.Color,
+    val content: androidx.compose.ui.graphics.Color,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector
+)

--- a/app/src/main/java/com/webtoapp/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/webtoapp/ui/navigation/AppNavigation.kt
@@ -663,7 +663,8 @@ fun AppNavigation() {
             composable(Routes.AGENT) {
                 AgentScreen(
                     onBack = { navController.popBackStack() },
-                    onOpenAiSettings = { navController.navigate(Routes.AI_SETTINGS) }
+                    onOpenAiSettings = { navController.navigate(Routes.AI_SETTINGS) },
+                    onOpenApp = { appId -> navController.navigate(Routes.editApp(appId)) }
                 )
             }
 

--- a/app/src/test/java/com/webtoapp/core/agent/engine/AgentEngineStreamTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/engine/AgentEngineStreamTest.kt
@@ -64,9 +64,82 @@ class AgentEngineStreamTest {
 
         assertEquals("one request attempt must subscribe the stream once", 1, producerRuns.get())
         assertEquals("Hello, world", events.filterIsInstance<AgentEvent.TextDelta>().joinToString("") { it.delta })
+        // The accumulated buffer must grow monotonically — #749 briefly rebuilt it per
+        // delta, leaving only the newest fragment (body streamed in replacing chunks
+        // and the persisted message ended up one token long).
+        assertEquals(
+            "the last delta must carry the FULL accumulated text",
+            "Hello, world",
+            events.filterIsInstance<AgentEvent.TextDelta>().last().accumulated
+        )
         val completed = events.last()
         assertTrue(completed is AgentEvent.Completed)
         assertEquals("Hello, world", (completed as AgentEvent.Completed).summary)
+    }
+
+    /**
+     * Thinking arrives first and anchors a TH marker in the accumulated text; body
+     * deltas must append AFTER the marker, keeping both intact across the stream.
+     */
+    @Test(timeout = 15_000)
+    fun `thinking marker and body text accumulate into one interleaved buffer`() = runBlocking {
+        val gateway = object : LlmGateway {
+            override fun chatStream(req: ChatRequest): Flow<LlmEvent> = callbackFlow {
+                trySend(LlmEvent.Started)
+                trySend(LlmEvent.ThinkingDelta("let me think"))
+                trySend(LlmEvent.TextDelta("Hello"))
+                trySend(LlmEvent.TextDelta(", "))
+                trySend(LlmEvent.TextDelta("world"))
+                trySend(LlmEvent.Done(FinishReason.STOP))
+                close()
+                awaitClose { }
+            }
+        }
+
+        val events = engine(gateway).run(input()).toList(mutableListOf())
+
+        val last = events.filterIsInstance<AgentEvent.TextDelta>().last()
+        assertEquals(
+            "marker must survive the body deltas that follow it",
+            "\u2063TH:th-turn-1\u2063Hello, world",
+            last.accumulated
+        )
+    }
+
+    /**
+     * A tool call that follows streamed prose must not truncate that prose: the TC
+     * marker is appended after it in the accumulated text.
+     */
+    @Test(timeout = 15_000)
+    fun `prose before a tool call marker is not truncated`() = runBlocking {
+        val producerRuns = AtomicInteger(0)
+        val gateway = object : LlmGateway {
+            override fun chatStream(req: ChatRequest): Flow<LlmEvent> = callbackFlow {
+                if (producerRuns.incrementAndGet() == 1) {
+                    trySend(LlmEvent.Started)
+                    trySend(LlmEvent.TextDelta("before the call"))
+                    trySend(LlmEvent.ToolCallBegin("call_1", "noop"))
+                    trySend(LlmEvent.ToolCallEnd("call_1", "noop", "{}"))
+                    trySend(LlmEvent.Done(FinishReason.TOOL_CALLS))
+                } else {
+                    trySend(LlmEvent.Started)
+                    trySend(LlmEvent.TextDelta("done"))
+                    trySend(LlmEvent.Done(FinishReason.STOP))
+                }
+                close()
+                awaitClose { }
+            }
+        }
+
+        val events = engine(gateway).run(input()).toList(mutableListOf())
+
+        val firstStreamAccumulated = events.filterIsInstance<AgentEvent.TextDelta>()
+            .first { it.accumulated.contains("TC:call_1") }
+            .accumulated
+        assertTrue(
+            "the marker event must still carry the prose that preceded it",
+            firstStreamAccumulated.startsWith("before the call\u2063TC:call_1\u2063")
+        )
     }
 
     @Test(timeout = 15_000)
@@ -93,6 +166,54 @@ class AgentEngineStreamTest {
         assertTrue(events.filterIsInstance<AgentEvent.Notice>().isNotEmpty())
         assertTrue(events.filterIsInstance<AgentEvent.TextDelta>().any { it.delta == "recovered" })
         assertTrue(events.last() is AgentEvent.Completed)
+    }
+
+    /**
+     * A stream that opens, completes with zero deltas, and closes is a distinct
+     * outcome from a request error. The Completed summary must say so explicitly —
+     * an empty summary previously made the whole turn vanish (nothing persisted).
+     */
+    @Test(timeout = 15_000)
+    fun `an empty stream completes with an explicit empty-response summary`() = runBlocking {
+        val gateway = object : LlmGateway {
+            override fun chatStream(req: ChatRequest): Flow<LlmEvent> = callbackFlow {
+                trySend(LlmEvent.Started)
+                trySend(LlmEvent.Done(FinishReason.STOP))
+                close()
+                awaitClose { }
+            }
+        }
+
+        val events = engine(gateway).run(input()).toList(mutableListOf())
+
+        val completed = events.last()
+        assertTrue(completed is AgentEvent.Completed)
+        assertEquals(
+            com.webtoapp.core.i18n.Strings.agentEmptyResponse,
+            (completed as AgentEvent.Completed).summary
+        )
+    }
+
+    /**
+     * A hard (non-recoverable) stream error must fail the turn with the provider's
+     * message — the UI and the session both rely on this message being present.
+     */
+    @Test(timeout = 15_000)
+    fun `a hard stream error fails the turn with the provider message`() = runBlocking {
+        val gateway = object : LlmGateway {
+            override fun chatStream(req: ChatRequest): Flow<LlmEvent> = callbackFlow {
+                trySend(LlmEvent.Started)
+                trySend(LlmEvent.Error("API key invalid or expired (401)"))
+                close()
+                awaitClose { }
+            }
+        }
+
+        val events = engine(gateway).run(input()).toList(mutableListOf())
+
+        val failed = events.last()
+        assertTrue(failed is AgentEvent.Failed)
+        assertEquals("API key invalid or expired (401)", (failed as AgentEvent.Failed).message)
     }
 
     private fun engine(gateway: LlmGateway) =

--- a/app/src/test/java/com/webtoapp/core/agent/runtime/TurnAccumulatorTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/runtime/TurnAccumulatorTest.kt
@@ -1,0 +1,69 @@
+package com.webtoapp.core.agent.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression coverage for the silent-empty-response bug: a turn whose request died
+ * BEFORE the first streamed delta accumulated no text/thinking/tools, and
+ * [TurnAccumulator.buildFinalMessage] returned null — the error was then dropped
+ * entirely (no persisted bubble, no banner, nothing). A failed turn must always
+ * leave a durable record; an empty-but-completed turn must persist the engine's
+ * empty-response notice; only a substance-less abort stays dropped.
+ */
+@RunWith(RobolectricTestRunner::class)
+class TurnAccumulatorTest {
+
+    @Test
+    fun `error turn with zero streamed output still produces a persisted message`() {
+        val acc = TurnAccumulator("session-1")
+        val msg = acc.buildFinalMessage(
+            summaryFallback = null,
+            isError = true,
+            errorSuffix = "API key invalid or expired (401)"
+        )
+        assertNotNull("a failed turn must never vanish without a record", msg)
+        assertTrue(msg!!.isError)
+        assertTrue(
+            "the persisted content must carry the failure reason for diagnosis",
+            msg.content.contains("API key invalid or expired (401)")
+        )
+    }
+
+    @Test
+    fun `completed turn with empty-response notice persists that notice`() {
+        val acc = TurnAccumulator("session-1")
+        val notice = "The model returned an empty response (no text, no tool calls)."
+        val msg = acc.buildFinalMessage(summaryFallback = notice, isError = false)
+        assertNotNull(msg)
+        assertFalse(msg!!.isError)
+        assertEquals(notice, msg.content)
+    }
+
+    @Test
+    fun `substance-less abort is still dropped`() {
+        val acc = TurnAccumulator("session-1")
+        val msg = acc.buildFinalMessage(
+            summaryFallback = null,
+            isError = true,
+            errorSuffix = null,
+            aborted = true
+        )
+        assertNull("a deliberate cancel with no output must stay silent", msg)
+    }
+
+    @Test
+    fun `normal completed turn keeps its streamed text over the fallback`() {
+        val acc = TurnAccumulator("session-1")
+        acc.applyTextDelta("hello world")
+        val msg = acc.buildFinalMessage(summaryFallback = "fallback-should-be-ignored", isError = false)
+        assertNotNull(msg)
+        assertEquals("hello world", msg!!.content)
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/agent/tool/builtin/AppChangeToolTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/tool/builtin/AppChangeToolTest.kt
@@ -1,0 +1,177 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.webtoapp.core.agent.files.ProjectFileManager
+import com.webtoapp.core.agent.permission.PermissionChecker
+import com.webtoapp.core.agent.permission.PermissionPrompter
+import com.webtoapp.core.agent.todo.TodoManager
+import com.webtoapp.core.agent.tool.AppChange
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.data.dao.WebAppDao
+import com.webtoapp.data.dao.WebAppStartupCandidate
+import com.webtoapp.data.dao.WebAppSummary
+import com.webtoapp.data.model.AiModel
+import com.webtoapp.data.model.AiProvider
+import com.webtoapp.data.model.ApiKeyConfig
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.ModelCapability
+import com.webtoapp.data.model.SavedModel
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.repository.WebAppRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * CreateApp/UpdateApp must attach an [AppChange] to every successful result so the
+ * agent UI can surface the "app changes" review card after a turn — without it the
+ * turn ends with zero indication that an app was created or modified.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppChangeToolTest {
+
+    @Test
+    fun `CreateApp manifest path reports a CREATE app change`() = runTest {
+        val repo = FakeRepo()
+        val tool = CreateAppTool()
+
+        val result = tool.execute(
+            JsonObject().apply {
+                addProperty("appType", "WEB")
+                addProperty("name", "Docs Site")
+                addProperty("manifest", """{"url":"https://example.com"}""")
+            },
+            context(repo)
+        )
+
+        assertFalse(result.isError)
+        val change = result.appChange
+        assertNotNull("a created app must carry appChange for the review card", change)
+        change!!
+        assertEquals(AppChange.Kind.CREATE, change.kind)
+        assertEquals("Docs Site", change.appName)
+        assertEquals("WEB", change.appType)
+        assertEquals(repo.lastInsertedId, change.appId)
+    }
+
+    @Test
+    fun `UpdateApp reports an UPDATE app change with the patched top-level fields`() = runTest {
+        val repo = FakeRepo(seed = WebApp(id = 7, name = "Old", url = "https://old.example", appType = AppType.WEB))
+        val tool = UpdateAppTool()
+
+        val result = tool.execute(
+            JsonObject().apply {
+                addProperty("appId", 7L)
+                addProperty("patch", """{"name":"New Name","url":"https://new.example"}""")
+            },
+            context(repo)
+        )
+
+        assertFalse(result.isError)
+        val change = result.appChange
+        assertNotNull("an updated app must carry appChange for the review card", change)
+        change!!
+        assertEquals(AppChange.Kind.UPDATE, change.kind)
+        assertEquals(7L, change.appId)
+        assertEquals("New Name", change.appName)
+        // The patch's top-level keys are what the review card shows as "what changed".
+        assertEquals(listOf("name", "url"), change.changedFields)
+        assertEquals("New Name", repo.updatedApp!!.name)
+    }
+
+    @Test
+    fun `failed tool calls carry no app change`() = runTest {
+        val repo = FakeRepo()
+        val create = CreateAppTool().execute(
+            JsonObject().apply {
+                addProperty("appType", "WEB")
+                addProperty("name", "No Manifest")
+            },
+            context(repo)
+        )
+        assertTrue(create.isError)
+        assertEquals(null, create.appChange)
+
+        val update = UpdateAppTool().execute(
+            JsonObject().apply {
+                addProperty("appId", 404L)
+                addProperty("patch", """{"name":"x"}""")
+            },
+            context(repo)
+        )
+        assertTrue(update.isError)
+        assertEquals(null, update.appChange)
+    }
+
+    private fun context(repo: FakeRepo): ToolContext {
+        val appCtx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        return ToolContext(
+            androidContext = appCtx,
+            sessionId = "test-session",
+            fileManager = ProjectFileManager(appCtx),
+            textModel = SavedModel(
+                model = AiModel(id = "m", name = "m", provider = AiProvider.OPENAI),
+                apiKeyId = "k",
+                capabilities = listOf(ModelCapability.TEXT)
+            ),
+            textApiKey = ApiKeyConfig(provider = AiProvider.OPENAI, apiKey = "key"),
+            prompter = PermissionPrompter(),
+            todos = TodoManager(),
+            appRepository = WebAppRepository(repo)
+        )
+    }
+
+    private class FakeRepo(seed: WebApp? = null) : WebAppDao {
+        private val nextId = MutableStateFlow(seed?.id?.plus(1) ?: 1L)
+        private val apps = MutableStateFlow(seed?.let { listOf(it) } ?: emptyList<WebApp>())
+        var lastInsertedId: Long = -1
+            private set
+        var updatedApp: WebApp? = null
+            private set
+
+        override fun getAllWebApps(): Flow<List<WebApp>> = apps
+        override fun getAllWebAppSummaries(): Flow<List<WebAppSummary>> = flowOf(emptyList())
+        override fun getHttpWebApps(appType: AppType): Flow<List<WebApp>> = flowOf(emptyList())
+        override suspend fun getStartupCandidatesWithoutIcons(appType: AppType, limit: Int): List<WebAppStartupCandidate> = emptyList()
+        override suspend fun getWebAppById(id: Long): WebApp? = apps.value.firstOrNull { it.id == id }
+        override fun getWebAppByIdFlow(id: Long): Flow<WebApp?> = flowOf(apps.value.firstOrNull { it.id == id })
+        override suspend fun insert(webApp: WebApp): Long {
+            val id = nextId.value
+            nextId.value = id + 1
+            apps.value = apps.value + webApp.copy(id = id)
+            lastInsertedId = id
+            return id
+        }
+        override suspend fun update(webApp: WebApp) {
+            updatedApp = webApp
+            apps.value = apps.value.map { if (it.id == webApp.id) webApp else it }
+        }
+        override suspend fun delete(webApp: WebApp) {}
+        override suspend fun deleteById(id: Long) {}
+        override suspend fun updateActivationStatus(id: Long, activated: Boolean) {}
+        override suspend fun upgradeRemoteHttpUrls(appType: AppType, updatedAt: Long): Int = 0
+        override suspend fun getCount(): Int = apps.value.size
+        override fun searchWebApps(query: String): Flow<List<WebApp>> = flowOf(emptyList())
+        override suspend fun insertAll(webApps: List<WebApp>): List<Long> = emptyList()
+        override suspend fun updateAll(webApps: List<WebApp>) {}
+        override suspend fun deleteAll(webApps: List<WebApp>) {}
+        override suspend fun deleteByIds(ids: List<Long>) {}
+        override suspend fun updateActivationStatusBatch(ids: List<Long>, activated: Boolean) {}
+        override suspend fun getWebAppsByIds(ids: List<Long>): List<WebApp> = emptyList()
+        override fun getActivatedWebApps(): Flow<List<WebApp>> = flowOf(emptyList())
+        override fun getRecentWebApps(limit: Int): Flow<List<WebApp>> = flowOf(emptyList())
+        override suspend fun countByName(name: String, excludeId: Long): Int = 0
+        override suspend fun clearCategoryId(categoryId: Long) {}
+        override suspend fun getAllUrls(): List<String> = emptyList()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the batch of agent-chat regressions reported after the v2.6.0-era engine rewrites, and adds the missing app-change feedback. A turn can no longer end silently — every outcome now leaves a visible, attributable record.

- **Silent empty responses (Fixes #820, part 1).** A request dying before the first delta produced no substance, so the service dropped the error entirely and the UI reset without a banner. Failed turns now always persist an error bubble and the ViewModel surfaces the reason immediately; empty-but-successful streams persist a localized "empty response" notice; network errors carry the endpoint URL.
- **Truncated streaming (Fixes #820, part 2, #749 regression).** `rebuildAccFromPrefix()` ran on every `TextDelta`, truncating `accText` to the turn start so the accumulated buffer (which drives both the live timeline and the persisted message) held only the newest fragment. It is now retry-path-only; the thinking/tool marker paths lost their copies for the same reason.
- **Auto-follow re-attach (Fixes #820, part 3).** `followBottom` stayed false across turns once the user had scrolled up, leaving a newly sent turn off-screen. A new turn now re-attaches and snaps to the newest item; the follow effect also jumps straight to the last item when a burst of output outgrows the viewport instead of stalling.
- **App changes review card (Closes #821).** `CreateApp`/`UpdateApp` now attach an `AppChange` to their result; after the turn, a review card below the conversation lists each created/updated app (badge, name, type, patched fields) and tapping a row opens that app's editor via `Routes.editApp`.

Fixes #820
Closes #821

## Test plan

- [x] `TurnAccumulatorTest` — error turns with zero streamed output persist; empty-response notices persist; substance-less aborts still drop; normal turns unchanged.
- [x] `AgentEngineStreamTest` — accumulated buffer grows monotonically across deltas (the missing assertion that let the #749 regression through), thinking/tool markers interleave without truncation, empty streams complete with an explicit summary, hard errors propagate their message.
- [x] `AppChangeToolTest` — `appChange` populated on create (all three creation paths' shared contract) and on update (with the patch's top-level fields), absent on failure.
- [x] i18n parity guards (`*Strings*` tests) for the new 10-language entries.
- [x] `:app:checkConfigFieldDrift` clean.
- [x] End-to-end on emulator with a live model: failed requests show the reason; streamed body renders monotonically and the final message is complete; send-from-history snaps to the new turn; scroll-up detaches / return-to-bottom re-attaches; a `CreateApp` turn shows the "1 app change" card and tapping it opens the app editor.