### PR TITLE
fix(engine): GeckoView parity — revive CORS bridge, navigation, prompts, errors, find-in-page

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/BrowserEngineCallback.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/BrowserEngineCallback.kt
@@ -47,6 +47,14 @@ interface BrowserEngineCallback {
     fun onConsoleMessage(level: Int, message: String, sourceId: String, lineNumber: Int) {}
 
     /**
+     * History navigation state changed. GeckoView reports canGoBack/canGoForward through its
+     * NavigationDelegate; the System WebView path derives them from `onUrlChanged` instead, so
+     * this stays a no-op there. Hosts use it to enable/disable back & forward affordances —
+     * without it the Gecko toolbar buttons never leave their initial disabled state.
+     */
+    fun onNavigationStateChanged(canGoBack: Boolean, canGoForward: Boolean) {}
+
+    /**
      * A popup window was requested. Return true when the host renders the popup transport;
      * false lets the WebViewManager fall back to loading the popup URL in the same window.
      */

--- a/app/src/main/java/com/webtoapp/core/engine/BrowserSurface.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/BrowserSurface.kt
@@ -59,6 +59,41 @@ class BrowserSurface private constructor(
 
     fun dispatchKeyEvent(event: KeyEvent): Boolean = view.dispatchKeyEvent(event)
 
+    /**
+     * Engine-agnostic find-in-page. `forward == null` starts a fresh search for [text];
+     * true/false steps to the next/previous match of the current search. [onResult] receives
+     * the 0-based active match ordinal (-1 when nothing matched) and the total match count,
+     * invoked once the engine finished counting for that step.
+     */
+    fun findInPage(text: String, forward: Boolean?, onResult: (activeMatch: Int, totalMatches: Int) -> Unit) {
+        val wv = webView
+        if (wv != null) {
+            try {
+                wv.setFindListener { active, total, done ->
+                    if (done) onResult(if (total > 0) active else -1, total)
+                }
+                if (forward == null) wv.findAllAsync(text) else wv.findNext(forward)
+            } catch (_: Exception) {
+                onResult(-1, 0)
+            }
+            return
+        }
+        (engine as? GeckoViewEngine)?.findInPage(text, forward, onResult) ?: onResult(-1, 0)
+    }
+
+    fun clearFindMatches() {
+        val wv = webView
+        if (wv != null) {
+            try {
+                wv.setFindListener(null)
+                wv.clearMatches()
+            } catch (_: Exception) {
+            }
+            return
+        }
+        (engine as? GeckoViewEngine)?.clearFindMatches()
+    }
+
     fun onResume() {
         webView?.onResume()
         webView?.resumeTimers()

--- a/app/src/main/java/com/webtoapp/core/engine/EngineViewFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/EngineViewFactory.kt
@@ -59,7 +59,13 @@ object EngineViewFactory {
         allowGlobalModuleFallback: Boolean = false,
         extensionEnabled: Boolean = true,
         browserDisguiseConfig: com.webtoapp.core.appearance.BrowserDisguiseConfig? = null,
-        deviceDisguiseConfig: com.webtoapp.core.appearance.DeviceDisguiseConfig? = null
+        deviceDisguiseConfig: com.webtoapp.core.appearance.DeviceDisguiseConfig? = null,
+        /**
+         * The app's own origin URL (target URL / local base). Only consumed by the GeckoView
+         * path, which builds its NativeBridge inside the engine; the System WebView path gets
+         * the same value from the host's own bridge construction sites.
+         */
+        appOriginUrl: String = ""
     ): BrowserSurface {
         val engineType = resolveEngineType(engineTypeName, config, context)
         AppLogger.i(
@@ -71,6 +77,7 @@ object EngineViewFactory {
             prepareGeckoNetwork(config)
             val engine = EngineManager.getInstance(context).createEngine(EngineType.GECKOVIEW, adBlocker)
             val geckoEngine = engine as GeckoViewEngine
+            geckoEngine.appOriginUrl = appOriginUrl
             val view = geckoEngine.createView(
                 context = context,
                 config = config,
@@ -113,6 +120,7 @@ object EngineViewFactory {
             )
         }
         GeckoViewEngine.applyAntiCapture(config.antiCapture)
+        GeckoViewEngine.applyAutoplayPolicy(config.mediaAutoplayEnabled)
 
         val tlsFingerprintEnabled = config.tlsFingerprintEnabled &&
             config.tlsFingerprintTemplate.isNotBlank()
@@ -199,6 +207,10 @@ fun WebViewCallbacks.toBrowserEngineCallback(): BrowserEngineCallback {
 
         override fun onConsoleMessage(level: Int, message: String, sourceId: String, lineNumber: Int) {
             source.onConsoleMessage(level, message, sourceId, lineNumber)
+        }
+
+        override fun onNavigationStateChanged(canGoBack: Boolean, canGoForward: Boolean) {
+            source.onNavigationStateChanged(canGoBack, canGoForward)
         }
 
         override fun onNewWindow(resultMsg: android.os.Message?): Boolean {

--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -17,6 +17,7 @@ import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoSessionSettings
 import org.mozilla.geckoview.GeckoView
 import org.mozilla.geckoview.StorageController
+import org.mozilla.geckoview.WebRequestError
 import org.mozilla.geckoview.WebResponse
 import org.mozilla.geckoview.WebExtension
 import kotlinx.coroutines.Dispatchers
@@ -108,7 +109,7 @@ class GeckoViewEngine(
             val ech = currentDnsConfig?.echEffective == true
             val proxy = currentProxyConfig?.let { buildProxyPrefs(it) } ?: emptyMap()
             val proxyKey = proxy.entries.joinToString(",") { "${it.key}=${it.value}" }
-            return "ech=$ech|proxy=$proxyKey|tlsMitm=$tlsMitmActive|enterpriseRoots=$enterpriseRootsEnabled|antiCapture=$antiCaptureActive"
+            return "ech=$ech|proxy=$proxyKey|tlsMitm=$tlsMitmActive|enterpriseRoots=$enterpriseRootsEnabled|antiCapture=$antiCaptureActive|autoplay=$autoplayAllowed"
         }
 
         fun getRuntime(context: Context): GeckoRuntime {
@@ -174,6 +175,20 @@ class GeckoViewEngine(
         fun applyAntiCapture(active: Boolean) {
             antiCaptureActive = active
             AppLogger.d(TAG, "applyAntiCapture: active=$active")
+        }
+
+        @Volatile
+        private var autoplayAllowed: Boolean = true
+
+        /**
+         * Autoplay parity with the WebView path's `mediaPlaybackRequiresUserGesture`:
+         * mediaAutoplayEnabled=false (the default) must block un-gestured playback on
+         * Gecko too, instead of silently leaving Gecko's allow-by-default policy in place.
+         * Applied through the `media.autoplay.default` pref at runtime creation.
+         */
+        fun applyAutoplayPolicy(allowed: Boolean) {
+            autoplayAllowed = allowed
+            AppLogger.d(TAG, "applyAutoplayPolicy: allowed=$allowed")
         }
 
         fun applyEnterpriseRootsEnabled(enabled: Boolean) {
@@ -294,6 +309,10 @@ class GeckoViewEngine(
                 appProxy?.let { prefs.putAll(buildProxyPrefs(it)) }
             }
 
+            // media.autoplay.default: 0 = allow, 1 = block audible without user gesture
+            // (Firefox's own default). Mirrors WebView's mediaPlaybackRequiresUserGesture.
+            prefs["media.autoplay.default"] = if (autoplayAllowed) 0 else 1
+
             if (antiCaptureActive) {
                 prefs["security.enterprise_roots.enabled"] = false
             } else if (tlsMitmActive || enterpriseRootsEnabled) {
@@ -403,6 +422,14 @@ class GeckoViewEngine(
 
     override val engineType = EngineType.GECKOVIEW
 
+    /**
+     * The app's own origin URL (target URL / local base), set by EngineViewFactory before
+     * createView. Feeds the NativeBridge caller gate — GeckoView has no WebView whose `.url`
+     * could be consulted, so without this (plus [currentUrl] as the page-URL provider) every
+     * CORS-bypass / private-network request from the bridge WebExtension is rejected.
+     */
+    var appOriginUrl: String = ""
+
     private var geckoView: GeckoView? = null
     private var session: GeckoSession? = null
     private var callback: BrowserEngineCallback? = null
@@ -420,6 +447,8 @@ class GeckoViewEngine(
 
     private var lastConfig: WebViewConfig? = null
     private var lastGeckoUaMode: Int = GeckoSessionSettings.USER_AGENT_MODE_MOBILE
+    private var lastGeckoViewportMode: Int = GeckoSessionSettings.VIEWPORT_MODE_MOBILE
+    private var lastAllowJavascript: Boolean = true
     private var lastUserAgentOverride: String? = null
 
     private var bridgeScope: kotlinx.coroutines.CoroutineScope? = null
@@ -450,6 +479,15 @@ class GeckoViewEngine(
 
         val runtime = getRuntime(context)
 
+        if (config.clearBrowsingDataOnLaunch) {
+            try {
+                runtime.storageController.clearData(StorageController.ClearFlags.ALL)
+                AppLogger.i(TAG, "Cleared browsing data on launch (clearBrowsingDataOnLaunch)")
+            } catch (e: Exception) {
+                AppLogger.w(TAG, "clearBrowsingDataOnLaunch failed: ${e.message}")
+            }
+        }
+
         if (config.enableCorsBypass || config.enablePrivateNetworkBridge) {
             if (bridgeScope == null) bridgeScope = kotlinx.coroutines.MainScope()
             val bridge = com.webtoapp.core.webview.NativeBridge(
@@ -459,23 +497,44 @@ class GeckoViewEngine(
                 capabilities = config.nativeBridgeCapabilities,
                 corsBypass = config.enableCorsBypass,
                 downloadLocationMode = config.downloadLocationMode,
-                customDownloadDirUri = config.customDownloadDirUri
+                customDownloadDirUri = config.customDownloadDirUri,
+                appOriginUrl = appOriginUrl,
+                callerPageUrlProvider = { currentUrl }
             )
             activeNativeBridge = bridge
             ensureNativeBridgeExtension(runtime)
         }
 
-        val geckoUaMode = when (config.userAgentMode) {
-            UserAgentMode.CHROME_DESKTOP, UserAgentMode.SAFARI_DESKTOP,
-            UserAgentMode.FIREFOX_DESKTOP, UserAgentMode.EDGE_DESKTOP -> GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
+        val geckoUaMode = when {
+            config.desktopMode -> GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
+            config.userAgentMode == UserAgentMode.CHROME_DESKTOP ||
+                config.userAgentMode == UserAgentMode.SAFARI_DESKTOP ||
+                config.userAgentMode == UserAgentMode.FIREFOX_DESKTOP ||
+                config.userAgentMode == UserAgentMode.EDGE_DESKTOP ->
+                GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
             else -> GeckoSessionSettings.USER_AGENT_MODE_MOBILE
         }
         this.lastGeckoUaMode = geckoUaMode
+
+        // Parity with the WebView path's useWideViewPort/loadWithOverviewMode (FIT_SCREEN)
+        // and desktopMode. CUSTOM stays MOBILE — its meta-viewport injection is JS-based and
+        // has no Gecko counterpart yet.
+        val geckoViewportMode = when {
+            config.desktopMode -> GeckoSessionSettings.VIEWPORT_MODE_DESKTOP
+            config.viewportMode == com.webtoapp.data.model.ViewportMode.FIT_SCREEN ||
+                config.viewportMode == com.webtoapp.data.model.ViewportMode.DESKTOP ->
+                GeckoSessionSettings.VIEWPORT_MODE_DESKTOP
+            else -> GeckoSessionSettings.VIEWPORT_MODE_MOBILE
+        }
+        this.lastGeckoViewportMode = geckoViewportMode
+        this.lastAllowJavascript = config.javaScriptEnabled
 
         val sessionSettings = GeckoSessionSettings.Builder()
             .usePrivateMode(false)
             .useTrackingProtection(false)
             .userAgentMode(geckoUaMode)
+            .viewportMode(geckoViewportMode)
+            .allowJavascript(config.javaScriptEnabled)
             .build()
 
         val newSession = GeckoSession(sessionSettings)
@@ -547,6 +606,13 @@ class GeckoViewEngine(
             }
 
             override fun onExternalResponse(session: GeckoSession, response: WebResponse) {
+                // Parity with the WebView path, where setDownloadListener is only installed
+                // when downloadEnabled — a disabled download feature must not silently start
+                // serving responses to the system downloader on Gecko.
+                if (lastConfig?.downloadEnabled == false) {
+                    AppLogger.d(TAG, "Download suppressed (downloadEnabled=false): ${response.uri}")
+                    return
+                }
                 val contentType = response.headers["Content-Type"] ?: "application/octet-stream"
                 val contentDisposition = response.headers["Content-Disposition"] ?: ""
                 val contentLength = response.headers["Content-Length"]?.toLongOrNull() ?: -1L
@@ -581,6 +647,211 @@ class GeckoViewEngine(
         config: WebViewConfig
     ) {
         session.promptDelegate = object : GeckoSession.PromptDelegate {
+            /**
+             * JS window.alert(). Unhandled Gecko prompts are dismissed silently, so pages
+             * using alert() as a user-facing signal (form errors, notices) went mute on
+             * Gecko. BasePrompt.confirm() is protected on AlertPrompt; dismiss() is the
+             * public completion and carries the same meaning for an alert (no return value).
+             */
+            override fun onAlertPrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.AlertPrompt
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse>? {
+                val activity = viewContext.findActivity()
+                if (activity == null || activity.isFinishing || activity.isDestroyed) {
+                    return GeckoResult.fromValue(prompt.dismiss())
+                }
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                activity.runOnUiThread {
+                    try {
+                        android.app.AlertDialog.Builder(activity)
+                            .setTitle(prompt.title)
+                            .setMessage(prompt.message)
+                            .setPositiveButton(com.webtoapp.core.i18n.Strings.confirm) { dialog, _ ->
+                                dialog.dismiss()
+                                result.complete(prompt.dismiss())
+                            }
+                            .setOnCancelListener { result.complete(prompt.dismiss()) }
+                            .show()
+                    } catch (e: Exception) {
+                        AppLogger.w(TAG, "onAlertPrompt dialog failed: ${e.message}")
+                        result.complete(prompt.dismiss())
+                    }
+                }
+                return result
+            }
+
+            /** JS window.confirm(). */
+            override fun onButtonPrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.ButtonPrompt
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse>? {
+                val activity = viewContext.findActivity()
+                if (activity == null || activity.isFinishing || activity.isDestroyed) {
+                    return GeckoResult.fromValue(
+                        prompt.confirm(GeckoSession.PromptDelegate.ButtonPrompt.Type.NEGATIVE)
+                    )
+                }
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                activity.runOnUiThread {
+                    try {
+                        android.app.AlertDialog.Builder(activity)
+                            .setTitle(prompt.title)
+                            .setMessage(prompt.message)
+                            .setPositiveButton(com.webtoapp.core.i18n.Strings.confirm) { dialog, _ ->
+                                dialog.dismiss()
+                                result.complete(prompt.confirm(GeckoSession.PromptDelegate.ButtonPrompt.Type.POSITIVE))
+                            }
+                            .setNegativeButton(com.webtoapp.core.i18n.Strings.btnCancel) { dialog, _ ->
+                                dialog.dismiss()
+                                result.complete(prompt.confirm(GeckoSession.PromptDelegate.ButtonPrompt.Type.NEGATIVE))
+                            }
+                            .setOnCancelListener {
+                                result.complete(prompt.confirm(GeckoSession.PromptDelegate.ButtonPrompt.Type.NEGATIVE))
+                            }
+                            .show()
+                    } catch (e: Exception) {
+                        AppLogger.w(TAG, "onButtonPrompt dialog failed: ${e.message}")
+                        result.complete(prompt.confirm(GeckoSession.PromptDelegate.ButtonPrompt.Type.NEGATIVE))
+                    }
+                }
+                return result
+            }
+
+            /** JS window.prompt() — cancel maps to dismiss() (JS receives null). */
+            override fun onTextPrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.TextPrompt
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse>? {
+                val activity = viewContext.findActivity()
+                if (activity == null || activity.isFinishing || activity.isDestroyed) {
+                    return GeckoResult.fromValue(prompt.dismiss())
+                }
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                activity.runOnUiThread {
+                    try {
+                        val input = android.widget.EditText(activity).apply {
+                            setText(prompt.defaultValue ?: "")
+                            setSelection(text.length)
+                            isSingleLine = true
+                        }
+                        val container = android.widget.FrameLayout(activity).apply {
+                            setPadding(64, 24, 64, 0)
+                            addView(input)
+                        }
+                        android.app.AlertDialog.Builder(activity)
+                            .setTitle(prompt.title)
+                            .setMessage(prompt.message)
+                            .setView(container)
+                            .setPositiveButton(com.webtoapp.core.i18n.Strings.confirm) { dialog, _ ->
+                                dialog.dismiss()
+                                result.complete(prompt.confirm(input.text.toString()))
+                            }
+                            .setNegativeButton(com.webtoapp.core.i18n.Strings.btnCancel) { dialog, _ ->
+                                dialog.dismiss()
+                                result.complete(prompt.dismiss())
+                            }
+                            .setOnCancelListener { result.complete(prompt.dismiss()) }
+                            .show()
+                    } catch (e: Exception) {
+                        AppLogger.w(TAG, "onTextPrompt dialog failed: ${e.message}")
+                        result.complete(prompt.dismiss())
+                    }
+                }
+                return result
+            }
+
+            /**
+             * HTTP Basic/Digest auth and proxy auth — the Gecko counterpart of
+             * onReceivedHttpAuthRequest. Mirrors the WebView path's dialog (same strings,
+             * same TextInputLayout shape); Gecko has no cached-credential store exposed
+             * here, so credentials are requested on every challenge.
+             */
+            override fun onAuthPrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.AuthPrompt
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse>? {
+                val activity = viewContext.findActivity()
+                if (activity == null || activity.isFinishing || activity.isDestroyed) {
+                    return GeckoResult.fromValue(prompt.dismiss())
+                }
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                val options = prompt.authOptions
+                val onlyPassword = (options.flags and
+                    GeckoSession.PromptDelegate.AuthPrompt.AuthOptions.Flags.ONLY_PASSWORD) != 0
+                activity.runOnUiThread {
+                    try {
+                        val dialogView = android.widget.LinearLayout(activity).apply {
+                            orientation = android.widget.LinearLayout.VERTICAL
+                            setPadding(64, 32, 64, 0)
+
+                            if (!onlyPassword) {
+                                addView(com.google.android.material.textfield.TextInputLayout(activity).apply {
+                                    hint = com.webtoapp.core.i18n.Strings.httpAuthUsername
+                                    boxBackgroundMode = com.google.android.material.textfield.TextInputLayout.BOX_BACKGROUND_OUTLINE
+                                    setBoxCornerRadii(12f, 12f, 12f, 12f)
+                                    addView(com.google.android.material.textfield.TextInputEditText(activity).apply {
+                                        tag = "auth_username"
+                                        inputType = android.text.InputType.TYPE_CLASS_TEXT
+                                        isSingleLine = true
+                                        setText(options.username ?: "")
+                                    })
+                                })
+                                addView(android.view.View(activity).apply {
+                                    layoutParams = android.widget.LinearLayout.LayoutParams(
+                                        android.widget.LinearLayout.LayoutParams.MATCH_PARENT, 24
+                                    )
+                                })
+                            }
+
+                            addView(com.google.android.material.textfield.TextInputLayout(activity).apply {
+                                hint = com.webtoapp.core.i18n.Strings.httpAuthPassword
+                                boxBackgroundMode = com.google.android.material.textfield.TextInputLayout.BOX_BACKGROUND_OUTLINE
+                                setBoxCornerRadii(12f, 12f, 12f, 12f)
+                                endIconMode = com.google.android.material.textfield.TextInputLayout.END_ICON_PASSWORD_TOGGLE
+                                addView(com.google.android.material.textfield.TextInputEditText(activity).apply {
+                                    tag = "auth_password"
+                                    inputType = android.text.InputType.TYPE_CLASS_TEXT or
+                                        android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD
+                                    isSingleLine = true
+                                    setText(options.password ?: "")
+                                })
+                            })
+                        }
+
+                        val hostDisplay = runCatching {
+                            android.net.Uri.parse(options.uri ?: "").host
+                        }.getOrNull() ?: options.uri ?: "server"
+
+                        android.app.AlertDialog.Builder(activity)
+                            .setTitle(com.webtoapp.core.i18n.Strings.httpAuthTitle)
+                            .setMessage(com.webtoapp.core.i18n.Strings.httpAuthMessage.format(hostDisplay))
+                            .setView(dialogView)
+                            .setPositiveButton(com.webtoapp.core.i18n.Strings.httpAuthLogin) { dialog, _ ->
+                                val username = dialogView.findViewWithTag<android.widget.EditText>("auth_username")
+                                    ?.text?.toString() ?: ""
+                                val password = dialogView.findViewWithTag<android.widget.EditText>("auth_password")
+                                    ?.text?.toString() ?: ""
+                                dialog.dismiss()
+                                result.complete(
+                                    if (onlyPassword) prompt.confirm(password)
+                                    else prompt.confirm(username, password)
+                                )
+                            }
+                            .setNegativeButton(com.webtoapp.core.i18n.Strings.btnCancel) { dialog, _ ->
+                                dialog.dismiss()
+                                result.complete(prompt.dismiss())
+                            }
+                            .setOnCancelListener { result.complete(prompt.dismiss()) }
+                            .show()
+                    } catch (e: Exception) {
+                        AppLogger.w(TAG, "onAuthPrompt dialog failed: ${e.message}")
+                        result.complete(prompt.dismiss())
+                    }
+                }
+                return result
+            }
+
             override fun onRequestCertificate(
                 session: GeckoSession,
                 request: GeckoSession.PromptDelegate.CertificateRequest
@@ -727,10 +998,34 @@ class GeckoViewEngine(
 
             override fun onCanGoBack(session: GeckoSession, canGoBack: Boolean) {
                 canGoBackFlag = canGoBack
+                callback.onNavigationStateChanged(canGoBackFlag, canGoForwardFlag)
             }
 
             override fun onCanGoForward(session: GeckoSession, canGoForward: Boolean) {
                 canGoForwardFlag = canGoForward
+                callback.onNavigationStateChanged(canGoBackFlag, canGoForwardFlag)
+            }
+
+            /**
+             * Main-frame load failure — the Gecko counterpart of WebViewClient.onReceivedError /
+             * onReceivedSslError. Without it the shell/host error UI (error card, failover,
+             * retry affordances) never fires on Gecko and a failed load leaves a blank page.
+             */
+            override fun onLoadError(
+                session: GeckoSession,
+                uri: String?,
+                error: WebRequestError
+            ): GeckoResult<String>? {
+                val description = describeWebRequestError(error)
+                AppLogger.w(TAG, "Main-frame load error: uri=$uri category=${error.category} code=${error.code}")
+                if (error.category == WebRequestError.ERROR_CATEGORY_SECURITY) {
+                    callback.onSslError(description)
+                } else {
+                    callback.onError(error.code, description)
+                }
+                // Resolve with null so GeckoView keeps its built-in error page beneath the
+                // host's own error UI, matching the default delegate behavior.
+                return GeckoResult.fromValue(null)
             }
 
             override fun onLoadRequest(
@@ -781,6 +1076,31 @@ class GeckoViewEngine(
     private fun isLoopbackHost(host: String): Boolean {
         val h = host.lowercase()
         return h == "127.0.0.1" || h == "localhost" || h == "[::1]" || h == "::1"
+    }
+
+    /**
+     * Maps Gecko's WebRequestError onto the `net::ERR_*` tokens the WebView path produces, so
+     * the shell/host error UI shows the same vocabulary on both engines.
+     */
+    private fun describeWebRequestError(error: WebRequestError): String = when (error.code) {
+        WebRequestError.ERROR_UNKNOWN_HOST -> "net::ERR_NAME_NOT_RESOLVED"
+        WebRequestError.ERROR_CONNECTION_REFUSED -> "net::ERR_CONNECTION_REFUSED"
+        WebRequestError.ERROR_NET_TIMEOUT -> "net::ERR_TIMED_OUT"
+        WebRequestError.ERROR_NET_INTERRUPT -> "net::ERR_CONNECTION_ABORTED"
+        WebRequestError.ERROR_NET_RESET -> "net::ERR_CONNECTION_RESET"
+        WebRequestError.ERROR_OFFLINE -> "net::ERR_INTERNET_DISCONNECTED"
+        WebRequestError.ERROR_PORT_BLOCKED -> "net::ERR_UNSAFE_PORT"
+        WebRequestError.ERROR_REDIRECT_LOOP -> "net::ERR_TOO_MANY_REDIRECTS"
+        WebRequestError.ERROR_UNKNOWN_PROTOCOL -> "net::ERR_UNKNOWN_URL_SCHEME"
+        WebRequestError.ERROR_MALFORMED_URI -> "net::ERR_INVALID_URL"
+        WebRequestError.ERROR_FILE_NOT_FOUND -> "net::ERR_FILE_NOT_FOUND"
+        WebRequestError.ERROR_FILE_ACCESS_DENIED -> "net::ERR_ACCESS_DENIED"
+        WebRequestError.ERROR_SECURITY_SSL -> "net::ERR_SSL_PROTOCOL_ERROR"
+        WebRequestError.ERROR_SECURITY_BAD_CERT -> "net::ERR_CERT_AUTHORITY_INVALID"
+        WebRequestError.ERROR_BAD_HSTS_CERT -> "net::ERR_CERT_AUTHORITY_INVALID"
+        WebRequestError.ERROR_PROXY_CONNECTION_REFUSED -> "net::ERR_PROXY_CONNECTION_FAILED"
+        WebRequestError.ERROR_UNKNOWN_PROXY_HOST -> "net::ERR_PROXY_NAME_NOT_RESOLVED"
+        else -> error.message ?: "net::ERR_FAILED"
     }
 
     private fun setupProgressDelegate(session: GeckoSession, callback: BrowserEngineCallback) {
@@ -884,6 +1204,8 @@ class GeckoViewEngine(
                 .usePrivateMode(false)
                 .useTrackingProtection(false)
                 .userAgentMode(lastGeckoUaMode)
+                .viewportMode(lastGeckoViewportMode)
+                .allowJavascript(lastAllowJavascript)
                 .build()
 
             val newSession = GeckoSession(sessionSettings)
@@ -990,6 +1312,49 @@ class GeckoViewEngine(
             session?.purgeHistory()
         } catch (e: Exception) {
             AppLogger.e(TAG, "Error clearing history", e)
+        }
+    }
+
+    /**
+     * Find-in-page backed by Gecko's native finder (SessionFinder). The old claim that
+     * "findAllAsync has no GeckoView equivalent" was simply wrong — session.finder offers
+     * find/findNext/clear with match counts, so the native find bar works on both engines.
+     *
+     * @param forward null starts a fresh search for [text]; true/false steps to the
+     * next/previous match of the current search.
+     */
+    fun findInPage(
+        text: String,
+        forward: Boolean?,
+        onResult: (activeMatch: Int, totalMatches: Int) -> Unit
+    ) {
+        val s = session
+        if (s == null || text.isEmpty()) {
+            onResult(-1, 0)
+            return
+        }
+        try {
+            val finder = s.finder
+            finder.displayFlags = GeckoSession.FINDER_DISPLAY_HIGHLIGHT_ALL
+            val flags = if (forward == false) GeckoSession.FINDER_FIND_BACKWARDS else 0
+            if (forward == null) finder.clear()
+            finder.find(text, flags).accept({ result ->
+                val total = result?.total ?: 0
+                onResult(if (total > 0) result?.current ?: 0 else -1, total)
+            }, { e ->
+                AppLogger.w(TAG, "findInPage failed: ${e?.message}")
+                onResult(-1, 0)
+            })
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "findInPage failed: ${e.message}")
+            onResult(-1, 0)
+        }
+    }
+
+    fun clearFindMatches() {
+        try {
+            session?.finder?.clear()
+        } catch (_: Exception) {
         }
     }
 

--- a/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
@@ -75,8 +75,21 @@ class NativeBridge(
     private val customDownloadDirUri: String = "",
 
     /** The app's configured origin (target URL / local base) for CORS-bypass caller checks. */
-    private val appOriginUrl: String = ""
+    private val appOriginUrl: String = "",
+
+    /**
+     * Page-URL source for engines without a WebView (GeckoView). Caller gates read the current
+     * page URL from [webViewProvider] on the System WebView path; GeckoView has no WebView
+     * instance, so its engine supplies the live navigation URL here — without it every caller
+     * check sees an empty URL and rejects, killing the CORS-bypass / private-network bridge on
+     * the Gecko engine.
+     */
+    private val callerPageUrlProvider: (() -> String?)? = null
 ) {
+    /** The URL of the page currently calling into the bridge, across both engines. */
+    private fun resolveCallerPageUrl(): String =
+        webViewProvider()?.url ?: callerPageUrlProvider?.invoke().orEmpty()
+
     companion object {
         const val JS_INTERFACE_NAME = "NativeBridge"
         private const val PRIVATE_NETWORK_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
@@ -1310,7 +1323,7 @@ NativeBridge.googleSignIn('sign-in-' + Date.now());
                 // anything; the app's own remote origin may bypass CORS for internet APIs
                 // but must not probe the phone's local services; anything else (random
                 // iframes / navigations) is rejected outright.
-                val pageUrl = webViewProvider()?.url.orEmpty()
+                val pageUrl = resolveCallerPageUrl()
                 val pageIsLocal = isPrivateNetworkUrl(pageUrl) ||
                     pageUrl.startsWith("file:") ||
                     pageUrl.startsWith("content://") ||
@@ -1335,7 +1348,7 @@ NativeBridge.googleSignIn('sign-in-' + Date.now());
                 return privateNetworkBridgeError("URL_NOT_ALLOWED", "Only private network HTTP(S) URLs are allowed")
             }
             if (!corsBypass) {
-                val pageUrl = webViewProvider()?.url.orEmpty()
+                val pageUrl = resolveCallerPageUrl()
                 if (!isPrivateNetworkUrl(pageUrl)) {
                     AppLogger.w("NativeBridge", "Blocked private-network bridge request from non-local page: $pageUrl -> $url")
                     return privateNetworkBridgeError("CALLER_NOT_ALLOWED", "Only packaged local pages can use the private network bridge")

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewCallbacks.kt
@@ -38,6 +38,13 @@ interface WebViewCallbacks {
     fun onUrlChanged(webView: WebView?, url: String?) {}
 
     /**
+     * History navigation state changed (canGoBack/canGoForward). Only fired by engines that
+     * track history themselves (GeckoView's NavigationDelegate); the System WebView path keeps
+     * deriving the state from [onUrlChanged] + `WebView.canGoBack()`.
+     */
+    fun onNavigationStateChanged(canGoBack: Boolean, canGoForward: Boolean) {}
+
+    /**
      * A popup window was requested (newWindowBehavior = POPUP_WINDOW). Return true when the
      * host actually renders the popup transport; false makes WebViewManager fall back to
      * loading the popup URL in the same window so the navigation is never silently dropped.

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1340,6 +1340,7 @@ class WebViewManager(
         }
 
         GeckoViewEngine.applyAntiCapture(config.antiCapture)
+        GeckoViewEngine.applyAutoplayPolicy(config.mediaAutoplayEnabled)
 
         val tlsFingerprintEnabled = config.tlsFingerprintEnabled &&
             config.tlsFingerprintTemplate.isNotBlank()

--- a/app/src/main/java/com/webtoapp/ui/shell/FindInPageBar.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/FindInPageBar.kt
@@ -1,6 +1,5 @@
 package com.webtoapp.ui.shell
 
-import android.webkit.WebView
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -17,48 +16,43 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.webtoapp.core.engine.BrowserSurface
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.core.logging.AppLogger
 
 /**
- * Native find-in-page bottom bar (issue #614). Drives the WebView engine directly
- * (findAllAsync / findNext / clearMatches) instead of going through the JS module
- * panel, so match counting and highlighting are handled by the engine itself.
- *
- * Android-WebView only: findAllAsync has no GeckoView equivalent here — callers
- * hide the toolbar entry for non-system kernels.
+ * Native find-in-page bottom bar (issue #614). Drives the engine's native finder through
+ * [BrowserSurface] — WebView findAllAsync on the system kernel, GeckoView's SessionFinder on
+ * the Gecko kernel — instead of going through the JS module panel, so match counting and
+ * highlighting are handled by the engine itself on both kernels.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FindInPageBar(
-    webView: WebView?,
+    surface: BrowserSurface?,
     onClose: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var query by remember { mutableStateOf("") }
     var activeMatchOrdinal by remember { mutableIntStateOf(-1) }
     var numberOfMatches by remember { mutableIntStateOf(0) }
-    var doneCounting by remember { mutableStateOf(true) }
     val inputFocusRequester = remember { FocusRequester() }
     var inputFocused by remember { mutableStateOf(false) }
 
-    // Listen for engine-side counting results while the bar is up; detach (and drop
-    // the highlights) when it goes away.
-    DisposableEffect(webView) {
-        webView?.setFindListener { active, total, done ->
-            activeMatchOrdinal = if (total > 0) active else -1
-            numberOfMatches = total
-            doneCounting = done
-        }
+    fun onFindResult(active: Int, total: Int) {
+        activeMatchOrdinal = active
+        numberOfMatches = total
+    }
+
+    // Drop the highlights when the bar goes away.
+    DisposableEffect(surface) {
         onDispose {
             try {
-                webView?.clearMatches()
-                webView?.setFindListener(null)
+                surface?.clearFindMatches()
             } catch (e: Exception) {
                 AppLogger.w("FindInPageBar", "cleanup failed", e)
             }
@@ -68,8 +62,8 @@ fun FindInPageBar(
     // Cursor and IME ready as soon as the bar opens (#652): requestFocus alone leaves the
     // keyboard hidden, so wait for focus to land before raising the IME.
     val keyboard = LocalSoftwareKeyboardController.current
-    LaunchedEffect(webView) {
-        if (webView != null) {
+    LaunchedEffect(surface) {
+        if (surface != null) {
             inputFocusRequester.requestFocus()
             withFrameNanos { }
             if (inputFocused) keyboard?.show()
@@ -77,24 +71,23 @@ fun FindInPageBar(
     }
 
     // Live search as the query changes (debounced), like Chrome's find bar.
-    LaunchedEffect(query, webView) {
-        val wv = webView ?: return@LaunchedEffect
+    LaunchedEffect(query, surface) {
+        val s = surface ?: return@LaunchedEffect
         if (query.isBlank()) {
-            wv.clearMatches()
+            s.clearFindMatches()
             activeMatchOrdinal = -1
             numberOfMatches = 0
-            doneCounting = true
             return@LaunchedEffect
         }
         kotlinx.coroutines.delay(300)
         try {
-            wv.findAllAsync(query)
-            // findAllAsync makes the WebView steal view focus from this input, which
-            // swallowed the backspace key (type worked, delete did not). Re-claim it
-            // after each search unless the user moved focus away on purpose.
+            s.findInPage(query, forward = null, onResult = ::onFindResult)
+            // On the WebView kernel findAllAsync makes the WebView steal view focus from
+            // this input, which swallowed the backspace key (type worked, delete did not).
+            // Re-claim it after each search unless the user moved focus away on purpose.
             if (!inputFocused) inputFocusRequester.requestFocus()
         } catch (e: Exception) {
-            AppLogger.w("FindInPageBar", "findAllAsync failed", e)
+            AppLogger.w("FindInPageBar", "findInPage failed", e)
         }
     }
 
@@ -137,7 +130,9 @@ fun FindInPageBar(
                 keyboardActions = KeyboardActions(
                     onSearch = {
                         if (query.isNotBlank()) {
-                            try { webView?.findNext(true) } catch (e: Exception) {
+                            try {
+                                surface?.findInPage(query, forward = true, onResult = ::onFindResult)
+                            } catch (e: Exception) {
                                 AppLogger.w("FindInPageBar", "findNext failed", e)
                             }
                         }
@@ -152,8 +147,7 @@ fun FindInPageBar(
                 text = if (query.isBlank() || numberOfMatches <= 0) {
                     "0/0"
                 } else {
-                    "${(activeMatchOrdinal + 1).coerceIn(1, numberOfMatches)}/$numberOfMatches" +
-                        if (!doneCounting) "…" else ""
+                    "${(activeMatchOrdinal + 1).coerceIn(1, numberOfMatches)}/$numberOfMatches"
                 },
                 style = MaterialTheme.typography.labelMedium.copy(fontFamily = FontFamily.Monospace),
                 color = if (numberOfMatches > 0) {
@@ -167,8 +161,10 @@ fun FindInPageBar(
             IconButton(
                 onClick = {
                     if (query.isNotBlank()) {
-                        try { webView?.findNext(false) } catch (e: Exception) {
-                            AppLogger.w("FindInPageBar", "findNext failed", e)
+                        try {
+                            surface?.findInPage(query, forward = false, onResult = ::onFindResult)
+                        } catch (e: Exception) {
+                            AppLogger.w("FindInPageBar", "findPrev failed", e)
                         }
                     }
                 },
@@ -181,7 +177,9 @@ fun FindInPageBar(
             IconButton(
                 onClick = {
                     if (query.isNotBlank()) {
-                        try { webView?.findNext(true) } catch (e: Exception) {
+                        try {
+                            surface?.findInPage(query, forward = true, onResult = ::onFindResult)
+                        } catch (e: Exception) {
                             AppLogger.w("FindInPageBar", "findNext failed", e)
                         }
                     }

--- a/app/src/main/java/com/webtoapp/ui/shell/MultiWebShellMode.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/MultiWebShellMode.kt
@@ -51,7 +51,8 @@ fun MultiWebShellMode(
     onWebViewCreated: (WebView) -> Unit,
     swipeRefreshEnabled: Boolean = false,
     isRefreshing: Boolean = false,
-    onRefresh: () -> Unit = {}
+    onRefresh: () -> Unit = {},
+    onBrowserSurfaceCreated: (com.webtoapp.core.engine.BrowserSurface) -> Unit = {}
 ) {
     val multiWebConfig = config.multiWebConfig
     val sites = multiWebConfig.sites.filter { it.enabled }
@@ -76,11 +77,11 @@ fun MultiWebShellMode(
     }
 
     when (multiWebConfig.displayMode.uppercase()) {
-        "TABS" -> TabsMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh)
-        "CARDS" -> CardsMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh)
-        "FEED" -> FeedMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh)
-        "DRAWER" -> DrawerMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh)
-        else -> TabsMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh)
+        "TABS" -> TabsMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh, onBrowserSurfaceCreated)
+        "CARDS" -> CardsMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh, onBrowserSurfaceCreated)
+        "FEED" -> FeedMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh, onBrowserSurfaceCreated)
+        "DRAWER" -> DrawerMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh, onBrowserSurfaceCreated)
+        else -> TabsMode(config, multiWebConfig, sites, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh, onBrowserSurfaceCreated)
     }
 }
 
@@ -94,7 +95,8 @@ private fun SiteContent(
     onWebViewCreated: (WebView) -> Unit,
     swipeRefreshEnabled: Boolean,
     isRefreshing: Boolean,
-    onRefresh: () -> Unit
+    onRefresh: () -> Unit,
+    onBrowserSurfaceCreated: (com.webtoapp.core.engine.BrowserSurface) -> Unit = {}
 ) {
     val siteCfg = site.siteShellConfig
     val effectiveConfig = siteCfg?.copy(
@@ -121,7 +123,11 @@ private fun SiteContent(
         onRefresh = onRefresh,
         onWebViewCreated = onWebViewCreated,
         onWebViewRefUpdated = { },
-        onActivityFinish = { }
+        onActivityFinish = { },
+        // Without this the activity never sees per-site surfaces: on a Gecko site the
+        // media-session adapter is never attached and back/forward/find stay dead (#593
+        // parity for MULTI_WEB).
+        onBrowserSurfaceCreated = onBrowserSurfaceCreated
     )
 }
 
@@ -137,7 +143,8 @@ private fun TabsMode(
     onWebViewCreated: (WebView) -> Unit,
     swipeRefreshEnabled: Boolean,
     isRefreshing: Boolean,
-    onRefresh: () -> Unit
+    onRefresh: () -> Unit,
+    onBrowserSurfaceCreated: (com.webtoapp.core.engine.BrowserSurface) -> Unit = {}
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
     val tabsListState = rememberLazyListState()
@@ -280,7 +287,8 @@ private fun TabsMode(
                                 onWebViewCreated = if (isVisible) onWebViewCreated else ({ }),
                                 swipeRefreshEnabled = swipeRefreshEnabled,
                                 isRefreshing = isRefreshing,
-                                onRefresh = onRefresh
+                                onRefresh = onRefresh,
+                                onBrowserSurfaceCreated = onBrowserSurfaceCreated
                             )
                         }
                     }
@@ -302,7 +310,8 @@ private fun CardsMode(
     onWebViewCreated: (WebView) -> Unit,
     swipeRefreshEnabled: Boolean,
     isRefreshing: Boolean,
-    onRefresh: () -> Unit
+    onRefresh: () -> Unit,
+    onBrowserSurfaceCreated: (com.webtoapp.core.engine.BrowserSurface) -> Unit = {}
 ) {
     var openSite by remember { mutableStateOf<MultiWebSiteShellConfig?>(null) }
 
@@ -327,7 +336,7 @@ private fun CardsMode(
         ) { padding ->
             Box(modifier = Modifier.fillMaxSize().padding(padding)) {
                 key(site.id) {
-                    SiteContent(site, config, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh)
+                    SiteContent(site, config, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh, onBrowserSurfaceCreated)
                 }
             }
         }
@@ -504,7 +513,8 @@ private fun FeedMode(
     onWebViewCreated: (WebView) -> Unit,
     swipeRefreshEnabled: Boolean,
     isRefreshing: Boolean,
-    onRefresh: () -> Unit
+    onRefresh: () -> Unit,
+    onBrowserSurfaceCreated: (com.webtoapp.core.engine.BrowserSurface) -> Unit = {}
 ) {
     val scope = rememberCoroutineScope()
     var feedItems by remember { mutableStateOf<List<FeedItem>>(emptyList()) }
@@ -551,7 +561,8 @@ private fun FeedMode(
                         onRefresh = onRefresh,
                         onWebViewCreated = onWebViewCreated,
                         onWebViewRefUpdated = { },
-                        onActivityFinish = { }
+                        onActivityFinish = { },
+                        onBrowserSurfaceCreated = onBrowserSurfaceCreated
                     )
                 }
             }
@@ -649,7 +660,8 @@ private fun DrawerMode(
     onWebViewCreated: (WebView) -> Unit,
     swipeRefreshEnabled: Boolean,
     isRefreshing: Boolean,
-    onRefresh: () -> Unit
+    onRefresh: () -> Unit,
+    onBrowserSurfaceCreated: (com.webtoapp.core.engine.BrowserSurface) -> Unit = {}
 ) {
     var selectedSite by remember { mutableStateOf(sites.firstOrNull()) }
     var drawerVisible by remember { mutableStateOf(false) }
@@ -700,7 +712,7 @@ private fun DrawerMode(
             Box(modifier = Modifier.fillMaxSize().padding(padding)) {
                 currentSite?.let { site ->
                     key(site.id) {
-                        SiteContent(site, config, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh)
+                        SiteContent(site, config, webViewConfig, webViewCallbacks, webViewManager, onWebViewCreated, swipeRefreshEnabled, isRefreshing, onRefresh, onBrowserSurfaceCreated)
                     }
                 } ?: run {
                     Column(modifier = Modifier.align(Alignment.Center), horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -680,6 +680,7 @@ class ShellActivity : AppCompatActivity() {
             activity = this,
             getCustomView = { customView },
             getWebView = { webView },
+            getBrowserSurface = { browserSurface },
             hideCustomView = ::hideCustomView,
             getShellConfig = { shellConfig }
         ))

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivityInit.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivityInit.kt
@@ -170,6 +170,7 @@ object ShellActivityInit {
         activity: AppCompatActivity,
         getCustomView: () -> android.view.View?,
         getWebView: () -> WebView?,
+        getBrowserSurface: () -> com.webtoapp.core.engine.BrowserSurface?,
         hideCustomView: () -> Unit,
         getShellConfig: () -> ShellConfig?
     ): OnBackPressedCallback {
@@ -208,7 +209,11 @@ object ShellActivityInit {
                                 ShellWebViewNavigation.goBackOrFinish(activity, wv, useJsHistoryBack = useJsHistoryBack)
                             }
                         } else {
-                            activity.finish()
+                            // GeckoView kernel: no WebView handle — walk the engine's own
+                            // history through the surface instead of exiting the app on every
+                            // back press. The Escape-key JS probe is skipped: Gecko's
+                            // javascript: URI eval cannot return a result to consult.
+                            ShellWebViewNavigation.goBackOrFinish(activity, getBrowserSurface())
                         }
                     }
                 }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellBrowserView.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellBrowserView.kt
@@ -76,7 +76,8 @@ fun ShellBrowserAndroidView(
                         allowGlobalModuleFallback = false,
                         extensionEnabled = config.extensionEnabled,
                         browserDisguiseConfig = config.browserDisguiseConfig,
-                        deviceDisguiseConfig = config.deviceDisguiseConfig
+                        deviceDisguiseConfig = config.deviceDisguiseConfig,
+                        appOriginUrl = config.targetUrl
                     )
                     surfaceRef = surface
                     tag = surface

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellContentRouter.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellContentRouter.kt
@@ -68,7 +68,8 @@ fun ShellContentRouter(
                 onWebViewRefUpdated = onWebViewRefUpdated,
                 swipeRefreshEnabled = swipeRefreshEnabled,
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                onBrowserSurfaceCreated = onBrowserSurfaceCreated
             )
         }
         appType == "NODEJS_APP" -> {
@@ -85,7 +86,8 @@ fun ShellContentRouter(
                     onWebViewRefUpdated = onWebViewRefUpdated,
                     swipeRefreshEnabled = swipeRefreshEnabled,
                     isRefreshing = isRefreshing,
-                    onRefresh = onRefresh
+                    onRefresh = onRefresh,
+                    onBrowserSurfaceCreated = onBrowserSurfaceCreated
                 )
             } else {
 
@@ -99,7 +101,8 @@ fun ShellContentRouter(
                 onWebViewRefUpdated = onWebViewRefUpdated,
                     swipeRefreshEnabled = swipeRefreshEnabled,
                     isRefreshing = isRefreshing,
-                    onRefresh = onRefresh
+                    onRefresh = onRefresh,
+                    onBrowserSurfaceCreated = onBrowserSurfaceCreated
                 )
             }
         }
@@ -114,7 +117,8 @@ fun ShellContentRouter(
                 onWebViewRefUpdated = onWebViewRefUpdated,
                 swipeRefreshEnabled = swipeRefreshEnabled,
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                onBrowserSurfaceCreated = onBrowserSurfaceCreated
             )
         }
         appType == "PYTHON_APP" -> {
@@ -130,7 +134,8 @@ fun ShellContentRouter(
                 onWebViewRefUpdated = onWebViewRefUpdated,
                 swipeRefreshEnabled = swipeRefreshEnabled,
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                onBrowserSurfaceCreated = onBrowserSurfaceCreated
             )
         }
         appType == "GO_APP" -> {
@@ -145,7 +150,8 @@ fun ShellContentRouter(
                 onWebViewRefUpdated = onWebViewRefUpdated,
                 swipeRefreshEnabled = swipeRefreshEnabled,
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                onBrowserSurfaceCreated = onBrowserSurfaceCreated
             )
         }
         appType == "MULTI_WEB" -> {
@@ -161,7 +167,8 @@ fun ShellContentRouter(
                     onWebViewCreated = onWebViewCreated,
                     swipeRefreshEnabled = swipeRefreshEnabled,
                     isRefreshing = isRefreshing,
-                    onRefresh = onRefresh
+                    onRefresh = onRefresh,
+                    onBrowserSurfaceCreated = onBrowserSurfaceCreated
                 )
             }
         }
@@ -176,7 +183,8 @@ fun ShellContentRouter(
                 onWebViewRefUpdated = onWebViewRefUpdated,
                 swipeRefreshEnabled = swipeRefreshEnabled,
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                onBrowserSurfaceCreated = onBrowserSurfaceCreated
             )
         }
         else -> {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -50,6 +50,7 @@ fun BoxScope.ShellScaffoldLayout(
     webViewRecreationKey: Int,
 
     webViewRef: WebView?,
+    browserSurface: com.webtoapp.core.engine.BrowserSurface? = null,
     webViewConfig: WebViewConfig,
     webViewCallbacks: WebViewCallbacks,
     webViewManager: com.webtoapp.core.webview.WebViewManager,
@@ -90,7 +91,9 @@ fun BoxScope.ShellScaffoldLayout(
         val controller = com.webtoapp.core.webview.AutoRefreshController(
             intervalSec = webViewConfig.autoRefreshIntervalSec.coerceAtLeast(1),
             showCountdown = webViewConfig.autoRefreshShowCountdown,
-            onReload = { webViewRef?.reload() }
+            // Surface-first: webViewRef stays null on the GeckoView kernel, where the
+            // countdown used to run against a reload that never happened.
+            onReload = { browserSurface?.reload() ?: webViewRef?.reload() }
         )
         autoRefreshController = controller
         controller.start()
@@ -103,8 +106,8 @@ fun BoxScope.ShellScaffoldLayout(
     }
 
     val toolbarCfg = config.webViewConfig
-    // Native find-in-page drives WebView.findAllAsync — system WebView only.
-    val findInPageSupported = config.engineType == "SYSTEM_WEBVIEW"
+    // Find-in-page runs on both kernels: WebView findAllAsync on the system engine,
+    // GeckoView's native SessionFinder on the Gecko engine (BrowserSurface.findInPage).
     val toolbarEnabled = toolbarCfg.browserToolbarEnabled
     val hasAnyItem = hasAnyToolbarItem(
         toolbarShowTitle = toolbarCfg.toolbarShowTitle,
@@ -113,7 +116,7 @@ fun BoxScope.ShellScaffoldLayout(
         toolbarShowForward = toolbarCfg.toolbarShowForward,
         toolbarShowRefresh = toolbarCfg.toolbarShowRefresh,
         toolbarShowConsole = toolbarCfg.toolbarShowConsole,
-        toolbarShowFind = toolbarCfg.toolbarShowFind && findInPageSupported
+        toolbarShowFind = toolbarCfg.toolbarShowFind
     )
     val showToolbar = toolbarEnabled && hasAnyItem &&
         (!hideToolbar || config.webViewConfig.showToolbarInFullscreen)
@@ -152,11 +155,12 @@ fun BoxScope.ShellScaffoldLayout(
                     canGoBack = canGoBack,
                     canGoForward = canGoForward,
                     webViewRef = webViewRef,
+                    browserSurface = browserSurface,
                     showConsoleButton = toolbarVisibility.showConsoleButton,
                     showConsole = showConsole,
                     onToggleConsole = onToggleConsole,
                     consoleErrorCount = consoleMessages.count { it.level == ConsoleLevel.ERROR },
-                    showFindButton = toolbarVisibility.showFind && findInPageSupported,
+                    showFindButton = toolbarVisibility.showFind,
                     showFindBar = showFindBar,
                     onToggleFindBar = onToggleFindBar
                 )
@@ -288,15 +292,15 @@ fun BoxScope.ShellScaffoldLayout(
                 )
             }
 
-            // Find-in-page bar (native WebView search; slides up like the console)
+            // Find-in-page bar (native engine search; slides up like the console)
             AnimatedVisibility(
-                visible = showFindBar && findInPageSupported,
+                visible = showFindBar,
                 enter = androidx.compose.animation.slideInVertically(initialOffsetY = { it }) + fadeIn(),
                 exit = androidx.compose.animation.slideOutVertically(targetOffsetY = { it }) + fadeOut(),
                 modifier = Modifier.align(Alignment.BottomCenter)
             ) {
                 FindInPageBar(
-                    webView = webViewRef,
+                    surface = browserSurface,
                     onClose = onToggleFindBar
                 )
             }
@@ -318,6 +322,7 @@ private fun ShellTopAppBar(
     canGoBack: Boolean,
     canGoForward: Boolean,
     webViewRef: WebView?,
+    browserSurface: com.webtoapp.core.engine.BrowserSurface? = null,
     showConsoleButton: Boolean = true,
     showConsole: Boolean = false,
     onToggleConsole: () -> Unit = {},
@@ -357,7 +362,13 @@ private fun ShellTopAppBar(
                 com.webtoapp.ui.design.WtaIconButton(
                     onClick = {
                         (context as? AppCompatActivity)?.let { activity ->
-                            ShellWebViewNavigation.goBackOrFinish(activity, webViewRef)
+                            // Surface-first: on the GeckoView kernel webViewRef is null and
+                            // the engine's own history must drive back navigation.
+                            if (browserSurface != null) {
+                                ShellWebViewNavigation.goBackOrFinish(activity, browserSurface)
+                            } else {
+                                ShellWebViewNavigation.goBackOrFinish(activity, webViewRef)
+                            }
                         }
                     },
                     icon = Icons.AutoMirrored.Filled.ArrowBack,
@@ -367,7 +378,7 @@ private fun ShellTopAppBar(
             }
             if (showForward) {
                 com.webtoapp.ui.design.WtaIconButton(
-                    onClick = { webViewRef?.goForward() },
+                    onClick = { browserSurface?.goForward() ?: webViewRef?.goForward() },
                     icon = Icons.AutoMirrored.Filled.ArrowForward,
                     contentDescription = "Forward",
                     enabled = canGoForward
@@ -375,7 +386,7 @@ private fun ShellTopAppBar(
             }
             if (showRefresh) {
                 com.webtoapp.ui.design.WtaIconButton(
-                    onClick = { webViewRef?.reload() },
+                    onClick = { browserSurface?.reload() ?: webViewRef?.reload() },
                     icon = Icons.Default.Refresh,
                     contentDescription = "Refresh"
                 )
@@ -397,7 +408,8 @@ private fun ShellTopAppBar(
                     )
                 }
             }
-            // Find-in-page button: opens the native bottom find bar (system WebView only).
+            // Find-in-page button: opens the native bottom find bar (works on both kernels
+            // — WebView findAllAsync and GeckoView SessionFinder via BrowserSurface).
             if (showFindButton) {
                 com.webtoapp.ui.design.WtaIconButton(
                     onClick = onToggleFindBar,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -145,6 +145,9 @@ fun ShellScreen(
     }
 
     var webViewRef by remember { mutableStateOf<WebView?>(null) }
+    var browserSurfaceRef by remember {
+        mutableStateOf<com.webtoapp.core.engine.BrowserSurface?>(null)
+    }
     var statusBarAutoColor by remember { mutableStateOf<String?>(null) }
     var statusBarColorTracker by remember { mutableStateOf<com.webtoapp.core.webview.StatusBarPageColorTracker?>(null) }
 
@@ -474,6 +477,7 @@ fun ShellScreen(
         canGoForward = canGoForward,
         webViewRecreationKey = webViewRecreationKey,
         webViewRef = webViewRef,
+        browserSurface = browserSurfaceRef,
         webViewConfig = webViewConfig,
         webViewCallbacks = webViewCallbacks,
         webViewManager = webViewManager,
@@ -483,7 +487,10 @@ fun ShellScreen(
         isRefreshing = isRefreshing,
         onRefresh = { isRefreshing = true },
         onWebViewCreated = handleWebViewCreated,
-        onBrowserSurfaceCreated = onBrowserSurfaceCreated,
+        onBrowserSurfaceCreated = { surface ->
+            browserSurfaceRef = surface
+            onBrowserSurfaceCreated(surface)
+        },
         onWebViewRefUpdated = { webViewRef = it },
         onShowActivationDialog = { showActivationDialog = true },
         onErrorDismiss = { errorMessage = null },
@@ -495,7 +502,11 @@ fun ShellScreen(
         showFindBar = showFindBar,
         onToggleFindBar = { showFindBar = !showFindBar },
         onRunScript = { script ->
-            webViewRef?.evaluateJavascript(script) { result ->
+            // Surface-first so the console also evaluates on the GeckoView kernel
+            // (webViewRef stays null there; Gecko cannot return the eval result, so
+            // the entry shows "=> null" but the script does run in the page).
+            val surface = browserSurfaceRef
+            val appendResult: (String?) -> Unit = { result ->
                 consoleMessages = consoleMessages + ConsoleLogEntry(
                     level = ConsoleLevel.LOG,
                     message = "=> $result",
@@ -503,6 +514,11 @@ fun ShellScreen(
                     lineNumber = 0,
                     timestamp = System.currentTimeMillis()
                 )
+            }
+            if (surface != null) {
+                surface.evaluateJavascript(script, appendResult)
+            } else {
+                webViewRef?.evaluateJavascript(script, appendResult)
             }
         },
         statusBarHeightDp = statusBarHeightDp

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
@@ -78,6 +78,13 @@ fun createShellWebViewCallbacks(
             scheduleStatusBarAutoColorSample()
         }
 
+        override fun onNavigationStateChanged(canGoBack: Boolean, canGoForward: Boolean) {
+            // GeckoView kernel: history state arrives as engine events because there is no
+            // WebView to poll (webViewRefProvider() stays null). Without this the toolbar
+            // back/forward buttons never enable in generated Gecko apps.
+            updateNavigation(canGoBack, canGoForward)
+        }
+
         override fun onPageCommitVisible(url: String?) {
             scheduleStatusBarAutoColorSample()
         }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewNavigation.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewNavigation.kt
@@ -2,6 +2,7 @@ package com.webtoapp.ui.shell
 
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
+import com.webtoapp.core.engine.BrowserSurface
 
 object ShellWebViewNavigation {
 
@@ -24,6 +25,30 @@ object ShellWebViewNavigation {
             return
         }
         goBackNative(activity, wv)
+    }
+
+    /**
+     * Surface-aware back navigation. On the System WebView kernel this delegates to the
+     * WebView resolver above (history heuristics + optional JS history.back). On GeckoView
+     * there is no WebView handle and no JS-result channel (Gecko's evaluateJavascript cannot
+     * return values), so back walks the engine's own history — previously this path fell
+     * through to finish(), making the back button always exit generated Gecko apps.
+     */
+    fun goBackOrFinish(
+        activity: AppCompatActivity,
+        surface: BrowserSurface?,
+        useJsHistoryBack: Boolean = false
+    ) {
+        val wv = surface?.webView
+        if (wv != null) {
+            goBackOrFinish(activity, wv, useJsHistoryBack)
+            return
+        }
+        if (surface != null && surface.canGoBack()) {
+            surface.goBack()
+            return
+        }
+        activity.finish()
     }
 
     private fun goBackViaJsHistoryBack(activity: AppCompatActivity, webView: WebView) {

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -137,6 +137,7 @@ class WebViewActivity : AppCompatActivity() {
     internal var geckoMediaAdapter: com.webtoapp.core.engine.GeckoMediaSessionAdapter? = null
 
     private var pendingPermissionRequest: PermissionRequest? = null
+    private var pendingEnginePermissionCallback: ((Boolean) -> Unit)? = null
     private var pendingGeolocationOrigin: String? = null
     private var pendingGeolocationCallback: GeolocationPermissions.Callback? = null
     private val pendingLocationAccessCallbacks = mutableListOf<(Boolean) -> Unit>()
@@ -482,6 +483,41 @@ class WebViewActivity : AppCompatActivity() {
                 request.deny()
             }
             pendingPermissionRequest = null
+        }
+    }
+
+    /**
+     * Android runtime permission requests coming from the GeckoView engine
+     * (PermissionDelegate.onAndroidPermissionsRequest). The engine must not auto-grant:
+     * without the real OS dialog, geolocation/camera/mic silently fail because Gecko is
+     * told the permission exists while it was never obtained (#344 — the shell already
+     * does this properly; the host preview used to fall through to the default grant).
+     */
+    private val enginePermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val allGranted = permissions.values.all { it }
+        pendingEnginePermissionCallback?.invoke(allGranted)
+        pendingEnginePermissionCallback = null
+    }
+
+    fun handleAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {
+        val notGranted = permissions.distinct().filter {
+            androidx.core.content.ContextCompat.checkSelfPermission(
+                this, it
+            ) != android.content.pm.PackageManager.PERMISSION_GRANTED
+        }
+        if (notGranted.isEmpty()) {
+            onResult(true)
+            return
+        }
+        pendingEnginePermissionCallback = onResult
+        try {
+            enginePermissionLauncher.launch(notGranted.toTypedArray())
+        } catch (e: Exception) {
+            AppLogger.e("WebViewActivity", "Engine permission request failed", e)
+            pendingEnginePermissionCallback = null
+            onResult(false)
         }
     }
 
@@ -940,7 +976,16 @@ class WebViewActivity : AppCompatActivity() {
                                 ShellWebViewNavigation.goBackOrFinish(this@WebViewActivity, wv, useJsHistoryBack = enableBackStatePreservation)
                             }
                         } else {
-                            finish()
+                            // GeckoView engine: no WebView handle — walk the engine's own
+                            // history through the surface. The Escape-key JS probe is skipped
+                            // (it needs an eval result, which Gecko's javascript: URI path
+                            // cannot return); back used to exit the preview outright here.
+                            val surface = browserSurface
+                            if (surface != null && surface.canGoBack()) {
+                                surface.goBack()
+                            } else {
+                                finish()
+                            }
                         }
                     }
                 }
@@ -2417,6 +2462,19 @@ fun WebViewScreen(
                 statusBarColorTracker?.scheduleSample(48L)
             }
 
+            override fun onNavigationStateChanged(newCanGoBack: Boolean, newCanGoForward: Boolean) {
+                // GeckoView engine path: history state arrives as events (the WebView path
+                // derives it from onUrlChanged). Without this the toolbar/floating back
+                // affordances never enable on Gecko.
+                canGoBack = newCanGoBack
+                canGoForward = newCanGoForward
+            }
+
+            override fun onAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {
+                (context as? WebViewActivity)?.handleAndroidPermissionsRequest(permissions, onResult)
+                    ?: onResult(true)
+            }
+
             override fun onPageFinished(url: String?) {
                 if (url == "about:blank") return
                 isLoading = false
@@ -2850,10 +2908,8 @@ fun WebViewScreen(
     val showToolbarInPreview = !hideToolbar || webApp?.webViewConfig?.showToolbarInFullscreen == true
 
     val toolbarCfg = webApp?.webViewConfig
-    // Native find-in-page drives WebView.findAllAsync — system WebView only.
-    // Declared here (not inside the toolbar actions) so the toolbar predicate
-    // below can discount the find item on non-system engines, mirroring the shell.
-    val findInPageSupported = (webApp?.apkExportConfig?.engineType ?: "SYSTEM_WEBVIEW") == "SYSTEM_WEBVIEW"
+    // Find-in-page runs on both kernels now (WebView findAllAsync; GeckoView SessionFinder
+    // through BrowserSurface.findInPage), so no engine gate remains here or in the shell.
     val hasAnyToolbarItem = toolbarCfg?.let {
         hasAnyToolbarItem(
             toolbarShowTitle = it.toolbarShowTitle,
@@ -2862,7 +2918,7 @@ fun WebViewScreen(
             toolbarShowForward = it.toolbarShowForward,
             toolbarShowRefresh = it.toolbarShowRefresh,
             toolbarShowConsole = it.toolbarShowConsole,
-            toolbarShowFind = it.toolbarShowFind && findInPageSupported
+            toolbarShowFind = it.toolbarShowFind
         )
     } == true
     val shouldShowTopBar = showToolbarInPreview && toolbarEnabled && hasAnyToolbarItem
@@ -2928,7 +2984,13 @@ fun WebViewScreen(
                             com.webtoapp.ui.design.WtaIconButton(
                                 onClick = {
                                     (context as? AppCompatActivity)?.let { activity ->
-                                        ShellWebViewNavigation.goBackOrFinish(activity, webViewRef)
+                                        // Surface-first: on the GeckoView kernel webViewRef is
+                                        // null and the engine's own history drives back.
+                                        if (browserSurfaceRef != null) {
+                                            ShellWebViewNavigation.goBackOrFinish(activity, browserSurfaceRef)
+                                        } else {
+                                            ShellWebViewNavigation.goBackOrFinish(activity, webViewRef)
+                                        }
                                     }
                                 },
                                 icon = Icons.AutoMirrored.Filled.ArrowBack,
@@ -2938,7 +3000,7 @@ fun WebViewScreen(
                         }
                         if (isTestMode || browserToolbarVisibility?.showForward == true) {
                             com.webtoapp.ui.design.WtaIconButton(
-                                onClick = { webViewRef?.goForward() },
+                                onClick = { browserSurfaceRef?.goForward() ?: webViewRef?.goForward() },
                                 icon = Icons.AutoMirrored.Filled.ArrowForward,
                                 contentDescription = "Forward",
                                 enabled = canGoForward
@@ -2968,9 +3030,9 @@ fun WebViewScreen(
                                 )
                             }
                         }
-                        // Find-in-page button: opens the native bottom find bar. System
-                        // WebView only — findAllAsync has no GeckoView equivalent here.
-                        if ((isTestMode || browserToolbarVisibility?.showFind == true) && (isTestMode || findInPageSupported)) {
+                        // Find-in-page button: opens the native bottom find bar (both
+                        // kernels — WebView findAllAsync and GeckoView SessionFinder).
+                        if (isTestMode || browserToolbarVisibility?.showFind == true) {
                             com.webtoapp.ui.design.WtaIconButton(
                                 onClick = { showFindBar = !showFindBar },
                                 icon = if (showFindBar) Icons.Filled.Search else Icons.Outlined.Search,
@@ -3172,6 +3234,23 @@ fun WebViewScreen(
                         onRefresh = {
                             isRefreshing = true
                             reloadBrowser()
+                        },
+                        onBrowserSurfaceCreated = { surface ->
+                            // Mirror the single-app preview wiring: keep the compose-level
+                            // and activity-level surface refs (back/forward/find/console) and
+                            // attach the Gecko media-session adapter for engine sites (#593
+                            // parity — MULTI_WEB previously never saw per-site surfaces).
+                            browserSurfaceRef = surface
+                            (context as? WebViewActivity)?.browserSurface = surface
+                            if (surface.webView == null && mwApp.webViewConfig.enableMediaSession) {
+                                val geckoEngine = surface.engine as? com.webtoapp.core.engine.GeckoViewEngine
+                                if (geckoEngine != null) {
+                                    (context as? WebViewActivity)?.let { host ->
+                                        host.geckoMediaAdapter?.runCatching { release() }
+                                        host.geckoMediaAdapter = com.webtoapp.core.engine.GeckoMediaSessionAdapter(host, geckoEngine)
+                                    }
+                                }
+                            }
                         }
                     )
                 } else {
@@ -3254,7 +3333,8 @@ fun WebViewScreen(
                                     allowGlobalModuleFallback = false,
                                     extensionEnabled = extensionMasterEnabled,
                                     browserDisguiseConfig = webApp?.browserDisguiseConfig,
-                                    deviceDisguiseConfig = webApp?.deviceDisguiseConfig
+                                    deviceDisguiseConfig = webApp?.deviceDisguiseConfig,
+                                    appOriginUrl = webApp?.url.orEmpty()
                                 )
                                 tag = surface
                                 browserSurfaceRef = surface
@@ -3384,6 +3464,12 @@ fun WebViewScreen(
                                             ViewGroup.LayoutParams.MATCH_PARENT
                                         )
                                     )
+                                    // Gecko engine preview: the WebView branch above ends with
+                                    // loadUrl(targetUrl); this branch never navigated at all, so
+                                    // plain WEB/HTML previews on Gecko/ECH showed a blank view.
+                                    if (targetUrl.isNotEmpty()) {
+                                        loadInBrowser(targetUrl)
+                                    }
                                 }
                             }
                         },
@@ -3407,7 +3493,10 @@ fun WebViewScreen(
                             onExpandToggle = { isConsoleExpanded = !isConsoleExpanded },
                             onClear = { consoleMessages = emptyList() },
                             onRunScript = { script ->
-                                webViewRef?.evaluateJavascript(script) { result ->
+                                // Surface-first so eval also runs on the GeckoView kernel
+                                // (webViewRef stays null there; Gecko cannot return the eval
+                                // result, so the entry shows "=> null" but the script runs).
+                                val appendResult: (String?) -> Unit = { result ->
                                     consoleMessages = consoleMessages + ConsoleLogEntry(
                                         level = ConsoleLevel.LOG,
                                         message = "=> $result",
@@ -3415,6 +3504,12 @@ fun WebViewScreen(
                                         lineNumber = 0,
                                         timestamp = System.currentTimeMillis()
                                     )
+                                }
+                                val surface = browserSurfaceRef
+                                if (surface != null) {
+                                    surface.evaluateJavascript(script, appendResult)
+                                } else {
+                                    webViewRef?.evaluateJavascript(script, appendResult)
                                 }
                             },
                             onClose = { showConsole = false }
@@ -3427,7 +3522,9 @@ fun WebViewScreen(
                         exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
                     ) {
                         com.webtoapp.ui.shell.FindInPageBar(
-                            webView = webViewRef,
+                            surface = browserSurfaceRef ?: webViewRef?.let {
+                                com.webtoapp.core.engine.BrowserSurface.fromWebView(it)
+                            },
                             onClose = { showFindBar = false }
                         )
                     }
@@ -3523,7 +3620,13 @@ fun WebViewScreen(
                     onClick = {
                         fadeKey++
                         (context as? AppCompatActivity)?.let { activity ->
-                            ShellWebViewNavigation.goBackOrFinish(activity, webViewRef)
+                            // Surface-first: the floating back button must walk Gecko
+                            // history too (webViewRef is null on that kernel).
+                            if (browserSurfaceRef != null) {
+                                ShellWebViewNavigation.goBackOrFinish(activity, browserSurfaceRef)
+                            } else {
+                                ShellWebViewNavigation.goBackOrFinish(activity, webViewRef)
+                            }
                         }
                     },
                     modifier = Modifier


### PR DESCRIPTION
## Summary

Fixes #824.

The GeckoView engine path bypasses the WebView-only feature pipeline (`WebViewManager.configureWebView` + `addJavascriptInterface` bridges are never invoked on the Gecko branch), which left a set of features silently broken — dead UI, swallowed prompts, a fully rejected CORS bridge — rather than visibly unsupported. This PR fixes every gap that existing GeckoView APIs can close without the (follow-up) WebExtension injection bus:

**Regression fixes**
- CORS-bypass / private-network bridge on Gecko was 100% rejected since the caller-gate hardening (43a5c564): the Gecko `NativeBridge` construction passed `webViewProvider = { null }` and no `appOriginUrl`, so the gate always saw an empty page URL. `NativeBridge` gains a `callerPageUrlProvider` (Gecko supplies the live navigation URL) and `appOriginUrl` is now threaded `EngineViewFactory.create` → `GeckoViewEngine` from both call sites (shell `config.targetUrl`, host `webApp.url`).
- Host single-app preview never issued the initial `loadUrl` on the Gecko branch — WEB/HTML previews rendered blank. Now loads through the surface.
- Back press exited generated Gecko apps (`webView == null` → `finish()`). Hardware back, toolbar back, and the floating back button now walk the engine's history via `BrowserSurface`; new `onNavigationStateChanged` event (Gecko `onCanGoBack/onCanGoForward` → `BrowserEngineCallback` → `WebViewCallbacks`) drives toolbar button enablement in shell + host. Toolbar refresh, auto-refresh, and console eval are surface-first too.

**New Gecko delegates**
- `PromptDelegate`: `onAlertPrompt` / `onButtonPrompt` / `onTextPrompt` native dialogs (previously dismissed silently) and `onAuthPrompt` for HTTP Basic/proxy auth, reusing the WebView path's dialog shape and the existing `httpAuth*` 10-language strings.
- `NavigationDelegate.onLoadError`: maps `WebRequestError` onto the `net::ERR_*` vocabulary the WebView path produces and routes into the existing `onError` / `onSslError` chains, so shell/host error UI (error card, failover entry) fires on Gecko.

**Find-in-page on both engines**
- The "findAllAsync has no GeckoView equivalent" claim was wrong: `GeckoSession.getFinder()` (SessionFinder) provides find/findNext/clear with match counts. `BrowserSurface.findInPage/clearFindMatches` abstracts both engines, `FindInPageBar` is rewritten against it, and the `engineType == "SYSTEM_WEBVIEW"` gates (which also misfired on ECH-forced Gecko and silent runtime fallbacks) are removed.

**Surface propagation**
- `ShellContentRouter` now passes `onBrowserSurfaceCreated` to MULTI_WEB (`SiteContent` included) and all server-runtime branches (WordPress / Node static+server / PHP / Python / Go / HTML-FRONTEND); previously the Gecko media-session adapter never attached and back/find stayed dead for those app types. Host multi-web preview wires the surface + adapter as well.

**Config parity + permissions**
- Host preview now requests real Android runtime permissions for engine permission requests instead of the default auto-grant (#344 parity with the shell).
- Gecko honors per-app config: session-level `allowJavascript` (`javaScriptEnabled=false` no longer ignored), desktop UA mode including `desktopMode`, `viewportMode` FIT_SCREEN/DESKTOP → `VIEWPORT_MODE_DESKTOP`, autoplay policy via the `media.autoplay.default` pref (added to the runtime fingerprint so changes recreate the runtime like proxy/ECH do), `clearBrowsingDataOnLaunch` via `StorageController`, and `downloadEnabled=false` now suppresses `onExternalResponse` downloads. Crash-recovery session rebuild preserves the new settings.

**Explicitly out of scope** (documented in #824): the JS-injection feature set (adblock, userscripts/GM, Chrome extensions, disguise/polyfills, full NativeBridge API, PWA offline, static asset packs) pending a generic WebExtension injection bus, and structurally-impossible items (TLS-fingerprint MITM by design, SSL-error proceed, state save/restore, editor CA anchors).

## Test plan

- [x] CI gate command run locally on the branch (clean worktree off `main`): `:app:compileStandardDebugKotlin`, `:shell:compileDebugKotlin`, `:app:testStandardDebugUnitTest`, `:app:checkConfigFieldDrift` — BUILD SUCCESSFUL, zero errors.
- [x] No config-field changes (drift gate untouched semantics; `checkConfigFieldDrift` green).
- [ ] Emulator pass with the downloaded Gecko runtime recommended after merge: back-key history walk, find-in-page on a Gecko app, alert/confirm/prompt + Basic-auth dialogs, error card on airplane-mode load, CORS-bypass fetch from a packaged local page, MULTI_WEB Gecko site media controls.