### PR TITLE
docs(guide): GeckoView feature support section on Browser Kernel pages (EN + ZH)

### DIFF
--- a/docs/guide/more-features/browser-kernel.md
+++ b/docs/guide/more-features/browser-kernel.md
@@ -13,3 +13,52 @@ Manage the browser engines available to your apps. Open it from [⋮ → Browser
 
 - Per-app engine selection happens in the [Build APK](/guide/app-actions/build-apk) dialog; this screen manages the engines themselves.
 - GeckoView is required for [ECH](/guide/config/network).
+
+## GeckoView (Firefox engine) feature support
+
+GeckoView is a complete second engine independent of the system WebView, not a WebView skin: its network-layer capabilities are implemented natively by the engine, while a set of features that rely on WebView-only mechanisms (request interception, `addJavascriptInterface`, JS injection) are unavailable on GeckoView. Read this section before picking a kernel in the Build APK dialog.
+
+### Fully supported (native implementations, on par with the system WebView)
+
+- **ECH (encrypted SNI)** — GeckoView only; enabling ECH automatically switches the app to this engine
+- DoH, static / PAC / SOCKS5 proxy, anti-capture (force direct connection, ignore system proxies)
+- UA modes and custom User-Agent, desktop mode
+- JavaScript toggle, autoplay policy, viewport mode (fit screen / desktop), clear browsing data on launch, download toggle
+- HTTP downloads, fullscreen video, file upload (incl. camera capture), automatic crash recovery
+- Camera / microphone and geolocation permission policies (deny all / remember per host)
+- mTLS client certificates, HTTP Basic / proxy auth dialogs
+- JS dialogs (alert / confirm / prompt)
+- Page-load error UI, back / forward history navigation, auto-refresh, find-in-page, console script execution
+- Media session / lock-screen playback controls (native Gecko implementation)
+
+### Not available yet (choose the system WebView kernel if you need these)
+
+- **[Ad blocking](/guide/app-actions/edit-common-config/ad-blocking)** — neither network-rule filtering nor cosmetic hiding takes effect
+- **[Userscripts](/extensions/userscript) (GM_\* APIs) and [Chrome MV3 extensions](/extensions/chrome-mv3)** (incl. declarativeNetRequest / webRequest rules)
+- **The full [NativeBridge](/extensions/api-reference) JS API** — clipboard, notifications, vibration, printing, sharing, screen wake, orientation, Google sign-in, etc.; on GeckoView only the CORS-bypass / private-network `httpRequest` entry point is available
+- **JS-injection features** — browser fingerprint disguise, [device disguise](/guide/app-actions/edit-common-config/device-disguise), kernel disguise & flavors, [page translation](/guide/app-actions/edit-common-config/translate), audio unlock, clipboard / notification / orientation polyfills, Cloudflare compatibility helpers, custom injected scripts, popup blocking, scroll-position memory, image repair, hide-link-preview
+- **PWA offline (service-worker injection), static asset packs, encrypted asset loading** — therefore **HTML / [front-end offline-package](/guide/app-types/frontend) apps with resource encryption enabled must use the system WebView kernel**
+- blob / data: download interception
+- The [long-press menu](/guide/app-actions/edit-common-config/long-press-menu) (save image/video, copy link, etc.)
+- Status-bar auto color sampling (follow page-top color; solid-color / theme modes are unaffected)
+- Page zoom settings (zoom percent / initial scale / text zoom; GeckoView keeps only its built-in pinch zoom)
+- Follow-system dark mode
+- Cookie policy (GeckoView always accepts all cookies)
+- Hosts mapping (domain → IP)
+- Console message capture and eval result return (scripts do run, but the panel receives no messages or return values)
+- New-window policy (GeckoView popups always load in the current window)
+- Proxy username / password authentication
+- WebView state save / restore (session restore after process death)
+
+### Unsupported by design (trade-offs, not defects)
+
+- **TLS fingerprint spoofing (MITM bridge)** — GeckoView natively presents a genuine Firefox TLS / JA3 fingerprint, which is the strongest "disguise" in itself, and the MITM bridge would terminate TLS and directly conflict with ECH. The feature is therefore offered on the system WebView kernel only. On GeckoView, the target site sees a real Firefox.
+- **"Proceed anyway" on SSL certificate errors** — GeckoView cannot ignore certificate errors, and editor-imported custom CAs are not trusted by GeckoView (only user CAs installed into the Android system, via the trust-user-certificates toggle).
+- DOM storage / database cannot be disabled (always on in GeckoView).
+- Floating-window mode always uses the system WebView regardless of the per-app engine choice.
+
+### Choosing an engine
+
+- Apps that rely on ad blocking, userscripts, Chrome extensions, the NativeBridge API, or encrypted resource packaging → choose the **system WebView**.
+- Apps that need ECH / SNI encryption, a genuine Firefox fingerprint, or Gecko engine behavior → choose **GeckoView** and accept the gaps listed above.
+- Download the GeckoView runtime on this page first: the Build APK dialog will not offer the engine until it is installed, and host previews silently fall back to the system WebView when the runtime is missing.

--- a/docs/zh/guide/more-features/browser-kernel.md
+++ b/docs/zh/guide/more-features/browser-kernel.md
@@ -13,3 +13,52 @@
 
 - 各应用的引擎选择在[构建 APK](/zh/guide/app-actions/build-apk) 对话框中进行;本界面管理引擎本身。
 - GeckoView 是 [ECH](/zh/guide/config/network) 所必需的。
+
+## GeckoView(Firefox 内核)功能支持说明
+
+GeckoView 是独立于系统 WebView 的完整第二引擎,而不是 WebView 的皮肤:网络层能力由内核原生实现,而一部分依赖 WebView 专有机制(请求拦截、`addJavascriptInterface`、JS 注入)的功能在 GeckoView 下不可用。构建 APK 选择内核前,请先读完本节。
+
+### 完整支持(原生实现,与系统 WebView 无差异)
+
+- **ECH(加密 SNI)** —— 仅 GeckoView 支持;开启 ECH 会自动切换到该内核
+- DoH、静态 / PAC / SOCKS5 代理、防抓包(强制直连、忽略系统代理)
+- UA 模式与自定义 User-Agent、桌面模式
+- JavaScript 开关、自动播放策略、视口模式(适应屏幕 / 桌面)、启动时清除浏览数据、下载开关
+- HTTP 下载、全屏视频、文件上传(含拍照)、渲染崩溃自动恢复
+- 摄像头 / 麦克风与地理位置授权策略(全部拒绝 / 按主机记住)
+- mTLS 客户端证书、HTTP Basic / 代理认证对话框
+- JS 对话框(alert / confirm / prompt)
+- 页面加载错误提示、前进 / 后退历史导航、自动刷新、页内查找、控制台脚本执行
+- 媒体会话 / 锁屏播放控制(Gecko 原生实现)
+
+### 暂不可用(需要这些功能请选择系统 WebView 内核)
+
+- **[广告拦截](/zh/guide/app-actions/edit-common-config/ad-blocking)** —— 网络规则过滤与元素隐藏均不生效
+- **[用户脚本](/zh/extensions/userscript)(GM_\* API)与 [Chrome MV3 扩展](/zh/extensions/chrome-mv3)**(含 declarativeNetRequest / webRequest 规则)
+- **[NativeBridge](/zh/extensions/api-reference) 完整 JS API** —— 剪贴板、通知、震动、打印、分享、屏幕常亮、屏幕方向、Google 登录等;GeckoView 下仅 CORS 绕过 / 私有网络访问的 `httpRequest` 可用
+- **JS 注入类功能** —— 浏览器指纹伪装、[设备伪装](/zh/guide/app-actions/edit-common-config/device-disguise)、内核伪装与风味、[页面翻译](/zh/guide/app-actions/edit-common-config/translate)、音频解锁、剪贴板 / 通知 / 屏幕方向 polyfill、Cloudflare 兼容辅助、自定义注入脚本、弹窗拦截、滚动位置记忆、图片修复、隐藏链接预览
+- **PWA 离线(Service Worker 注入)、静态资产包、资源加密加载** —— 因此**开启资源加密的 HTML / [前端离线包](/zh/guide/app-types/frontend)类应用必须使用系统 WebView 内核**
+- blob / data: 下载拦截
+- [长按菜单](/zh/guide/app-actions/edit-common-config/long-press-menu)(保存图片 / 视频、复制链接等)
+- 状态栏自动取色(跟随页面顶部颜色;纯色 / 主题模式不受影响)
+- 页面缩放设置(缩放比例 / 初始缩放 / 文字缩放;GeckoView 仅保留自带的双指缩放)
+- 跟随系统深色模式
+- Cookie 策略(GeckoView 固定接受全部 Cookie)
+- Hosts 映射(域名 → IP)
+- 控制台消息回传与 eval 结果返回(脚本会执行,但面板收不到消息与返回值)
+- 新窗口策略(GeckoView 弹窗一律在当前窗口加载)
+- 代理的用户名 / 密码认证
+- WebView 状态保存 / 恢复(进程被杀后的会话还原)
+
+### 设计上不支持(属于取舍,不是缺陷)
+
+- **TLS 指纹伪装(MITM 桥)** —— GeckoView 原生携带真实的 Firefox TLS / JA3 指纹,本身就是最强"伪装";MITM 桥会终止 TLS 重签,与 ECH 直接冲突。因此该功能仅在系统 WebView 内核下提供。使用 GeckoView 时,目标网站看到的就是货真价实的 Firefox。
+- **SSL 证书错误"仍要继续"** —— GeckoView 不允许忽略证书错误;编辑器导入的自定义 CA 也不会被 GeckoView 信任(仅可通过"信任用户证书"开关信任安装进 Android 系统的用户 CA)。
+- DOM 存储 / 数据库无法关闭(GeckoView 始终开启)。
+- 悬浮窗模式固定使用系统 WebView,不跟随各应用的内核选择。
+
+### 选型建议
+
+- 依赖广告拦截、用户脚本、Chrome 扩展、NativeBridge API 或资源加密打包 → 选择**系统 WebView**。
+- 需要 ECH / SNI 加密、真实 Firefox 指纹或 Gecko 内核行为 → 选择 **GeckoView**,并接受上列功能缺失。
+- 构建前需先在本页下载 GeckoView 运行时,否则构建对话框不允许选择该内核;宿主预览中运行时缺失时会自动回退到系统 WebView。


### PR DESCRIPTION
## Summary

Fixes #828.

Appends a final **GeckoView (Firefox engine) feature support** section to the Browser Kernel guide page in both languages — the user-facing companion to the engine work in #824/#825:

- **Fully supported on Gecko** (native implementations): ECH (Gecko-only), DoH/proxy/anti-capture, UA & desktop mode, JS toggle / autoplay / viewport / clear-on-launch / download toggle, downloads, fullscreen video, file upload, permission policies, mTLS, Basic/proxy auth dialogs, JS dialogs, load-error UI, history navigation, auto-refresh, find-in-page, console script execution, native media session.
- **Not available yet** (WebView-mechanism features, with cross-links to each feature page): ad blocking, userscripts/GM_*, Chrome MV3 extensions, the full NativeBridge JS API (only `httpRequest` works on Gecko), the JS-injection family (fingerprint/device/kernel disguise, translation, polyfills, custom scripts, …), PWA offline / static asset packs / **encrypted asset loading** (so encrypted HTML/front-end packs must stay on the system WebView), blob downloads, long-press menu, status-bar auto color, page zoom, dark-mode follow, cookie policy, hosts mapping, console capture, new-window policy, proxy auth, state save/restore.
- **Unsupported by design** with rationale: TLS-fingerprint MITM (Gecko *is* a genuine Firefox fingerprint; MITM would strip ECH), SSL-error "proceed anyway", editor-imported custom CAs, always-on DOM storage, floating-window mode being WebView-only.
- **Choosing an engine** guidance, including the runtime-download prerequisite and the preview fallback behavior.

Docs-only change; EN and ZH carry identical content with locale-correct links.

## Test plan

- [x] `npm run build` (VitePress) locally on the branch — build complete, zero errors/warnings.
- [ ] `docs-deploy` PR gate (site build) green; deploys to https://shiaho777.github.io/web-to-app/ on merge.