### PR TITLE
feat(network): forced HTTP/3 and dual-engine ECH via a Chromium upstream (issue #721)

### DIFF
--- a/.github/docs/README_CN.md
+++ b/.github/docs/README_CN.md
@@ -59,7 +59,7 @@
 绝大多数「网站转 App」工具到「套一个 WebView」就结束了。WebToApp 更像一个放在手机里的 APK 工作台,而真正难的地方,正是它和那些工具的分界线:
 
 - **在设备上跑真实的服务端运行时。** Node.js、PHP、Python、Go、WordPress 以原生二进制的形式直接从 app 存储 fork+exec —— 像 Termux 那样,但被打进一个可安装的 APK。URL 套壳工具根本做不到。
-- **内置硬核、反审查的网络栈。** DNS-over-HTTPS、TLS 指纹伪装(Chrome / Firefox / Safari 的 JA3 模板,经本地 MITM 桥接)、GeckoView 引擎上的 ECH(加密 SNI)、每应用代理、以及针对受限 SPA 的 CORS 绕过。
+- **内置硬核、反审查的网络栈。** DNS-over-HTTPS、TLS 指纹伪装(Chrome / Firefox / Safari 的 JA3 模板,经本地 MITM 桥接)、双引擎 ECH(加密 SNI)、每应用代理、以及针对受限 SPA 的 CORS 绕过。
 - **整个构建自包含。** 二进制 AXML/ARSC 修补、权限裁剪、V1/V2/V3 签名、可直接上架 Google Play 的 AAB 导出,全部在 app 内通过 `apksig` 完成 —— 不排远程队列、不需要电脑。
 - **发布后仍可扩展。** 通过 JS/CSS 模块、Tampermonkey 风格油猴脚本,或 MV3 Chrome 扩展(可在应用内实时搜索 Chrome 网上应用店并安装)给应用补能力,不必重新发布宿主。
 - **宿主 UI 原生支持 10 种语言。** 中文、English、العربية(RTL)、Português、Español、Français、Deutsch、Русский、日本語、한국어 —— 设置里随时切换;新增界面文案按 10 语维护。
@@ -73,7 +73,7 @@
 | 方向 | 亮点 |
 | --- | --- |
 | **构建目标** | Web · HTML · 前端 · WordPress · Node.js · PHP · Python · Go · 图片 · 视频 · 图库 · 多网站 |
-| **浏览器引擎** | 默认系统 WebView;可选 GeckoView(Firefox)运行时,用于 ECH / SNI 加密 |
+| **浏览器引擎** | 默认系统 WebView;可选 GeckoView(Firefox)运行时 |
 | **网络与反审查** | DoH(7 个服务商)、TLS 指纹伪装 + MITM 桥、ECH、静态/PAC/SOCKS5 代理、CORS 绕过 |
 | **隐私与加固** | 50+ 维浏览器指纹伪装、资源加密(AES-256-GCM)、反调试、激活码门控 |
 | **本地运行时** | 原生 Node.js 18.20、PHP 8.4 + Composer 2.10、Python 3.14、官方 Go 1.26、WordPress 7.x over SQLite |
@@ -111,7 +111,7 @@ WebToApp 的开关非常多。下面按使用场景分组,并用可折叠区段�
 - **弹窗处理** —— 当前窗口、外部浏览器、弹窗窗口或直接拦截。
 - **代理** —— 静态 HTTP/HTTPS/SOCKS5、PAC、身份验证、绕过规则和本地 HTTP-to-SOCKS 桥。
 - **DNS-over-HTTPS** —— Cloudflare、Google、AdGuard、NextDNS、CleanBrowsing、Quad9、Mullvad,以及自定义 endpoint;支持 strict / automatic 模式。
-- **ECH(Encrypted Client Hello)** —— 加密 TLS 握手中的 SNI(仅 GeckoView;开关启用时自动联动 DoH + GeckoView)。
+- **ECH(Encrypted Client Hello)** —— 在**两种引擎**上加密 TLS 握手中的 SNI:GeckoView 经 TRR + 自身 ECH 配置;系统 WebView 经本地 MITM 桥的 Chromium 上行链路(首次使用自动下载组件,导出的 APK 内置)。开关启用时自动联动 DoH;与 SOCKS 上游代理互斥。
 - **TLS 指纹伪装** —— 模拟 Chrome 131 / Firefox 133 / Safari 18 的 JA3 指纹(或自定义密码套件),经本地 TLS-MITM 桥接,让发出的 ClientHello 与真实浏览器一致。
 - **CORS 绕过** —— 默认开启,让受限静态 SPA 能调用原本被 CORS 拦截的外部 API;同源请求不会被误拦,仅需 CORS/内网桥接时可用轻量 `PrivateNetworkNativeBridgeAdapter`,不必挂完整 Native Bridge。
 - **回退链** —— 主目标不可达时自动回退到镜像 URL。

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 Most "website to app" tools stop at wrapping a URL in a WebView. WebToApp is closer to a pocket-sized APK workshop, and the hard parts are exactly where it diverges:
 
 - **It runs real server runtimes on-device.** Node.js, PHP, Python, Go, and WordPress are fork+exec'd as native binaries straight from app storage — like Termux, packaged into an installable APK. URL-wrapper tools cannot do this at all.
-- **It ships a hardened, anti-censorship network stack.** DNS-over-HTTPS, TLS fingerprint spoofing (Chrome / Firefox / Safari JA3 templates) with a local MITM bridge, Encrypted Client Hello (ECH) on the GeckoView engine to encrypt the SNI, per-app proxies, and CORS bypass for locked-down SPAs.
+- **It ships a hardened, anti-censorship network stack.** DNS-over-HTTPS, TLS fingerprint spoofing (Chrome / Firefox / Safari JA3 templates) with a local MITM bridge, Encrypted Client Hello (ECH) on both engines to encrypt the SNI, per-app proxies, and CORS bypass for locked-down SPAs.
 - **The whole build is self-contained.** Binary AXML/ARSC patching, permission pruning, V1/V2/V3 signing, and Google Play-ready AAB export all happen inside the app via `apksig` — no remote build queue, no PC.
 - **It stays extensible after shipping.** Add JS/CSS modules, Tampermonkey-style userscripts, or MV3 Chrome extensions (live-searched and installed from the Chrome Web Store) without rebuilding the host.
 - **The host UI speaks 10 languages out of the box.** Chinese, English, Arabic (RTL), Portuguese, Spanish, French, German, Russian, Japanese, and Korean — switch anytime in Settings; new in-app copy is maintained for all ten.
@@ -73,7 +73,7 @@ A quick scan of what's in the box. Each links to the detailed feature map below.
 | Area | Highlights |
 | --- | --- |
 | **Build targets** | Web · HTML · Frontend · WordPress · Node.js · PHP · Python · Go · Image · Video · Gallery · Multi-Web |
-| **Browser engines** | System WebView by default; optional GeckoView (Firefox) runtime for ECH / SNI encryption |
+| **Browser engines** | System WebView by default; optional GeckoView (Firefox) runtime |
 | **Network & anti-censorship** | DoH (7 providers), TLS fingerprint spoofing + MITM bridge, ECH, static/PAC/SOCKS5 proxies, CORS bypass |
 | **Privacy & hardening** | 50+ vector browser fingerprint disguise, resource encryption (AES-256-GCM), anti-debug, activation gating |
 | **Local runtimes** | Native Node.js 18.20, PHP 8.4 + Composer 2.10, Python 3.14, official Go 1.26, WordPress 7.x over SQLite |
@@ -111,7 +111,7 @@ WebToApp has a large number of switches. The sections below group them by use ca
 - **Popup handling** — same window, external browser, popup window, or block.
 - **Proxies** — static HTTP/HTTPS/SOCKS5, PAC, authentication, bypass rules, and a local HTTP-to-SOCKS bridge.
 - **DNS-over-HTTPS** — Cloudflare, Google, AdGuard, NextDNS, CleanBrowsing, Quad9, Mullvad, plus custom endpoints; strict or automatic modes.
-- **Encrypted Client Hello (ECH)** — encrypt the SNI in the TLS handshake (GeckoView only; auto-wires DoH + GeckoView when toggled).
+- **Encrypted Client Hello (ECH)** — encrypt the SNI in the TLS handshake on **both engines**: GeckoView via TRR + its ECH prefs, the system WebView via the MITM bridge's Chromium upstream (auto-downloaded on first use, embedded in exported APKs). Auto-wires DoH when toggled; a SOCKS upstream proxy takes precedence.
 - **TLS fingerprint spoofing** — impersonate Chrome 131 / Firefox 133 / Safari 18 JA3 profiles (or custom ciphers), served through a local TLS-MITM bridge so the outgoing ClientHello matches a real browser.
 - **CORS bypass** — on by default for static SPAs that call external APIs blocked by CORS; same-origin traffic is left alone, and CORS-only apps can use a lightweight `PrivateNetworkNativeBridgeAdapter` without the full Native Bridge surface.
 - **Failover** — automatic fallback to mirror URLs when the primary target is unreachable.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -203,6 +203,9 @@ android {
             excludes += "**/libplugin-container.so"
 
             excludes += "**/libcrypto_engine.so"
+
+            // Cronet natives are downloaded on demand / injected per-export, never bundled.
+            excludes += "**/libcronet*.so"
         }
     }
     androidResources {
@@ -615,6 +618,13 @@ dependencies {
     implementation("com.android.tools.build:apksig:8.3.0")
 
     implementation("org.mozilla.geckoview:geckoview-arm64-v8a:142.0.20250827004350")
+
+    // Forced HTTP/3 (issue #721): Chromium's own network stack as the MITM bridge's
+    // upstream leg. Java classes ship in the APK; libcronet is NEVER bundled — the host
+    // downloads it on demand (filesDir/cronet_deps) and ApkBuilder injects it into
+    // exported APKs only when the app enables 强制 HTTP/3 (libnode/GeckoView precedent).
+    // Version must match CronetDependencyManager.CRONET_ARTIFACT_VERSION.
+    implementation("org.chromium.net:cronet-embedded:143.7445.0")
 
     implementation("com.google.zxing:core:3.5.2")
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -301,3 +301,15 @@
 -keep class com.google.android.gms.** { *; }
 -dontwarn com.google.firebase.**
 -dontwarn com.google.android.gms.**
+
+# ============================================================
+# Cronet (forced HTTP/3 upstream)
+# ============================================================
+# Cronet's native code reaches its Java classes via JNI and ServiceLoader
+# (org.chromium.net.impl.** / org.chromium.base.**); R8 must not rename or
+# strip them. The AAR ships consumer rules, this is the belt-and-braces copy.
+-keep class org.chromium.net.** { *; }
+-keep class org.chromium.base.** { *; }
+-keep class org.chromium.components.** { *; }
+-dontwarn org.chromium.**
+-keepdirectories META-INF/services/**

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -109,6 +109,18 @@ class ApkBuilder(private val context: Context) {
             add("assets/omni.ja")
         }
 
+        /**
+         * Whether the exported APK needs the Cronet native lib: the h3 toggle or ECH on
+         * the system engine activates the Cronet upstream. Mirrors
+         * TlsMitmBridge.Config.cronetActive (SOCKS upstream wins and disables both).
+         */
+        internal fun cronetNeededForExport(config: ApkConfig): Boolean {
+            if (!(config.tlsFingerprint.forceHttp3 || config.dns.config.echEffective)) return false
+            val socksUpstream = config.proxyMode == "STATIC" &&
+                (config.proxyType == "SOCKS5" || config.proxyType == "SOCKS")
+            return !socksUpstream
+        }
+
         private fun injectedNativeLibNames(appType: String): Set<String> = when (appType) {
             "GO_APP" -> setOf("libgo_exec_loader.so")
             "NODEJS_APP" -> setOf("libc++_shared.so", "libnode_bridge.so", "libnode.so")
@@ -711,7 +723,11 @@ class ApkBuilder(private val context: Context) {
             val appTypeEnum = runCatching { com.webtoapp.data.model.AppType.valueOf(config.appType) }.getOrNull()
             if (appTypeEnum != null) {
                 onProgress(18, "Ensuring runtime dependencies...")
-                val ensured = ExportRuntimeEnsure.ensure(context, appTypeEnum)
+                val ensured = ExportRuntimeEnsure.ensure(
+                    context,
+                    appTypeEnum,
+                    cronetNeededForExport(config)
+                )
                 logger.logKeyValue("exportRuntimeEnsure", ensured)
                 if (!ensured) {
                     logger.warn("Export runtime ensure failed for ${config.appType}")
@@ -814,7 +830,11 @@ class ApkBuilder(private val context: Context) {
                 htmlFiles = htmlFiles,
                 galleryItems = galleryItems,
                 errorPageMediaPath = errorPageMediaPath,
-                nativeLibsFingerprint = runtimeAssetsFingerprint(webApp.appType, config.engineType),
+                nativeLibsFingerprint = runtimeAssetsFingerprint(
+                    webApp.appType,
+                    config.engineType,
+                    cronetNeededForExport(config)
+                ),
                 hostVersionCode = hostVersionCode,
                 forceFullRebuild = forceFullRebuild,
                 // The derived permission/component set is the exact manifest content:
@@ -1709,6 +1729,15 @@ class ApkBuilder(private val context: Context) {
                     logger.section("Inject GeckoView Runtime (native libs + omni.ja)")
                     injectGeckoViewRuntime(zipOut, abiFilters, checkNotNull(geckoEngineFiles))
                 }
+
+                // The Cronet upstream (forced HTTP/3 and/or ECH on the system engine)
+                // needs the native lib inside the APK; cronetNeededForExport mirrors the
+                // runtime activation condition (SOCKS wins and disables both).
+                if (mode == ModifyApkMode.FULL && cronetNeededForExport(config)) {
+                    onProgress(98, "Injecting HTTP/3 runtime...")
+                    logger.section("Inject Cronet Runtime (forced HTTP/3 / ECH)")
+                    injectCronetNativeLib(zipOut)
+                }
             }
         }
 
@@ -2364,7 +2393,8 @@ class ApkBuilder(private val context: Context) {
      */
     private fun runtimeAssetsFingerprint(
         appType: com.webtoapp.data.model.AppType,
-        engineType: String?
+        engineType: String?,
+        cronetNeeded: Boolean = false
     ): String? {
         val parts = mutableListOf<String>()
         if (appType == com.webtoapp.data.model.AppType.NODEJS_APP) {
@@ -2395,6 +2425,10 @@ class ApkBuilder(private val context: Context) {
                 parts += "musl=${libFingerprint(musl)}"
                 parts += "stdlib=${buildCache.treeFingerprint(File(pythonHome, "lib"))}"
             }
+        }
+        if (cronetNeeded) {
+            val cronet = com.webtoapp.core.webview.CronetDependencyManager.resolveCronetLib(context)
+            parts += "cronet=${libFingerprint(cronet ?: File(context.cacheDir, "cronet-missing"))}"
         }
         if (engineType == "GECKOVIEW") {
             val manager = com.webtoapp.core.engine.download.EngineFileManager(context)
@@ -2730,6 +2764,37 @@ builtins.__import__ = _w2a_import
         } catch (e: Exception) {
             logger.error("Failed to embed Go exec loader", e)
             throw IllegalStateException("Failed to embed Go exec loader: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Forced HTTP/3 embeds the Cronet native library so the generated app's bridge can
+     * route through Chromium's own QUIC stack. Mirrors injectNodeJsNativeLibs: a missing
+     * runtime fails the build instead of shipping a silently degraded app.
+     */
+    private fun injectCronetNativeLib(zipOut: ZipOutputStream) {
+        val cronet = com.webtoapp.core.webview.CronetDependencyManager
+        val lib = cronet.resolveCronetLib(context)
+        if (lib == null) {
+            val cachePath = cronet.getLibFile(context).absolutePath
+            val msg =
+                "Cronet native library missing (host nativeLibraryDir and download cache $cachePath). " +
+                    "Open the app once with 强制 HTTP/3 enabled in preview (auto-downloads it), then re-export."
+            logger.error(msg)
+            throw IllegalStateException(msg)
+        }
+        try {
+            val abi = cronet.getDeviceAbi()
+            val aligned = ensureAligned16kNativeLib(lib, cronet.LIB_FILE_NAME)
+            writeEntryStoredStreaming(zipOut, "lib/$abi/${cronet.LIB_FILE_NAME}", aligned)
+            logger.log(
+                "Cronet runtime embedded as native lib: lib/$abi/${cronet.LIB_FILE_NAME} (${aligned.length() / 1024} KB)"
+            )
+        } catch (e: IllegalStateException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to embed Cronet native lib", e)
+            throw IllegalStateException("Failed to embed Cronet native lib: ${e.message}", e)
         }
     }
 
@@ -3732,7 +3797,7 @@ builtins.__import__ = _w2a_import
         if (translateEnabled) return true
         if (proxyMode != "NONE") return true
         if (dnsMode != "SYSTEM") return true
-        if (tlsFingerprintEnabled) return true
+        if (tlsFingerprintEnabled || tlsFingerprintForceHttp3) return true
         if (pwaOfflineEnabled) return true
         if (enablePrivateNetworkBridge) return true
         if (enableCloudflareCompat && webViewBehavior.cloudflareCompatMode == "ALWAYS_ON") return true
@@ -4232,7 +4297,8 @@ private fun WebApp.buildDnsBlock(): DnsBlock = DnsBlock(
 private fun WebApp.buildTlsFingerprintBlock(): TlsFingerprintBlock = TlsFingerprintBlock(
     enabled = webViewConfig.tlsFingerprintEnabled,
     template = webViewConfig.tlsFingerprintTemplate,
-    customCipherSuites = webViewConfig.tlsFingerprintCustomCiphers
+    customCipherSuites = webViewConfig.tlsFingerprintCustomCiphers,
+    forceHttp3 = webViewConfig.forceHttp3
 )
 
 private fun WebApp.buildErrorPageBlock(): ErrorPageBlock {

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -243,6 +243,7 @@ data class ApkConfig(
     val tlsFingerprintEnabled: Boolean get() = tlsFingerprint.enabled
     val tlsFingerprintTemplate: String get() = tlsFingerprint.template
     val tlsFingerprintCustomCiphers: List<String> get() = tlsFingerprint.customCipherSuites
+    val tlsFingerprintForceHttp3: Boolean get() = tlsFingerprint.forceHttp3
     val antiCaptureEnabled: Boolean get() = webView.antiCapture
 
     val dnsMode: String get() = dns.mode
@@ -674,7 +675,8 @@ data class DnsBlock(
 data class TlsFingerprintBlock(
     val enabled: Boolean = false,
     val template: String = "CHROME_131",
-    val customCipherSuites: List<String> = emptyList()
+    val customCipherSuites: List<String> = emptyList(),
+    val forceHttp3: Boolean = false
 )
 
 data class ErrorPageBlock(
@@ -946,4 +948,15 @@ data class DnsApkConfig(
     val dohMode: String = "automatic",
     val bypassSystemDns: Boolean = false,
     val echEnabled: Boolean = false
-)
+) {
+    /** Mirrors [com.webtoapp.data.model.DnsConfig.echEffective] on the export side. */
+    val echEffective: Boolean
+        get() = echEnabled && effectiveDohUrl.isNotBlank()
+
+    val effectiveDohUrl: String
+        get() = if (provider == "custom") {
+            customDohUrl
+        } else {
+            com.webtoapp.data.model.DnsProvider.entries.find { it.key == provider }?.dohUrl ?: ""
+        }
+}

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -328,6 +328,7 @@ internal object ApkConfigJsonFactory {
         "tlsFingerprintEnabled" to tlsFingerprint.enabled,
         "tlsFingerprintTemplate" to tlsFingerprint.template,
         "tlsFingerprintCustomCiphers" to tlsFingerprint.customCipherSuites,
+        "forceHttp3" to tlsFingerprint.forceHttp3,
         "antiCapture" to webView.antiCapture,
         "showFloatingBackButton" to webView.showFloatingBackButton,
         "backButtonBehavior" to webView.backButtonBehavior,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ExportRuntimeEnsure.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ExportRuntimeEnsure.kt
@@ -8,7 +8,10 @@ import com.webtoapp.data.model.AppType
 
 object ExportRuntimeEnsure {
 
-    fun needsEnsure(context: Context, appType: AppType): Boolean {
+    fun needsEnsure(context: Context, appType: AppType, needsCronet: Boolean = false): Boolean {
+        if (needsCronet && !com.webtoapp.core.webview.CronetDependencyManager.isCronetReady(context)) {
+            return true
+        }
         return when (appType) {
             AppType.PYTHON_APP -> !PythonDependencyManager.isPythonReady(context)
             AppType.NODEJS_APP -> !NodeDependencyManager.isNodeReady(context)
@@ -21,7 +24,12 @@ object ExportRuntimeEnsure {
         }
     }
 
-    suspend fun ensure(context: Context, appType: AppType): Boolean {
+    suspend fun ensure(context: Context, appType: AppType, needsCronet: Boolean = false): Boolean {
+        if (needsCronet && !com.webtoapp.core.webview.CronetDependencyManager.isCronetReady(context)) {
+            if (!com.webtoapp.core.webview.CronetDependencyManager.downloadCronetRuntime(context)) {
+                return false
+            }
+        }
         return when (appType) {
             AppType.PYTHON_APP -> {
                 if (PythonDependencyManager.isPythonReady(context)) true

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -4172,6 +4172,9 @@ object Strings {
     val tlsFingerprintCustomCiphersHint: String get() = StringsE.tlsFingerprintCustomCiphersHint
     val tlsFingerprintGeckoWarning: String get() = StringsE.tlsFingerprintGeckoWarning
     val tlsFingerprintProxyIntegration: String get() = StringsE.tlsFingerprintProxyIntegration
+    val forceHttp3Title: String get() = StringsE.forceHttp3Title
+    val forceHttp3Description: String get() = StringsE.forceHttp3Description
+    val forceHttp3Note: String get() = StringsE.forceHttp3Note
     val proxyModeNone: String get() = StringsE.proxyModeNone
     val proxyModeStatic: String get() = StringsE.proxyModeStatic
     val proxyModePac: String get() = StringsE.proxyModePac
@@ -40310,41 +40313,41 @@ object StringsC {
     }
 
     val dnsEchDesc: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "加密 TLS 握手，隐藏你访问的网站域名，防止网络中间人看到你连了哪个站。仅对支持 ECH 的网站生效。"
-        AppLanguage.ENGLISH -> "Encrypts the TLS handshake to hide which website domain you visit from on-path observers. Only effective for sites that support ECH."
-        AppLanguage.ARABIC -> "يشفّر مصافحة TLS لإخفاء اسم نطاق الموقع الذي تزوره عن المراقبين على المسار. يعمل فقط مع المواقع التي تدعم ECH."
-        AppLanguage.PORTUGUESE -> "Criptografa o handshake TLS para ocultar o domínio do site que você visita de observadores no caminho. Efetivo apenas para sites que suportam ECH."
-        AppLanguage.SPANISH -> "Cifra el handshake TLS para ocultar el dominio del sitio web que visitas a observadores en ruta. Solo efectivo para sitios que soportan ECH."
-        AppLanguage.FRENCH -> "Chiffre le handshake TLS pour cacher le domaine du site web que vous visitez aux observateurs sur le chemin. Efficace uniquement pour les sites qui supportent ECH."
-        AppLanguage.GERMAN -> "Verschlüsselt den TLS-Handshake, um die besuchte Website-Domain vor Pfad-Beobachtern zu verbergen. Nur wirksam für Sites, die ECH unterstützen."
-        AppLanguage.RUSSIAN -> "Шифрует TLS-рукопожатие, чтобы скрыть домен посещаемого сайта от наблюдателей на пути. Эффективно только для сайтов, поддерживающих ECH."
-        AppLanguage.JAPANESE -> "TLS ハンドシェイクを暗号化し、経路上の観察者から訪問先のウェブサイトドメインを隠します。ECH をサポートするサイトにのみ有効です。"
-        AppLanguage.KOREAN -> "TLS 핸드셰이크를 암호화하여 경로상 관찰자로부터 방문하는 웹사이트 도메인을 숨깁니다. ECH를 지원하는 사이트에만 유효합니다."
+        AppLanguage.CHINESE -> "加密 TLS 握手，隐藏你访问的网站域名，防止网络中间人看到你连了哪个站。两种引擎均支持；仅对支持 ECH 的网站生效。"
+        AppLanguage.ENGLISH -> "Encrypts the TLS handshake to hide which website domain you visit from on-path observers. Works on both engines; only effective for sites that support ECH."
+        AppLanguage.ARABIC -> "يشفّر مصافحة TLS لإخفاء اسم نطاق الموقع الذي تزوره عن المراقبين على المسار. يعمل على كلا المحركين؛ فعال فقط مع المواقع التي تدعم ECH."
+        AppLanguage.PORTUGUESE -> "Criptografa o handshake TLS para ocultar o domínio do site que você visita de observadores no caminho. Funciona em ambos os motores; efetivo apenas para sites que suportam ECH."
+        AppLanguage.SPANISH -> "Cifra el handshake TLS para ocultar el dominio del sitio web que visitas a observadores en ruta. Funciona en ambos motores; solo efectivo para sitios que soportan ECH."
+        AppLanguage.FRENCH -> "Chiffre le handshake TLS pour cacher le domaine du site web que vous visitez aux observateurs sur le chemin. Fonctionne sur les deux moteurs ; efficace uniquement pour les sites qui supportent ECH."
+        AppLanguage.GERMAN -> "Verschlüsselt den TLS-Handshake, um die besuchte Website-Domain vor Pfad-Beobachtern zu verbergen. Funktioniert auf beiden Engines; nur wirksam für Sites, die ECH unterstützen."
+        AppLanguage.RUSSIAN -> "Шифрует TLS-рукопожатие, чтобы скрыть домен посещаемого сайта от наблюдателей на пути. Работает на обоих движках; эффективно только для сайтов, поддерживающих ECH."
+        AppLanguage.JAPANESE -> "TLS ハンドシェイクを暗号化し、経路上の観察者から訪問先のウェブサイトドメインを隠します。両方のエンジンで動作し、ECH をサポートするサイトにのみ有効です。"
+        AppLanguage.KOREAN -> "TLS 핸드셰이크를 암호화하여 경로상 관찰자로부터 방문하는 웹사이트 도메인을 숨깁니다. 두 엔진 모두에서 작동하며 ECH를 지원하는 사이트에만 유효합니다."
     }
 
     val dnsEchGeckoBadge: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "仅 Gecko"
-        AppLanguage.ENGLISH -> "Gecko only"
-        AppLanguage.ARABIC -> "Gecko فقط"
-        AppLanguage.PORTUGUESE -> "Apenas Gecko"
-        AppLanguage.SPANISH -> "Solo Gecko"
-        AppLanguage.FRENCH -> "Gecko uniquement"
-        AppLanguage.GERMAN -> "Nur Gecko"
-        AppLanguage.RUSSIAN -> "Только Gecko"
-        AppLanguage.JAPANESE -> "Gecko のみ"
-        AppLanguage.KOREAN -> "Gecko 전용"
+        AppLanguage.CHINESE -> "SNI 加密"
+        AppLanguage.ENGLISH -> "Encrypted SNI"
+        AppLanguage.ARABIC -> "SNI مشفّر"
+        AppLanguage.PORTUGUESE -> "SNI criptografado"
+        AppLanguage.SPANISH -> "SNI cifrado"
+        AppLanguage.FRENCH -> "SNI chiffré"
+        AppLanguage.GERMAN -> "Verschlüsseltes SNI"
+        AppLanguage.RUSSIAN -> "Шифрование SNI"
+        AppLanguage.JAPANESE -> "SNI 暗号化"
+        AppLanguage.KOREAN -> "SNI 암호화"
     }
     val dnsEchEngineWarn: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "ECH 需 GeckoView 引擎才能加密 SNI。已自动切换到 GeckoView，构建后请确保已下载 GeckoView 运行时。"
-        AppLanguage.ENGLISH -> "ECH needs the GeckoView engine to encrypt SNI. Switched to GeckoView automatically — make sure the GeckoView runtime is downloaded before building."
-        AppLanguage.ARABIC -> "يحتاج ECH إلى محرك GeckoView لتشفير SNI. تم التبديل إلى GeckoView تلقائياً — تأكد من تنزيل وقت تشغيل GeckoView قبل البناء."
-        AppLanguage.PORTUGUESE -> "ECH precisa do motor GeckoView para criptografar SNI. Mudou para GeckoView automaticamente — certifique-se de baixar o runtime GeckoView antes de construir."
-        AppLanguage.SPANISH -> "ECH necesita el motor GeckoView para cifrar SNI. Se cambió a GeckoView automáticamente — asegúrate de descargar el runtime de GeckoView antes de construir."
-        AppLanguage.FRENCH -> "ECH nécessite le moteur GeckoView pour chiffrer SNI. Basculement vers GeckoView automatique — assurez-vous de télécharger le runtime GeckoView avant la construction."
-        AppLanguage.GERMAN -> "ECH benötigt die GeckoView-Engine, um SNI zu verschlüsseln. Automatisch auf GeckoView umgeschaltet — stellen Sie sicher, dass die GeckoView-Laufzeitumgebung vor dem Build heruntergeladen ist."
-        AppLanguage.RUSSIAN -> "ECH требует движок GeckoView для шифрования SNI. Автоматически переключено на GeckoView — убедитесь, что среда выполнения GeckoView загружена перед сборкой."
-        AppLanguage.JAPANESE -> "ECH は SNI を暗号化するために GeckoView エンジンが必要です。自動的に GeckoView に切り替わりました — ビルド前に GeckoView ランタイムがダウンロード済みであることを確認してください。"
-        AppLanguage.KOREAN -> "ECH는 SNI 암호화를 위해 GeckoView 엔진이 필요합니다. 자동으로 GeckoView로 전환되었습니다 — 빌드 전에 GeckoView 런타임이 다운로드되어 있는지 확인하세요."
+        AppLanguage.CHINESE -> "系统内核下 ECH 经本地桥接的 Chromium 网络组件实现：首次使用会自动下载组件（约 14MB），导出的 APK 将内置；与 SOCKS 上游代理互斥。若本地桥未启用，连接将回退为普通加密。"
+        AppLanguage.ENGLISH -> "On the system engine ECH rides the locally-bridged Chromium network component: first use auto-downloads it (~14 MB) and exported APKs embed it; mutually exclusive with a SOCKS upstream proxy. Without the component the connection falls back to ordinary encryption."
+        AppLanguage.ARABIC -> "على محرك النظام يعمل ECH عبر مكوّن شبكة Chromium المتصل محليًا: الاستخدام الأول ينزّله تلقائيًا (حوالي 14 ميغابايت) وتُدمجه ملفات APK المصدَّرة؛ وهو حصري مع وكيل SOCKS. بدونه تعود الاتصالات إلى التشفير العادي."
+        AppLanguage.PORTUGUESE -> "No motor do sistema, o ECH usa o componente de rede Chromium conectado localmente: o primeiro uso o baixa automaticamente (~14 MB) e os APKs exportados o incorporam; é mutuamente exclusivo com um proxy SOCKS upstream. Sem ele, a conexão volta à criptografia comum."
+        AppLanguage.SPANISH -> "En el motor del sistema, ECH funciona mediante el componente de red Chromium conectado localmente: el primer uso lo descarga automáticamente (~14 MB) y los APK exportados lo incorporan; es mutuamente excluyente con un proxy SOCKS. Sin él, la conexión vuelve al cifrado ordinario."
+        AppLanguage.FRENCH -> "Sur le moteur système, ECH passe par le composant réseau Chromium relié localement : le premier usage le télécharge automatiquement (~14 Mo) et les APK exportés l'intègrent ; il est mutuellement exclusif avec un proxy SOCKS. Sans lui, la connexion revient au chiffrement ordinaire."
+        AppLanguage.GERMAN -> "Auf der System-Engine läuft ECH über die lokal angebundene Chromium-Netzkomponente: Die erste Nutzung lädt sie automatisch herunter (~14 MB), exportierte APKs binden sie ein; gegenseitig ausgeschlossen mit einem SOCKS-Upstream. Ohne sie fällt die Verbindung auf gewöhnliche Verschlüsselung zurück."
+        AppLanguage.RUSSIAN -> "На системном движке ECH работает через локально подключённый сетевой компонент Chromium: первое использование скачивает его автоматически (~14 МБ), экспортируемые APK встраивают его; взаимоисключается с прокси SOCKS. Без него соединение откатывается к обычному шифрованию."
+        AppLanguage.JAPANESE -> "システムエンジンでは ECH はローカルにブリッジされた Chromium ネットワークコンポーネント経由で動作します。初回使用時に自動ダウンロード（約 14MB）され、エクスポートされた APK には組み込まれます。SOCKS 上流プロキシとは排他です。コンポーネントがない場合は通常の暗号化にフォールバックします。"
+        AppLanguage.KOREAN -> "시스템 엔진에서 ECH는 로컬로 브리지된 Chromium 네트워크 컴포넌트를 통해 작동합니다. 최초 사용 시 자동 다운로드(약 14MB)되며 내보낸 APK에는 포함됩니다. SOCKS 업스트림 프록시와는 상호 배타적입니다. 컴포넌트가 없으면 일반 암호화로 폴백합니다."
     }
 
     val browserDisguiseTitle: String get() = when (Strings.lang) {
@@ -57105,6 +57108,42 @@ object StringsE {
         AppLanguage.RUSSIAN -> "При совместном использовании с прокси SOCKS5 повторное рукопожатие TLS проходит через туннель прокси"
         AppLanguage.JAPANESE -> "SOCKS5 プロキシと組み合わせると、TLS 再ハンドシェイクはプロキシトンネルを経由します"
         AppLanguage.KOREAN -> "SOCKS5 프록시와 함께 사용하면 TLS 재핸드셰이크가 프록시 터널을 통과합니다"
+    }
+    val forceHttp3Title: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "强制 HTTP/3 (QUIC)"
+        AppLanguage.ENGLISH -> "Force HTTP/3 (QUIC)"
+        AppLanguage.ARABIC -> "فرض HTTP/3 (QUIC)"
+        AppLanguage.PORTUGUESE -> "Forçar HTTP/3 (QUIC)"
+        AppLanguage.SPANISH -> "Forzar HTTP/3 (QUIC)"
+        AppLanguage.FRENCH -> "Forcer HTTP/3 (QUIC)"
+        AppLanguage.GERMAN -> "HTTP/3 erzwingen (QUIC)"
+        AppLanguage.RUSSIAN -> "Принудительный HTTP/3 (QUIC)"
+        AppLanguage.JAPANESE -> "HTTP/3 を強制 (QUIC)"
+        AppLanguage.KOREAN -> "HTTP/3 강제 (QUIC)"
+    }
+    val forceHttp3Description: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "流量经真实 Chromium 网络栈传输，对每个站点从首个请求起优先尝试 QUIC"
+        AppLanguage.ENGLISH -> "Traffic rides the real Chromium network stack; every host tries QUIC from the first request"
+        AppLanguage.ARABIC -> "يستخدم حركة البيانات مكدس الشبكة الحقيقي لـ Chromium؛ كل موقع يجرب QUIC من الطلب الأول"
+        AppLanguage.PORTUGUESE -> "O tráfego usa a pilha de rede real do Chromium; cada host tenta QUIC desde a primeira solicitação"
+        AppLanguage.SPANISH -> "El tráfico usa la pila de red real de Chromium; cada host prueba QUIC desde la primera solicitud"
+        AppLanguage.FRENCH -> "Le trafic passe par la pile réseau réelle de Chromium ; chaque hôte tente QUIC dès la première requête"
+        AppLanguage.GERMAN -> "Der Verkehr läuft über den echten Chromium-Netzwerkstapel; jeder Host versucht QUIC ab der ersten Anfrage"
+        AppLanguage.RUSSIAN -> "Трафик идёт через настоящий сетевой стек Chromium; каждый хост пробует QUIC с первого запроса"
+        AppLanguage.JAPANESE -> "トラフィックは本物の Chromium ネットワークスタックを経由し、各ホストは最初のリクエストから QUIC を試みます"
+        AppLanguage.KOREAN -> "트래픽은 실제 Chromium 네트워크 스택을 통해 흐르며, 각 호스트는 첫 요청부터 QUIC를 시도합니다"
+    }
+    val forceHttp3Note: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "经本地桥将请求转发到内置的 Chromium 网络组件 (Cronet)：对每个目标站点从首个请求起优先建立 HTTP/3 (QUIC/UDP) 连接，不支持的站点自动回退到真实 Chrome 的 TLS 通道，出口指纹即真实 Chromium，无需另行伪装。首次使用会自动下载网络组件（约 14MB），导出的 APK 将内置该组件。与 SOCKS 上游代理互斥：配置 SOCKS 时本开关不生效。"
+        AppLanguage.ENGLISH -> "The local bridge forwards requests to the embedded Chromium network stack (Cronet): every target site is preferred over HTTP/3 (QUIC/UDP) from its first request, sites without h3 fall back to a genuine Chrome TLS path, and the outbound fingerprint is real Chromium — no spoofing needed. First use auto-downloads the network component (~14 MB); exported APKs embed it. Mutually exclusive with a SOCKS upstream: the switch is inert while SOCKS is configured."
+        AppLanguage.ARABIC -> "يعيد الجسر المحلي توجيه الطلبات إلى مكدس شبكة Chromium المدمج (Cronet): يُفضَّل HTTP/3 (QUIC/UDP) لكل موقع مستهدف من طلبه الأول، وتتراجع المواقع بدون h3 إلى مسار TLS حقيقي من Chrome، وبصمة الخروج هي Chromium حقيقي — لا حاجة للانتحال. الاستخدام الأول ينزّل مكوّن الشبكة تلقائيًا (حوالي 14 ميغابايت)؛ وتُدمج ملفات APK المصدَّرة المكوّن. حصري بشكل متبادل مع وكيل SOCKS: لا يعمل المفتاح عند تهيئة SOCKS."
+        AppLanguage.PORTUGUESE -> "A ponte local encaminha as solicitações para a pilha de rede Chromium integrada (Cronet): cada site de destino prefere HTTP/3 (QUIC/UDP) desde a primeira solicitação, sites sem h3 recuam para um caminho TLS genuíno do Chrome, e a impressão digital de saída é o Chromium real — sem necessidade de falsificação. O primeiro uso baixa automaticamente o componente de rede (~14 MB); APKs exportados o incorporam. Mutuamente exclusivo com um proxy SOCKS: a opção fica inerte com o SOCKS configurado."
+        AppLanguage.SPANISH -> "El puente local reenvía las solicitudes a la pila de red Chromium integrada (Cronet): cada sitio de destino prefiere HTTP/3 (QUIC/UDP) desde su primera solicitud, los sitios sin h3 retroceden a una ruta TLS genuina de Chrome, y la huella de salida es Chromium real, sin necesidad de suplantación. El primer uso descarga automáticamente el componente de red (~14 MB); los APK exportados lo incorporan. Mutuamente excluyente con un proxy SOCKS: la opción queda inerte con SOCKS configurado."
+        AppLanguage.FRENCH -> "Le pont local transmet les requêtes à la pile réseau Chromium intégrée (Cronet) : chaque site cible privilégie HTTP/3 (QUIC/UDP) dès sa première requête, les sites sans h3 reviennent à un chemin TLS authentique de Chrome, et l'empreinte sortante est du vrai Chromium — aucune usurpation nécessaire. La première utilisation télécharge automatiquement le composant réseau (~14 Mo) ; les APK exportés l'intègrent. Mutuellement exclusif avec un proxy SOCKS : l'option est inactive si SOCKS est configuré."
+        AppLanguage.GERMAN -> "Die lokale Bridge leitet Anfragen an den eingebetteten Chromium-Netzwerkstapel (Cronet) weiter: Jede Zielseite bevorzugt HTTP/3 (QUIC/UDP) ab der ersten Anfrage, Seiten ohne h3 fallen auf einen echten Chrome-TLS-Pfad zurück, und der ausgehende Fingerabdruck ist echtes Chromium — kein Spoofing nötig. Die erste Nutzung lädt die Netzkomponente automatisch herunter (~14 MB); exportierte APKs binden sie ein. Gegenseitig ausgeschlossen mit einem SOCKS-Upstream: Der Schalter ist wirkungslos, wenn SOCKS konfiguriert ist."
+        AppLanguage.RUSSIAN -> "Локальный мост перенаправляет запросы во встроенный сетевой стек Chromium (Cronet): каждому целевому сайту предпочтителен HTTP/3 (QUIC/UDP) с первого запроса, сайты без h3 откатываются на подлинный TLS-путь Chrome, а исходящий отпечаток — настоящий Chromium, подмена не нужна. Первый запуск автоматически скачивает сетевой компонент (~14 МБ); экспортируемые APK встраивают его. Взаимно исключается с вышестоящим SOCKS: при настроенном SOCKS переключатель не действует."
+        AppLanguage.JAPANESE -> "ローカルブリッジはリクエストを内蔵の Chromium ネットワークスタック (Cronet) へ転送します。各ターゲットサイトは最初のリクエストから HTTP/3 (QUIC/UDP) を優先し、h3 非対応サイトは本物の Chrome TLS 経路にフォールバックします。送出フィンガープリントは本物の Chromium そのものであり、偽装は不要です。初回使用時にネットワークコンポーネント（約 14MB）を自動ダウンロードし、エクスポートされた APK には組み込まれます。SOCKS 上流プロキシとは排他で、SOCKS 設定時はこのスイッチは無効になります。"
+        AppLanguage.KOREAN -> "로컬 브리지는 요청을 내장된 Chromium 네트워크 스택(Cronet)으로 전달합니다. 각 대상 사이트는 첫 요청부터 HTTP/3(QUIC/UDP)를 우선 시도하고, h3를 지원하지 않는 사이트는 진짜 Chrome TLS 경로로 폴백합니다. 송출 핑거프린트는 진짜 Chromium이므로 별도 위장이 필요 없습니다. 최초 사용 시 네트워크 컴포넌트(약 14MB)를 자동 다운로드하며, 내보낸 APK에는 포함됩니다. SOCKS 업스트림 프록시와는 상호 배타적이며 SOCKS 구성 시 이 스위치는 동작하지 않습니다."
     }
     val proxyModeNone: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "无代理"

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -1583,6 +1583,9 @@ data class WebViewShellConfig(
     @SerializedName("tlsFingerprintCustomCiphers")
     val tlsFingerprintCustomCiphers: List<String> = emptyList(),
 
+    @SerializedName("forceHttp3")
+    val forceHttp3: Boolean = false,
+
     @SerializedName("antiCapture")
     val antiCapture: Boolean = false,
 

--- a/app/src/main/java/com/webtoapp/core/webview/CronetDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/CronetDependencyManager.kt
@@ -1,0 +1,168 @@
+package com.webtoapp.core.webview
+
+import android.content.Context
+import android.os.Build
+import com.webtoapp.core.download.DependencyDownloadEngine
+import com.webtoapp.core.logging.AppLogger
+import com.webtoapp.util.SafeZip
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.zip.ZipInputStream
+
+/**
+ * On-demand fetch of the Cronet native library that powers forced HTTP/3 (issue #721).
+ *
+ * The `cronet-embedded` Gradle dependency contributes only its Java classes to the
+ * host/shell APKs — the .so files are excluded from packaging in both build files,
+ * mirroring the GeckoView / libnode precedents (heavy natives are never bundled):
+ *  - Host preview loads the library from [getDepsDir] via Cronet's LibraryLoader.
+ *  - ApkBuilder injects the same file into exported APKs when 强制 HTTP/3 is on,
+ *    so generated apps load it straight from their own nativeLibraryDir.
+ */
+object CronetDependencyManager {
+
+    private const val TAG = "CronetDependencyManager"
+
+    /** Gradle artifact version (app/shell build.gradle.kts must match). */
+    const val CRONET_ARTIFACT_VERSION = "143.7445.0"
+
+    /** Native library version baked inside the artifact (differs from the artifact version). */
+    const val CRONET_LIB_VERSION = "143.0.7445.0"
+
+    const val LIB_FILE_NAME = "libcronet.$CRONET_LIB_VERSION.so"
+
+    private const val MAX_RETRY_PER_URL = 2
+    private const val RETRY_DELAY_MS = 2000L
+
+    private val downloadMutex = Mutex()
+
+    // Google Maven is unreachable from mainland China, and forced HTTP/3 is an
+    // anti-censorship feature whose audience skews exactly there — so the Aliyun
+    // mirror (globally reachable, CDN-backed) goes first and Google Maven is the
+    // fallback for the rare case Aliyun is down or stale.
+    /** Google Maven — canonical source, kept as the fallback (see [downloadUrls]). */
+    private val PRIMARY_URL =
+        "https://maven.google.com/org/chromium/net/cronet-embedded/$CRONET_ARTIFACT_VERSION/cronet-embedded-$CRONET_ARTIFACT_VERSION.aar"
+
+    // Aliyun's Google-Maven mirror.
+    private val CN_MIRROR_URL =
+        "https://maven.aliyun.com/repository/google/org/chromium/net/cronet-embedded/$CRONET_ARTIFACT_VERSION/cronet-embedded-$CRONET_ARTIFACT_VERSION.aar"
+
+    private fun downloadUrls(): List<String> = listOf(CN_MIRROR_URL, PRIMARY_URL)
+
+    fun getDepsDir(context: Context): File =
+        File(context.filesDir, "cronet_deps").also { it.mkdirs() }
+
+    fun getDeviceAbi(): String = Build.SUPPORTED_ABIS.firstOrNull() ?: "arm64-v8a"
+
+    fun getLibDir(context: Context): File =
+        File(getDepsDir(context), getDeviceAbi()).also { it.mkdirs() }
+
+    fun getLibFile(context: Context): File = File(getLibDir(context), LIB_FILE_NAME)
+
+    /**
+     * Resolve the Cronet native library for the current device ABI: the app's own
+     * nativeLibraryDir first (generated APKs get it injected there), then the
+     * downloaded copy (host preview). Null when neither is available.
+     */
+    fun resolveCronetLib(context: Context): File? {
+        val native = File(context.applicationInfo.nativeLibraryDir, LIB_FILE_NAME)
+        if (native.isFile && native.length() > 0L) return native
+        val downloaded = getLibFile(context)
+        if (downloaded.isFile && downloaded.length() > 0L) return downloaded
+        return null
+    }
+
+    fun isCronetReady(context: Context): Boolean = resolveCronetLib(context) != null
+
+    fun clearCache(context: Context) {
+        getDepsDir(context).deleteRecursively()
+        AppLogger.i(TAG, "Cronet dependency cache cleared")
+    }
+
+    fun getCacheSize(context: Context): Long {
+        return getDepsDir(context).walkTopDown().filter { it.isFile }.sumOf { it.length() }
+    }
+
+    suspend fun downloadCronetRuntime(context: Context): Boolean = downloadMutex.withLock {
+        if (isCronetReady(context)) return@withLock true
+        withContext(Dispatchers.IO) {
+            val urls = downloadUrls()
+            val archive = File(context.cacheDir, "cronet_temp.aar")
+            val downloaded = try {
+                DependencyDownloadEngine.downloadFileWithFallback(
+                    urls = urls,
+                    destFile = archive,
+                    displayName = "Cronet $CRONET_ARTIFACT_VERSION",
+                    context = context,
+                    maxRetryPerUrl = MAX_RETRY_PER_URL,
+                    retryDelayMs = RETRY_DELAY_MS
+                )
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "Cronet download failed", e)
+                false
+            }
+            if (!downloaded) return@withContext false
+            try {
+                extractCronetLib(context, archive)
+                true
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "Cronet extraction failed", e)
+                false
+            } finally {
+                try { archive.delete() } catch (_: Exception) {}
+            }
+        }
+    }
+
+    private fun extractCronetLib(context: Context, archive: File) {
+        val abi = getDeviceAbi()
+        val wanted = "jni/$abi/$LIB_FILE_NAME"
+        val outFile = getLibFile(context)
+        outFile.parentFile?.mkdirs()
+
+        // Drop stale libs from other Cronet releases so the deps dir stays bounded.
+        getDepsDir(context).listFiles()?.forEach { abiDir ->
+            if (abiDir.isDirectory) {
+                abiDir.listFiles()?.forEach { f ->
+                    if (f.isFile && f.name.startsWith("libcronet.") && f.name != LIB_FILE_NAME) {
+                        try { f.delete() } catch (_: Exception) {}
+                    }
+                }
+            }
+        }
+
+        var found = false
+        val guard = SafeZip.EntryGuard()
+        ZipInputStream(archive.inputStream().buffered()).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                guard.onEntry()
+                if (!entry.isDirectory && entry.name == wanted) {
+                    val tmp = File(outFile.parentFile, "$LIB_FILE_NAME.tmp")
+                    tmp.outputStream().buffered().use { fos ->
+                        guard.copyTo(zis, fos)
+                    }
+                    if (tmp.length() <= 0L) {
+                        tmp.delete()
+                        throw IllegalStateException("Empty Cronet library entry: ${entry.name}")
+                    }
+                    if (outFile.exists()) outFile.delete()
+                    if (!tmp.renameTo(outFile)) {
+                        tmp.copyTo(outFile, overwrite = true)
+                        tmp.delete()
+                    }
+                    found = true
+                    AppLogger.i(TAG, "Extracted ${entry.name} -> ${outFile.absolutePath} (${outFile.length()} bytes)")
+                }
+                entry = zis.nextEntry
+            }
+        }
+        if (!found) {
+            throw IllegalStateException("Cronet library not found in AAR (ABI: $abi)")
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/CronetForwarder.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/CronetForwarder.kt
@@ -1,0 +1,380 @@
+package com.webtoapp.core.webview
+
+import android.content.Context
+import com.webtoapp.core.logging.AppLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.chromium.net.CronetEngine
+import org.chromium.net.CronetException
+import org.chromium.net.DnsOptions
+import org.chromium.net.UploadDataProviders
+import org.chromium.net.UrlRequest
+import org.chromium.net.UrlResponseInfo
+import java.io.File
+import java.io.IOException
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Upstream HTTP engine for forced HTTP/3 (issue #721).
+ *
+ * The TLS-MITM bridge hands every request here once the 强制 HTTP/3 toggle is on:
+ * requests are re-issued through Chromium's own network stack (Cronet) with a QUIC
+ * hint for the target host, so the very first request races QUIC against TCP instead
+ * of waiting for an Alt-Svc advertisement. Sites without HTTP/3 fall back to Cronet's
+ * genuine Chrome TLS/TCP transport — the outbound fingerprint IS real Chromium, which
+ * is why this lives next to the fingerprint-spoofing feature instead of conflicting
+ * with it.
+ *
+ * Cronet is a full HTTP client, not a byte relay, so both sides of the bridge speak
+ * plain HTTP/1.1 while the upstream leg speaks whatever Chromium negotiates (h3
+ * preferred, h2 fallback) — the WebView sees an ordinary proxy and never notices.
+ */
+object CronetForwarder {
+
+    private const val TAG = "CronetForwarder"
+
+    /**
+     * QUIC hints are engine-build-time only; beyond this many distinct hosts the
+     * engine stops being rebuilt and newer hosts rely on Alt-Svc discovery (their
+     * first request goes out on Chrome's TCP stack, subsequent ones on h3).
+     */
+    private const val MAX_HINTED_HOSTS = 24
+
+    private const val READ_BUFFER_BYTES = 32 * 1024
+
+    private val CRLF = "\r\n".toByteArray(Charsets.ISO_8859_1)
+
+    private val buildLock = Any()
+
+    @Volatile private var engineRef: CronetEngine? = null
+    private val hintedHosts: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /**
+     * ECH mode: builds engines with the built-in (Chromium async) resolver so HTTPS
+     * records are queried and ECH applied on the upstream handshakes. Fixed per
+     * bridge session; the bridge restarts (rebuilding the engine) when it changes.
+     */
+    @Volatile private var echMode = false
+
+    /** One-shot guard for the background self-heal download when the native lib is missing. */
+    private val downloadKick = AtomicBoolean(false)
+    private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Callbacks run on these daemon threads; they write response bytes to the client sink. */
+    private val callbackExecutor = ThreadPoolExecutor(
+        0, 32, 30L, TimeUnit.SECONDS,
+        SynchronousQueue()
+    ) { r -> Thread(r, "CronetForwarder-Cb").apply { isDaemon = true } }
+        .also { it.allowCoreThreadTimeOut(true) }
+
+    /**
+     * Response headers that must not be relayed verbatim to the HTTP/1.1 client:
+     * hop-by-hop headers, plus the body-framing ones (the body is re-framed as
+     * chunked) and Content-Encoding — Chromium transparently decodes the body but
+     * still reports the original encoding header, so relaying it would make the
+     * WebView try to gunzip already-decoded bytes (ERR_CONTENT_DECODING_FAILED).
+     */
+    private val HOP_BY_HOP_RESPONSE_HEADERS = setOf(
+        "content-length", "transfer-encoding", "connection", "keep-alive",
+        "proxy-authenticate", "proxy-authorization", "upgrade",
+        "content-encoding"
+    )
+
+    /**
+     * Cheap gate for the bridge: an engine is already live, or the native library is
+     * available (embedded in generated APKs / downloaded for host preview) so one could
+     * be built. Until then the bridge stays on the classic raw relay.
+     */
+    fun isReady(context: Context): Boolean =
+        engineRef != null || CronetDependencyManager.isCronetReady(context)
+
+    /** Called by the bridge when the Cronet upstream activates; warms the engine and,
+     *  when the native library is missing, kicks a one-shot background download so the
+     *  app self-heals. */
+    fun start(appContext: Context, echUpstream: Boolean = false) {
+        echMode = echUpstream
+        try {
+            ensureEngine(appContext, host = null, port = 443)
+        } catch (t: Throwable) {
+            AppLogger.w(TAG, "Cronet engine not available yet: ${t.message}")
+        }
+    }
+
+    fun stop() {
+        synchronized(buildLock) {
+            val engine = engineRef
+            engineRef = null
+            echMode = false
+            hintedHosts.clear()
+            if (engine != null) {
+                retireAsync(engine)
+            }
+        }
+    }
+
+    /** shutdown() blocks until in-flight requests drain; keep it off the caller's thread. */
+    private fun retireAsync(engine: CronetEngine) {
+        Thread({
+            try { engine.shutdown() } catch (_: Throwable) {}
+        }, "CronetForwarder-Retire").apply { isDaemon = true }.start()
+    }
+
+    /**
+     * Returns the shared engine, rebuilding it with a QUIC hint for [host] when that
+     * host has not been hinted yet (the rebuild keeps h3 available from the very
+     * first request; the retired engine drains on a background thread).
+     */
+    private fun ensureEngine(context: Context, host: String?, port: Int): CronetEngine? {
+        val existing = engineRef
+        if (existing != null && (host == null || hintedHosts.contains(host))) return existing
+
+        synchronized(buildLock) {
+            val again = engineRef
+            if (again != null && (host == null || hintedHosts.contains(host))) return again
+            if (host != null && hintedHosts.size >= MAX_HINTED_HOSTS) return again
+
+            try {
+                val newEngine = buildEngine(context, if (host != null) hintedHosts + host else hintedHosts, port)
+                if (host != null) hintedHosts.add(host)
+                if (again != null) retireAsync(again)
+                engineRef = newEngine
+                AppLogger.i(TAG, "Cronet engine ready (version=${newEngine.versionString}, hinted=${hintedHosts.size}, ech=$echMode)")
+                return newEngine
+            } catch (t: Throwable) {
+                AppLogger.e(TAG, "Failed to build Cronet engine", t)
+                kickBackgroundDownload(context)
+                return again
+            }
+        }
+    }
+
+    private fun buildEngine(context: Context, hosts: Set<String>, port: Int): CronetEngine {
+        val depsDir = CronetDependencyManager.getLibDir(context)
+        val builder = CronetEngine.Builder(context)
+            .enableQuic(true)
+            .enableHttp2(true)
+            .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISABLED, 0)
+            .setLibraryLoader(object : CronetEngine.Builder.LibraryLoader() {
+                override fun loadLibrary(libName: String) {
+                    try {
+                        // Generated APKs (and any host that bundles it): nativeLibraryDir.
+                        System.loadLibrary(libName)
+                        return
+                    } catch (_: Throwable) {
+                    }
+                    // Host preview: the .so is downloaded on demand (packaging excludes it).
+                    val downloaded = File(depsDir, "lib$libName.so")
+                    if (downloaded.isFile && downloaded.length() > 0L) {
+                        System.load(downloaded.absolutePath)
+                        return
+                    }
+                    throw UnsatisfiedLinkError("Cronet native library unavailable: $libName")
+                }
+            })
+        val hintPort = if (port in 1..65535) port else 443
+        hosts.forEach { builder.addQuicHint(it, hintPort, hintPort) }
+        if (echMode) {
+            // The built-in resolver is what queries HTTPS (type 65) records; without it
+            // Cronet falls back to getaddrinfo and ECH never sees an ECHConfig to use.
+            builder.setDnsOptions(
+                DnsOptions.builder().useBuiltInDnsResolver(true).build()
+            )
+        }
+        return builder.build()
+    }
+
+    private fun kickBackgroundDownload(context: Context) {
+        if (!downloadKick.compareAndSet(false, true)) return
+        downloadScope.launch {
+            try {
+                val ok = CronetDependencyManager.downloadCronetRuntime(context)
+                AppLogger.i(TAG, "Cronet background download: ${if (ok) "ok" else "failed"}")
+            } catch (t: Throwable) {
+                AppLogger.e(TAG, "Cronet background download error", t)
+            }
+        }
+    }
+
+    /**
+     * Forwards one HTTP/1.1 request through Cronet and writes the serialized HTTP/1.1
+     * response (chunked body framing) to [sink]. Blocks the caller until the response
+     * completes.
+     *
+     * @param headers request headers in their original wire order, hop-by-hop headers
+     *   already filtered by the caller (authority, body framing, and proxy headers
+     *   are all re-derived by Cronet)
+     * @param clientWantsClose the client sent `Connection: close`; the response head
+     *   says so accordingly
+     * @return true when a complete response was written; false when the exchange failed
+     *   before anything was written (caller synthesizes a 502)
+     * @throws IOException the client side broke mid-response (a partial chunked stream
+     *   cannot be completed, so the connection must be closed)
+     */
+    fun forward(
+        context: Context,
+        method: String,
+        url: String,
+        headers: List<Pair<String, String>>,
+        body: ByteArray?,
+        sink: OutputStream,
+        clientWantsClose: Boolean,
+        hostForHint: String,
+        portForHint: Int
+    ): Boolean {
+        val engine = ensureEngine(context, hostForHint, portForHint)
+            ?: return false
+
+        val latch = CountDownLatch(1)
+        val headWritten = AtomicBoolean(false)
+        val failure = AtomicReference<Throwable?>()
+        val scratch = ByteArray(READ_BUFFER_BYTES)
+
+        val callback = object : UrlRequest.Callback() {
+            var status: Int = 0
+
+            /** 204/205/304 and HEAD responses carry no body and thus no chunked framing. */
+            val bodyPermitted: Boolean
+                get() = method != "HEAD" &&
+                    status != 204 && status != 205 && status != 304 &&
+                    status >= 200
+
+            override fun onRedirectReceived(request: UrlRequest, info: UrlResponseInfo, newLocation: String) {
+                try {
+                    // Proxy semantics: hand the 3xx to the client instead of following it —
+                    // the WebView owns navigation, history, and origin decisions. The
+                    // redirect response carries an empty chunked body so HTTP/1.1 framing
+                    // stays valid on the keep-alive connection.
+                    status = info.httpStatusCode
+                    writeHead(sink, info, clientWantsClose, chunked = method != "HEAD")
+                    if (method != "HEAD") {
+                        sink.write("0\r\n\r\n".toByteArray(Charsets.ISO_8859_1))
+                    }
+                    sink.flush()
+                    headWritten.set(true)
+                    request.cancel()
+                } catch (t: Throwable) {
+                    failure.compareAndSet(null, t)
+                    request.cancel()
+                }
+            }
+
+            override fun onResponseStarted(request: UrlRequest, info: UrlResponseInfo) {
+                status = info.httpStatusCode
+                try {
+                    writeHead(sink, info, clientWantsClose, chunked = bodyPermitted)
+                    headWritten.set(true)
+                    if (bodyPermitted) {
+                        request.read(ByteBuffer.allocateDirect(READ_BUFFER_BYTES))
+                    }
+                    // HEAD / 204 / 304 / early responses complete via onSucceeded.
+                } catch (t: Throwable) {
+                    failure.compareAndSet(null, t)
+                    request.cancel()
+                }
+            }
+
+            override fun onReadCompleted(request: UrlRequest, info: UrlResponseInfo, byteBuffer: ByteBuffer) {
+                try {
+                    byteBuffer.flip()
+                    if (byteBuffer.hasRemaining()) {
+                        val length = byteBuffer.remaining()
+                        val chunkHead = Integer.toHexString(length).toByteArray(Charsets.ISO_8859_1)
+                        sink.write(chunkHead)
+                        sink.write(CRLF)
+                        byteBuffer.get(scratch, 0, length)
+                        sink.write(scratch, 0, length)
+                        sink.write(CRLF)
+                    }
+                    byteBuffer.clear()
+                    request.read(byteBuffer)
+                } catch (t: Throwable) {
+                    failure.compareAndSet(null, t)
+                    request.cancel()
+                }
+            }
+
+            override fun onSucceeded(request: UrlRequest, info: UrlResponseInfo) {
+                try {
+                    if (bodyPermitted) {
+                        sink.write("0\r\n\r\n".toByteArray(Charsets.ISO_8859_1))
+                    }
+                    sink.flush()
+                } catch (t: Throwable) {
+                    failure.compareAndSet(null, t)
+                }
+                AppLogger.d(
+                    TAG,
+                    "h3 forward done: ${info.httpStatusCode} proto=${info.negotiatedProtocol} url=$url"
+                )
+                latch.countDown()
+            }
+
+            override fun onFailed(request: UrlRequest, info: UrlResponseInfo?, error: CronetException) {
+                failure.compareAndSet(null, error)
+                latch.countDown()
+            }
+
+            override fun onCanceled(request: UrlRequest, info: UrlResponseInfo?) {
+                latch.countDown()
+            }
+        }
+
+        val requestBuilder = engine.newUrlRequestBuilder(url, callback, callbackExecutor)
+            .setHttpMethod(method)
+            .disableCache()
+        headers.forEach { (name, value) -> requestBuilder.addHeader(name, value) }
+        if (body != null && body.isNotEmpty()) {
+            requestBuilder.setUploadDataProvider(UploadDataProviders.create(body), callbackExecutor)
+        }
+
+        val request = requestBuilder.build()
+        request.start()
+
+        latch.await()
+
+        val error = failure.get()
+        if (error != null) {
+            if (headWritten.get()) {
+                // Body cut mid-stream — the connection is unusable for keep-alive.
+                throw IOException("Cronet forward failed mid-response: ${error.message}", error)
+            }
+            AppLogger.w(TAG, "Cronet forward failed for $url: ${error.message}")
+            return false
+        }
+        return headWritten.get()
+    }
+
+    private fun writeHead(
+        sink: OutputStream,
+        info: UrlResponseInfo,
+        clientWantsClose: Boolean,
+        chunked: Boolean
+    ) {
+        val sb = StringBuilder()
+        sb.append("HTTP/1.1 ").append(info.httpStatusCode)
+            .append(' ').append(info.httpStatusText.ifEmpty { "Unknown" })
+            .append("\r\n")
+        info.allHeadersAsList.forEach { (name, value) ->
+            val lower = name.lowercase(Locale.ROOT)
+            if (lower in HOP_BY_HOP_RESPONSE_HEADERS) return@forEach
+            sb.append(name).append(": ").append(value).append("\r\n")
+        }
+        if (chunked) {
+            sb.append("Transfer-Encoding: chunked\r\n")
+        }
+        sb.append("Connection: ").append(if (clientWantsClose) "close" else "keep-alive").append("\r\n")
+        sb.append("\r\n")
+        sink.write(sb.toString().toByteArray(Charsets.ISO_8859_1))
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/TlsMitmBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/TlsMitmBridge.kt
@@ -28,11 +28,26 @@ object TlsMitmBridge {
     private const val MAX_HEADER_BYTES = 64 * 1024
     private const val CLIENT_READ_TIMEOUT_MS = 60_000
 
+    /** h3 forwarding buffers full request bodies; huge uploads exceed that contract. */
+    private const val MAX_H3_BODY_BYTES = 32 * 1024 * 1024
+
     data class Config(
         val template: TlsFingerprintTemplate,
         val customCipherSuites: List<String> = emptyList(),
-        val upstreamSocks: LocalHttpToSocksBridge.Upstream? = null
-    )
+        val upstreamSocks: LocalHttpToSocksBridge.Upstream? = null,
+        val forceHttp3: Boolean = false,
+        /** ECH on the system engine: the upstream leg is Cronet, whose Chromium stack
+         *  fetches HTTPS records and encrypts the ClientHello SNI natively (issue #721). */
+        val echUpstream: Boolean = false
+    ) {
+        /**
+         * Both forced HTTP/3 and ECH ride the same MITM bridge as fingerprint spoofing,
+         * but their upstream leg is Cronet — which cannot chain through a SOCKS proxy.
+         * When the user configures a SOCKS upstream the bridge stays on the classic
+         * relay and both toggles are inert.
+         */
+        val cronetActive: Boolean get() = (forceHttp3 || echUpstream) && upstreamSocks == null
+    }
 
     @Volatile private var serverSocket: ServerSocket? = null
     @Volatile private var executor: ThreadPoolExecutor? = null
@@ -41,6 +56,7 @@ object TlsMitmBridge {
     @Volatile private var currentConfig: Config? = null
     @Volatile private var listenPort: Int = 0
     @Volatile private var caDir: File? = null
+    @Volatile private var appContext: android.content.Context? = null
 
     /** User-imported CA anchors additionally trusted when verifying upstream certificates. */
     @Volatile private var customCaAnchors: List<java.security.cert.X509Certificate> = emptyList()
@@ -79,7 +95,8 @@ object TlsMitmBridge {
     fun start(
         config: Config,
         caDir: File,
-        customCaAnchors: List<java.security.cert.X509Certificate> = emptyList()
+        customCaAnchors: List<java.security.cert.X509Certificate> = emptyList(),
+        appContext: android.content.Context? = null
     ): Int {
         TlsMitmCaManager.init(caDir)
         if (!TlsMitmCaManager.isCaInitialized()) {
@@ -93,6 +110,7 @@ object TlsMitmBridge {
         }
         stopInternal()
         this.customCaAnchors = customCaAnchors
+        this.appContext = appContext
 
         try {
             val socket = ServerSocket(0, 64, InetAddress.getByName("127.0.0.1"))
@@ -114,9 +132,13 @@ object TlsMitmBridge {
             acceptThread = accept
             accept.start()
 
+            if (config.cronetActive && appContext != null) {
+                CronetForwarder.start(appContext, echUpstream = config.echUpstream)
+            }
+
             AppLogger.i(
                 TAG,
-                "TLS MITM bridge listening 127.0.0.1:$listenPort template=${config.template.id} customCiphers=${config.customCipherSuites.size} socks=${config.upstreamSocks != null}"
+                "TLS MITM bridge listening 127.0.0.1:$listenPort template=${config.template.id} customCiphers=${config.customCipherSuites.size} socks=${config.upstreamSocks != null} http3=${config.forceHttp3} ech=${config.echUpstream}"
             )
             return listenPort
         } catch (e: Exception) {
@@ -149,6 +171,8 @@ object TlsMitmBridge {
         customCaAnchors = emptyList()
         allowedHosts.clear()
         hostAllowlistEnforcement = true
+        appContext = null
+        try { CronetForwarder.stop() } catch (_: Throwable) {}
     }
 
     private fun acceptLoop(socket: ServerSocket) {
@@ -248,6 +272,14 @@ object TlsMitmBridge {
             safeClose(client); return
         }
 
+        // Missing Cronet (not yet downloaded / not embedded) degrades to the classic
+        // relay instead of failing every request with 502.
+        val cronetCtx = appContext
+        if (config.cronetActive && cronetCtx != null && CronetForwarder.isReady(cronetCtx)) {
+            handleConnectCronet(client, clientOut, host, port, config)
+            return
+        }
+
         // Handshake with the WebView FIRST and remember which ALPN protocol it picked,
         // so the upstream connection can be restricted to the same protocol. The bridge
         // relays raw bytes — if the two sides negotiated independently, a WebView on h2
@@ -299,6 +331,10 @@ object TlsMitmBridge {
     }
 
     private fun performTlsHandshake(client: Socket, host: String): SSLSocket {
+        return performTlsHandshake(client, host, arrayOf("h2", "http/1.1"))
+    }
+
+    private fun performTlsHandshake(client: Socket, host: String, alpn: Array<String>): SSLSocket {
         val kmf = TlsMitmCaManager.createKeyManagerFactory(host)
             ?: throw java.io.IOException("Failed to create key manager for $host")
 
@@ -312,7 +348,7 @@ object TlsMitmBridge {
 
         try {
             val params = sslSocket.sslParameters
-            params.applicationProtocols = arrayOf("h2", "http/1.1")
+            params.applicationProtocols = alpn
             params.endpointIdentificationAlgorithm = null
             sslSocket.sslParameters = params
         } catch (_: Exception) {
@@ -320,6 +356,283 @@ object TlsMitmBridge {
 
         sslSocket.startHandshake()
         return sslSocket
+    }
+
+    /**
+     * Cronet upstream path (forced HTTP/3 and/or ECH): the bridge terminates TLS with
+     * the WebView speaking plain HTTP/1.1 only, then re-issues every request through
+     * Cronet — Chromium's own stack, QUIC-first when h3 forcing is on, ECH when the
+     * target publishes an HTTPS record. WebSocket upgrades and other non-plain-HTTP
+     * tunnels fall back to the classic raw relay. Cronet is a request/response engine,
+     * not a byte pump — this is the only part of the bridge that speaks HTTP.
+     */
+    private fun handleConnectCronet(
+        client: Socket,
+        clientOut: OutputStream,
+        host: String,
+        port: Int,
+        config: Config
+    ) {
+        val context = appContext ?: run { safeClose(client); return }
+
+        AppLogger.d(TAG, "h3 CONNECT tunnel: $host:$port")
+
+        // Answer the CONNECT before handshaking: clients that wait for the 200
+        // before starting TLS (no ClientHello pipelining) would otherwise deadlock
+        // the tunnel until their connect timeout fires. A pipelining client simply
+        // leaves its buffered ClientHello in the socket until we read it.
+        try {
+            clientOut.write("HTTP/1.1 200 Connection Established\r\n\r\n".toByteArray(StandardCharsets.US_ASCII))
+            clientOut.flush()
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "Failed to send CONNECT 200: ${e.message}")
+            safeClose(client); return
+        }
+
+        val mitmSocket = try {
+            performTlsHandshake(client, host, arrayOf("http/1.1"))
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "MITM TLS handshake failed for $host: ${e.message}")
+            safeClose(client); return
+        }
+
+        // Keep-alive connections idle between requests; Chromium closes its side when
+        // its pool retires the socket, and loopback always delivers the FIN.
+        try { mitmSocket.soTimeout = 0 } catch (_: Exception) {}
+
+        val input = BufferedInputStream(mitmSocket.getInputStream())
+        val output = mitmSocket.getOutputStream()
+        val hostPart = if (host.contains(':') && !host.startsWith("[")) "[$host]" else host
+        val portPart = if (port == 443) "" else ":$port"
+
+        try {
+            while (true) {
+                val firstLine = readHttpLine(input) ?: break
+                if (firstLine.isEmpty()) continue
+                val parts = firstLine.split(' ', limit = 3)
+                if (parts.size < 3) {
+                    sendStatus(output, 400, "Bad Request")
+                    break
+                }
+                val method = parts[0]
+                val target = parts[1]
+
+                val headerLines = mutableListOf<String>()
+                var headerBytes = firstLine.length
+                while (true) {
+                    val line = readHttpLine(input) ?: return
+                    if (line.isEmpty()) break
+                    headerLines.add(line)
+                    headerBytes += line.length
+                    if (headerBytes > MAX_HEADER_BYTES) {
+                        sendStatus(output, 431, "Request Header Fields Too Large")
+                        return
+                    }
+                }
+
+                // Upgrades (WebSocket, h2c, ...) cannot ride a request/response engine;
+                // hand the connection to the classic raw TLS relay instead.
+                val wantsUpgrade = headerLines.any { it.startsWith("upgrade:", ignoreCase = true) }
+                if (wantsUpgrade) {
+                    fallbackToRawRelay(mitmSocket, input, host, port, config, firstLine, headerLines)
+                    return
+                }
+
+                val clientWantsClose = headerLines.any {
+                    it.startsWith("connection:", ignoreCase = true) &&
+                        it.substringAfter(':', "").contains("close", ignoreCase = true)
+                }
+
+                val body = try {
+                    readRequestBody(input, headerLines)
+                } catch (e: Exception) {
+                    AppLogger.w(TAG, "Failed to read request body for $host: ${e.message}")
+                    sendStatus(output, 413, "Payload Too Large")
+                    return
+                }
+
+                val filteredHeaders = headerLines.mapNotNull { line ->
+                    val lower = line.lowercase(Locale.ROOT)
+                    when {
+                        lower.startsWith("host:") -> null
+                        lower.startsWith("proxy-connection:") ||
+                            lower.startsWith("proxy-authorization:") -> null
+                        lower.startsWith("connection:") ||
+                            lower.startsWith("keep-alive:") -> null
+                        lower.startsWith("content-length:") ||
+                            lower.startsWith("transfer-encoding:") -> null
+                        else -> {
+                            val idx = line.indexOf(':')
+                            if (idx > 0) {
+                                line.substring(0, idx).trim() to line.substring(idx + 1).trim()
+                            } else {
+                                null
+                            }
+                        }
+                    }
+                }
+
+                val requestUrl = if (target.startsWith("http://", true) || target.startsWith("https://", true)) {
+                    target
+                } else {
+                    "https://$hostPart$portPart$target"
+                }
+
+                val forwarded = try {
+                    CronetForwarder.forward(
+                        context = context,
+                        method = method,
+                        url = requestUrl,
+                        headers = filteredHeaders,
+                        body = body,
+                        sink = output,
+                        clientWantsClose = clientWantsClose,
+                        hostForHint = host,
+                        portForHint = port
+                    )
+                } catch (e: java.io.IOException) {
+                    // Client broke mid-response; nothing left to salvage.
+                    AppLogger.d(TAG, "h3 forward client I/O error for $host: ${e.message}")
+                    return
+                }
+
+                if (!forwarded) {
+                    sendStatus(output, 502, "Bad Gateway")
+                    return
+                }
+                if (clientWantsClose) break
+            }
+        } catch (e: Exception) {
+            AppLogger.d(TAG, "h3 connect loop ended for $host: ${e.message}")
+        } finally {
+            safeClose(mitmSocket)
+        }
+    }
+
+    /**
+     * WebSocket / upgrade fallback: replay the already-parsed request head into a
+     * classic upstream TLS connection, flush anything the buffered stream pre-read,
+     * then raw-relay the rest of the session.
+     */
+    private fun fallbackToRawRelay(
+        mitmSocket: SSLSocket,
+        bufferedInput: BufferedInputStream,
+        host: String,
+        port: Int,
+        config: Config,
+        firstLine: String,
+        headerLines: List<String>
+    ) {
+        val upstreamSocket = try {
+            TlsUpstreamConnector.connect(
+                host = host,
+                port = port,
+                template = config.template,
+                customCipherSuites = config.customCipherSuites,
+                upstreamSocks = config.upstreamSocks,
+                restrictAlpnTo = "http/1.1",
+                customCaAnchors = customCaAnchors
+            ).sslSocket
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "h3 upgrade fallback upstream connect failed for $host:$port: ${e.message}")
+            safeClose(mitmSocket)
+            return
+        }
+
+        try {
+            val upstreamOut = upstreamSocket.getOutputStream()
+            val sb = StringBuilder()
+            sb.append(firstLine).append("\r\n")
+            headerLines.forEach { sb.append(it).append("\r\n") }
+            sb.append("\r\n")
+            upstreamOut.write(sb.toString().toByteArray(StandardCharsets.ISO_8859_1))
+            upstreamOut.flush()
+
+            // The buffered stream may hold pipelined bytes past the request head.
+            val preRead = ByteArray(IO_BUFFER)
+            while (bufferedInput.available() > 0) {
+                val n = bufferedInput.read(preRead)
+                if (n <= 0) break
+                upstreamOut.write(preRead, 0, n)
+            }
+            upstreamOut.flush()
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "h3 upgrade fallback replay failed for $host: ${e.message}")
+            safeClose(upstreamSocket)
+            safeClose(mitmSocket)
+            return
+        }
+
+        try { mitmSocket.soTimeout = 0 } catch (_: Exception) {}
+        try { upstreamSocket.soTimeout = 0 } catch (_: Exception) {}
+        bridge(mitmSocket, upstreamSocket)
+    }
+
+    /** Reads a request body bounded by Content-Length or chunked framing. */
+    private fun readRequestBody(input: InputStream, headerLines: List<String>): ByteArray? {
+        val transferEncoding = headerLines.firstOrNull { it.startsWith("transfer-encoding:", ignoreCase = true) }
+            ?.substringAfter(':')
+            ?.trim()
+            ?.lowercase(Locale.ROOT)
+        return if (transferEncoding != null && transferEncoding.contains("chunked")) {
+            readChunkedBody(input)
+        } else {
+            val contentLength = headerLines.firstOrNull { it.startsWith("content-length:", ignoreCase = true) }
+                ?.substringAfter(':')
+                ?.trim()
+                ?.toIntOrNull()
+                ?: return null
+            if (contentLength <= 0) null else readBounded(input, contentLength)
+        }
+    }
+
+    private fun readBounded(input: InputStream, length: Int): ByteArray {
+        if (length > MAX_H3_BODY_BYTES) {
+            throw java.io.IOException("Request body too large: $length")
+        }
+        val buffer = ByteArray(length)
+        var off = 0
+        while (off < length) {
+            val read = input.read(buffer, off, length - off)
+            if (read < 0) throw java.io.EOFException("Request body truncated")
+            off += read
+        }
+        return buffer
+    }
+
+    private fun readChunkedBody(input: InputStream): ByteArray {
+        val out = java.io.ByteArrayOutputStream()
+        while (true) {
+            val sizeLine = readHttpLine(input) ?: throw java.io.EOFException("Chunked body truncated")
+            val size = sizeLine.substringBefore(';').trim().toIntOrNull(16)
+                ?: throw java.io.IOException("Bad chunk size: $sizeLine")
+            if (size == 0) {
+                // Consume trailers until the empty line.
+                while (true) {
+                    val trailer = readHttpLine(input) ?: break
+                    if (trailer.isEmpty()) break
+                }
+                break
+            }
+            if (out.size() + size > MAX_H3_BODY_BYTES) {
+                throw java.io.IOException("Chunked request body too large")
+            }
+            readBoundedInto(input, out, size)
+            // Trailing CRLF after each chunk.
+            readHttpLine(input)
+        }
+        return out.toByteArray()
+    }
+
+    private fun readBoundedInto(input: InputStream, out: java.io.ByteArrayOutputStream, length: Int) {
+        val buffer = ByteArray(minOf(length, IO_BUFFER))
+        var remaining = length
+        while (remaining > 0) {
+            val read = input.read(buffer, 0, minOf(remaining, buffer.size))
+            if (read < 0) throw java.io.EOFException("Chunk truncated")
+            out.write(buffer, 0, read)
+            remaining -= read
+        }
     }
 
     private fun handleHttpForward(

--- a/app/src/main/java/com/webtoapp/core/webview/TlsMitmCaManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/TlsMitmCaManager.kt
@@ -152,8 +152,16 @@ object TlsMitmCaManager {
         return try {
             // Issuer DN alone is forgeable (the CA subject is public in every shipped APK);
             // require an actual signature verification against the local CA key. Fail-closed.
-            cert.issuerX500Principal == ca.subjectX500Principal &&
-                runCatching { cert.verify(caKey); true }.getOrDefault(false)
+            val issuerMatches = cert.issuerX500Principal == ca.subjectX500Principal
+            val verified = runCatching { cert.verify(caKey); true }.getOrDefault(false)
+            if (!(issuerMatches && verified)) {
+                AppLogger.d(
+                    TAG,
+                    "isSignedByLocalCa rejected leaf: issuerMatches=$issuerMatches verified=$verified " +
+                        "leafIssuer=${cert.issuerX500Principal.name} caSubject=${ca.subjectX500Principal.name}"
+                )
+            }
+            issuerMatches && verified
         } catch (_: Exception) {
             false
         }
@@ -174,8 +182,13 @@ object TlsMitmCaManager {
             leafKeyGen.initialize(CA_KEY_SIZE)
             val leafPair = leafKeyGen.generateKeyPair()
 
-            val issuer = caPrincipal ?: return null
-            val issuerName = X500Name(issuer.name)
+            // Build the issuer from the CA certificate's subject DER, not from its
+            // RFC 2253 string: X500Name(String) reorders RDNs (BC style), which makes the
+            // minted leaf's issuerX500Principal differ from the CA's subjectX500Principal
+            // (DER order matters in X500Principal.equals) and isSignedByLocalCa then
+            // rejects our own leaf — the WebView pops an SSL error dialog instead of
+            // letting the MITM cert through.
+            val issuerName = X500Name.getInstance(caCertLocal.subjectX500Principal.encoded)
             val subjectName = X500Name("CN=$normalizedHost")
 
             val serial = BigInteger.valueOf(System.currentTimeMillis())

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1344,8 +1344,16 @@ class WebViewManager(
 
         val tlsFingerprintEnabled = config.tlsFingerprintEnabled &&
             config.tlsFingerprintTemplate.isNotBlank()
+        // ECH on the system engine rides the same MITM bridge as forced HTTP/3: the
+        // upstream leg is Cronet, whose Chromium stack fetches HTTPS records and
+        // encrypts the ClientHello SNI natively. Without DoH the record query goes out
+        // over plain DNS — echEffective still allows that; the SNI itself stays hidden.
+        val echUpstream = config.dnsConfig.echEffective
+        // Forced HTTP/3 and ECH both ride the MITM bridge (their upstream leg is
+        // Cronet), so either must be able to start the bridge alone.
+        val needsMitmBridge = tlsFingerprintEnabled || config.forceHttp3 || echUpstream
 
-        if (tlsFingerprintEnabled) {
+        if (needsMitmBridge) {
             val template = TlsFingerprintTemplate.fromId(config.tlsFingerprintTemplate)
             val upstreamSocks = if (config.proxyMode == "STATIC" &&
                 (config.proxyType == "SOCKS5" || config.proxyType == "SOCKS")) {
@@ -1358,6 +1366,12 @@ class WebViewManager(
             } else {
                 null
             }
+            if (config.forceHttp3 && upstreamSocks != null) {
+                AppLogger.w("WebViewManager", "强制 HTTP/3 ignored: SOCKS upstream proxy takes precedence")
+            }
+            if (echUpstream && upstreamSocks != null) {
+                AppLogger.w("WebViewManager", "ECH ignored on system engine: SOCKS upstream proxy takes precedence")
+            }
 
             val mitmPort = TlsMitmBridge.start(
                 config = TlsMitmBridge.Config(
@@ -1367,13 +1381,16 @@ class WebViewManager(
                     } else {
                         emptyList()
                     },
-                    upstreamSocks = upstreamSocks
+                    upstreamSocks = upstreamSocks,
+                    forceHttp3 = config.forceHttp3,
+                    echUpstream = echUpstream
                 ),
                 caDir = context.filesDir,
                 customCaAnchors = runCatching {
                     CustomCaTrustStore.init(context)
                     CustomCaTrustStore.getAnchorCertificates()
-                }.getOrDefault(emptyList())
+                }.getOrDefault(emptyList()),
+                appContext = context.applicationContext
             )
 
             if (mitmPort > 0) {

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -468,6 +468,12 @@ data class WebViewConfig(
     val tlsFingerprintTemplate: String = "CHROME_131",
     val tlsFingerprintCustomCiphers: List<String> = emptyList(),
 
+    // Issue #721: forward bridged requests through Chromium's own network stack with a
+    // QUIC hint per host, so HTTP/3 is attempted from the first request. Pairs with TLS
+    // fingerprint spoofing (the h3 upstream IS genuine Chromium); inert when a SOCKS
+    // upstream proxy is configured.
+    val forceHttp3: Boolean = false,
+
     val antiCapture: Boolean = false,
 
     val dnsMode: String = "SYSTEM",

--- a/app/src/main/java/com/webtoapp/ui/components/DnsConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/DnsConfigCard.kt
@@ -54,7 +54,6 @@ fun DnsConfigCard(
     onDnsModeChange: (String) -> Unit,
     onDnsConfigChange: (DnsConfig) -> Unit,
     engineType: String = "SYSTEM_WEBVIEW",
-    onEngineTypeChange: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val enabled = dnsMode != "SYSTEM"
@@ -65,8 +64,10 @@ fun DnsConfigCard(
             onDnsConfigChange(dnsConfig.copy(echEnabled = false))
             return
         }
+        // ECH works on both engines now: GeckoView via TRR + its own ECH prefs, the
+        // system engine via the MITM bridge's Cronet upstream (Chromium fetches HTTPS
+        // records and encrypts the ClientHello SNI itself). DoH is still preferred.
         if (dnsMode == "SYSTEM") onDnsModeChange("DOH")
-        if (!isGecko) onEngineTypeChange("GECKOVIEW")
         onDnsConfigChange(dnsConfig.copy(echEnabled = true))
     }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt
@@ -258,7 +258,9 @@ private fun BuildApkContent(
             }
             val ensureOk = ExportRuntimeEnsure.ensure(
                 context,
-                webAppWithConfig.appType
+                webAppWithConfig.appType,
+                webAppWithConfig.webViewConfig.forceHttp3 ||
+                    webAppWithConfig.webViewConfig.dnsConfig.echEffective
             )
             if (!ensureOk) {
                 progressText = when (webAppWithConfig.appType) {
@@ -315,7 +317,8 @@ private fun BuildApkContent(
     ) {
         if (!uiReady) return@LaunchedEffect
         val config = currentBuildConfig()
-        if (ExportRuntimeEnsure.needsEnsure(context, config.appType)) {
+        val needsCronet = config.webViewConfig.forceHttp3 || config.webViewConfig.dnsConfig.echEffective
+        if (ExportRuntimeEnsure.needsEnsure(context, config.appType, needsCronet)) {
             isEnsuringRuntime = true
             ensureRuntimeText = when (config.appType) {
                 AppType.PYTHON_APP -> Strings.preparingPythonEnv
@@ -324,7 +327,7 @@ private fun BuildApkContent(
                 AppType.WORDPRESS -> Strings.preparing
                 else -> Strings.preparing
             }
-            val ensureOk = ExportRuntimeEnsure.ensure(context, config.appType)
+            val ensureOk = ExportRuntimeEnsure.ensure(context, config.appType, needsCronet)
             if (!ensureOk) {
                 ensureRuntimeText = when (config.appType) {
                     AppType.PYTHON_APP -> Strings.pythonRuntimeDownloadFailed

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
@@ -475,12 +475,7 @@ fun CreateAppScreen(
                             copy(webViewConfig = webViewConfig.copy(dnsConfig = config))
                         }
                     },
-                    engineType = editState.apkExportConfig.engineType,
-                    onEngineTypeChange = { type ->
-                        viewModel.updateEditState {
-                            copy(apkExportConfig = apkExportConfig.copy(engineType = type))
-                        }
-                    }
+                    engineType = editState.apkExportConfig.engineType
                 )
             }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -1740,6 +1740,26 @@ fun BrowserAdvancedConfigCard(
                                         color = MaterialTheme.colorScheme.tertiary
                                     )
 
+                                    WtaToggleRow(
+                                        title = Strings.forceHttp3Title,
+                                        subtitle = Strings.forceHttp3Description,
+                                        icon = Icons.Outlined.Bolt,
+                                        checked = config.forceHttp3,
+                                        onCheckedChange = { onConfigChange(config.copy(forceHttp3 = it)) }
+                                    )
+
+                                    AnimatedVisibility(
+                                        visible = config.forceHttp3,
+                                        enter = CardExpandTransition,
+                                        exit = CardCollapseTransition
+                                    ) {
+                                        Text(
+                                            text = Strings.forceHttp3Note,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+
                                     if (config.proxyMode == "STATIC" &&
                                         (config.proxyType == "SOCKS5" || config.proxyType == "SOCKS")) {
                                         Text(

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -298,6 +298,7 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         tlsFingerprintEnabled = config.webViewConfig.tlsFingerprintEnabled,
         tlsFingerprintTemplate = config.webViewConfig.tlsFingerprintTemplate,
         tlsFingerprintCustomCiphers = config.webViewConfig.tlsFingerprintCustomCiphers,
+        forceHttp3 = config.webViewConfig.forceHttp3,
         antiCapture = config.webViewConfig.antiCapture,
 
         dnsMode = config.webViewConfig.dnsMode,

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
@@ -68,7 +68,7 @@ class WebViewConfigBooleanCoverageTest {
             "databaseEnabled", "primeUserActivation", "failoverEnabled",
             "hostsMappingEnabled", "autoRefreshEnabled", "autoRefreshShowCountdown",
             "allowFileAccessFromFileURLs", "allowUniversalAccessFromFileURLs",
-            "tlsFingerprintEnabled"
+            "tlsFingerprintEnabled", "forceHttp3"
         )
 
         val missing = allBooleanFields - listedFields
@@ -371,7 +371,8 @@ class WebViewConfigBooleanCoverageTest {
             autoRefreshShowCountdown = bool("autoRefreshShowCountdown"),
             allowFileAccessFromFileURLs = bool("allowFileAccessFromFileURLs"),
             allowUniversalAccessFromFileURLs = bool("allowUniversalAccessFromFileURLs"),
-            tlsFingerprintEnabled = bool("tlsFingerprintEnabled")
+            tlsFingerprintEnabled = bool("tlsFingerprintEnabled"),
+            forceHttp3 = bool("forceHttp3")
         )
     }
 }

--- a/app/src/test/java/com/webtoapp/core/webview/TlsMitmBridgeTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/TlsMitmBridgeTest.kt
@@ -116,6 +116,28 @@ class TlsMitmBridgeTest {
     }
 
     @Test
+    fun `cronet activation matrix for http3 and ech`() {
+        val template = TlsFingerprintTemplate.CHROME_131
+        val socks = LocalHttpToSocksBridge.Upstream("127.0.0.1", 1080)
+
+        // Plain fingerprint spoofing stays on the classic raw relay.
+        assertThat(TlsMitmBridge.Config(template = template).cronetActive).isFalse()
+        // Forced HTTP/3 and ECH both activate the Cronet upstream.
+        assertThat(TlsMitmBridge.Config(template = template, forceHttp3 = true).cronetActive).isTrue()
+        assertThat(TlsMitmBridge.Config(template = template, echUpstream = true).cronetActive).isTrue()
+        assertThat(
+            TlsMitmBridge.Config(template = template, forceHttp3 = true, echUpstream = true).cronetActive
+        ).isTrue()
+        // A SOCKS upstream takes precedence and leaves both toggles inert.
+        assertThat(
+            TlsMitmBridge.Config(template = template, forceHttp3 = true, upstreamSocks = socks).cronetActive
+        ).isFalse()
+        assertThat(
+            TlsMitmBridge.Config(template = template, echUpstream = true, upstreamSocks = socks).cronetActive
+        ).isFalse()
+    }
+
+    @Test
     fun `multiple start stop cycles work correctly`() {
         for (i in 1..3) {
             val port = TlsMitmBridge.start(

--- a/app/src/test/java/com/webtoapp/core/webview/TlsMitmCaManagerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/TlsMitmCaManagerTest.kt
@@ -78,6 +78,13 @@ class TlsMitmCaManagerTest {
 
         assertThat(leafCert.issuerX500Principal).isEqualTo(caCert.subjectX500Principal)
         assertThat(TlsMitmCaManager.isSignedByLocalCa(leafCert)).isTrue()
+
+        // X500Principal.equals is lenient on the JVM but byte-exact on Android
+        // (Conscrypt): an RDN-order drift between the minted leaf's issuer and the
+        // CA subject passes on the host and pops SSL error dialogs on devices.
+        // Compare the raw DER encodings so the drift fails everywhere.
+        assertThat(leafCert.issuerX500Principal.encoded)
+            .isEqualTo(caCert.subjectX500Principal.encoded)
     }
 
     @Test

--- a/app/src/test/java/com/webtoapp/data/model/WebViewConfigDefaultsContractTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/WebViewConfigDefaultsContractTest.kt
@@ -39,6 +39,7 @@ class WebViewConfigDefaultsContractTest {
         "showFloatingBackButton",
         "hostsMappingEnabled",
         "tlsFingerprintEnabled",
+        "forceHttp3",                     // forced QUIC is an opt-in network mode
         "enableNotificationPolyfill",    // implies POST_NOTIFICATIONS on every export
         "geolocationEnabled"             // implies location permission on every export
     )

--- a/docs/guide/more-features/browser-kernel.md
+++ b/docs/guide/more-features/browser-kernel.md
@@ -5,11 +5,11 @@ Manage the browser engines available to your apps. Open it from [⋮ → Browser
 ## Features
 
 - **Current WebView info** — inspect the system WebView version on this device.
-- **Embedded engine** — download, manage, and delete the optional GeckoView (Firefox) runtime, used for ECH / SNI encryption. Shows download size and progress; the heavy native artifacts are fetched on first use.
+- **Embedded engine** — download, manage, and delete the optional GeckoView (Firefox) runtime. Shows download size and progress; the heavy native artifacts are fetched on first use.
 - **Change WebView provider** — switch the system WebView provider (with developer-options steps guidance).
 - **Engine descriptions** — reference info for Chrome, Edge, Brave, Firefox, and Via.
 
 ## Notes
 
 - Per-app engine selection happens in the [Build APK](/guide/app-actions/build-apk) dialog; this screen manages the engines themselves.
-- GeckoView is required for [ECH](/guide/config/network).
+- [ECH](/guide/config/network) works on both engines; GeckoView is one option, not a requirement.

--- a/docs/zh/guide/more-features/browser-kernel.md
+++ b/docs/zh/guide/more-features/browser-kernel.md
@@ -5,11 +5,11 @@
 ## 功能
 
 - **当前 WebView 信息** —— 查看本设备的系统 WebView 版本。
-- **内置引擎** —— 下载、管理和删除可选的 GeckoView(Firefox)运行时,用于 ECH / SNI 加密。显示下载大小和进度;沉重的原生产物在首次使用时获取。
+- **内置引擎** —— 下载、管理和删除可选的 GeckoView(Firefox)运行时。显示下载大小和进度;沉重的原生产物在首次使用时获取。
 - **更改 WebView 提供者** —— 切换系统 WebView 提供者(带开发者选项步骤指引)。
 - **引擎说明** —— Chrome、Edge、Brave、Firefox 和 Via 的参考信息。
 
 ## 说明
 
 - 各应用的引擎选择在[构建 APK](/zh/guide/app-actions/build-apk) 对话框中进行;本界面管理引擎本身。
-- GeckoView 是 [ECH](/zh/guide/config/network) 所必需的。
+- [ECH](/zh/guide/config/network) 在两种引擎上均可用;GeckoView 只是选项之一,并非必需。

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -149,6 +149,10 @@ android {
             // Host-preview-only user-mode exec loader; generated APKs
             // (targetSdk 28) always execve directly and never load it.
             excludes += "**/libstatic_exec.so"
+
+            // Cronet natives are injected into exported APKs by ApkBuilder when
+            // 强制 HTTP/3 is enabled; the template never carries them.
+            excludes += "**/libcronet*.so"
         }
     }
     androidResources {
@@ -452,6 +456,10 @@ dependencies {
     implementation("org.tukaani:xz:1.9")
 
     implementation("org.mozilla.geckoview:geckoview-arm64-v8a:142.0.20250827004350")
+
+    // Forced HTTP/3 upstream (see app/build.gradle.kts): classes only, natives are
+    // injected into exported APKs by ApkBuilder when 强制 HTTP/3 is enabled.
+    implementation("org.chromium.net:cronet-embedded:143.7445.0")
 
     implementation("androidx.browser:browser:1.8.0")
 

--- a/shell/proguard-rules.pro
+++ b/shell/proguard-rules.pro
@@ -296,3 +296,16 @@
 -keep class com.google.android.gms.** { *; }
 -dontwarn com.google.firebase.**
 -dontwarn com.google.android.gms.**
+
+# ============================================================
+# Cronet (forced HTTP/3 upstream)
+# ============================================================
+# Cronet's native code reaches its Java classes via JNI and ServiceLoader
+# (org.chromium.net.impl.** / org.chromium.base.**); R8 must not rename or
+# strip them. The AAR ships consumer rules, this is the belt-and-braces copy
+# for the shell template path.
+-keep class org.chromium.net.** { *; }
+-keep class org.chromium.base.** { *; }
+-keep class org.chromium.components.** { *; }
+-dontwarn org.chromium.**
+-keepdirectories META-INF/services/**


### PR DESCRIPTION
Closes #721 (see the issue comment for the request: forced h3 + domain fronting, referencing SniShaper/lumine-for-android).

## What this delivers

### 1. Forced HTTP/3 (QUIC) — per-app toggle in the TLS fingerprint card
- The TLS-MITM bridge gains a Cronet upstream leg: Chromium's own network stack re-issues every bridged request, QUIC-first. The outbound fingerprint **is** real Chromium, which is why the toggle lives inside the fingerprint-spoofing card instead of conflicting with it.
- Per-host QUIC hints (engine rebuild on new host, capped) make h3 available from the **very first request** instead of waiting for an Alt-Svc advertisement.
- The WebView side speaks plain HTTP/1.1 to the bridge; WebSocket/upgrade traffic falls back to the classic raw TLS relay. Requests are bounded (32 MB bodies); redirects are handed back to the WebView as 3xx responses per proxy semantics.
- `CronetDependencyManager` downloads `libcronet.143.0.7445.0.so` on demand (Aliyun Google-Maven mirror first — this feature's audience skews exactly where maven.google.com is unreachable; ~14 MB). Generated APKs embed the lib **only** when a Cronet-based feature is enabled (`cronetNeededForExport`), 16 KB-aligned, following the libnode/GeckoView precedents.

### 2. ECH on the system WebView engine (previously GeckoView-only)
- Reverse-engineering the Cronet 143 artifacts showed Chromium's `UseDnsHttpsSvcb` (HTTPS-record resolution, which carries ECHConfigs) is enabled by default with `EnforceSecureResponse` off — so the public `DnsOptions.builder().useBuiltInDnsResolver(true)` API is all that's needed: the built-in resolver queries type-65 records and Chromium encrypts the ClientHello SNI itself. No private APIs, no DoH configuration required.
- The DNS card's ECH toggle **no longer force-switches the engine to GeckoView**; both engines now support ECH. GeckoView keeps its TRR + ECH-pref path; the system engine rides the bridge's Cronet upstream.
- SOCKS upstream proxies take precedence over both features (Cronet cannot chain through SOCKS); the UI and export conditions mirror this.

### 3. Bugs found and fixed along the way (the existing fingerprint feature benefits too)
- **MITM leaf issuer DN mismatch (pre-existing):** leaves minted the issuer via `X500Name(String)`, which reorders RDNs vs the CA subject. `X500Principal.equals` is DER-exact on Android (lenient on the JVM — why the old unit test passed), so real devices rejected our own MITM certs with an SSL error dialog. The leaf issuer is now built from the CA subject's exact DER bytes, with a byte-level regression test.
- **CONNECT handshake deadlock:** the h3 path handshook before answering the CONNECT; clients that wait for the 200 before sending ClientHello stalled until their connect timeout. Now 200-first.
- **`ERR_CONTENT_DECODING_FAILED`:** Chromium transparently decodes response bodies but reports the original `Content-Encoding` header; relaying it made the WebView gunzip plain bytes. `content-encoding` is now stripped from the relayed head (bodies are re-framed as chunked anyway).

## Config chain (full passthrough)
`WebViewConfig.forceHttp3` → `ApkConfig` (`TlsFingerprintBlock.forceHttp3`) → `ApkConfigJsonFactory` → `ShellModeManager` (`@SerializedName("forceHttp3")`) → `ShellWebViewConfig` → `WebViewManager` → `TlsMitmBridge.Config.cronetActive`. `checkConfigFieldDrift` passes; boolean coverage / defaults-contract / i18n parity tests updated.

## Verification
- Full unit test suite green; `:shell:compileDebugKotlin` (CI parity) and the release template rebuild pass.
- Emulator end-to-end:
  - Force-h3: first request to quic.nginx.org served `proto=h3` (330 ms including engine rebuild with QUIC hint).
  - ECH (system engine, pure-ECH mode): DNS pcap shows the type-65 query and a 186-byte HTTPS answer; NetLog shows the ECHConfigList injected into the SSL socket; and a TLS pcap of the session shows **all outgoing ClientHellos carrying the outer SNI `cloudflare-ech.com` with zero real-hostname leakage**.
- Known Chromium behavior (not a bug, documented here): when Android's system-level Private DNS (DoT) is enabled, Chromium honors the system encrypted-DNS policy and skips plain type-65 queries, so ECH is silently inactive on such devices. CN-network resolvers were verified to faithfully return ECH-carrying HTTPS records.

## Docs
README / README_CN / docs site (EN + ZH) updated: ECH is now dual-engine, "Gecko only" badges and warnings removed.