### PR TITLE
fix(adblock): uBO :style() cosmetic support, poison-proof hide batches, list title metadata

### DIFF
--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlockFilterCache.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlockFilterCache.kt
@@ -15,7 +15,7 @@ object AdBlockFilterCache {
     private const val SOURCE_CONTENT_DIR = "source_content"
     private const val COMPILED_STATE_FILE = "compiled_state.bin"
     private const val CONTENT_HASH_FILE = "content_hash.txt"
-    private const val CACHE_VERSION = 2
+    private const val CACHE_VERSION = 3
     private const val URL_CACHE_TTL_MS = 24 * 60 * 60 * 1000L
 
     suspend fun getCachedUrlContent(context: Context, url: String): String? = withContext(Dispatchers.IO) {
@@ -321,14 +321,22 @@ object AdBlockFilterCache {
         out.writeBoolean(filter.isException)
         writeStringSet(out, filter.domains)
         writeStringSet(out, filter.excludedDomains)
+        out.writeBoolean(filter.styleOverride != null)
+        if (filter.styleOverride != null) out.writeUTF(filter.styleOverride)
     }
 
     private fun readCosmeticFilter(input: DataInputStream): AdBlocker.CosmeticFilter {
+        val selector = input.readUTF()
+        val isException = input.readBoolean()
+        val domains = readStringSet(input)
+        val excludedDomains = readStringSet(input)
+        val styleOverride = if (input.readBoolean()) input.readUTF() else null
         return AdBlocker.CosmeticFilter(
-            selector = input.readUTF(),
-            isException = input.readBoolean(),
-            domains = readStringSet(input),
-            excludedDomains = readStringSet(input)
+            selector = selector,
+            isException = isException,
+            domains = domains,
+            excludedDomains = excludedDomains,
+            styleOverride = styleOverride
         )
     }
 

--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
@@ -83,7 +83,9 @@ class AdBlocker {
         val domains: Set<String>,
         val excludedDomains: Set<String>,
 
-        val rawRule: String = ""
+        val rawRule: String = "",
+        /** Body of a uBO `:style(...)` pseudo: restyle matches instead of hiding them. */
+        val styleOverride: String? = null
     )
 
     companion object {
@@ -91,6 +93,29 @@ class AdBlocker {
         private val HOST_EXTRACT_REGEX = Regex("^(?:https?://)?([^/:]+)")
         private val WHITESPACE_REGEX = Regex("\\s+")
         private val ABP_SEPARATOR_REGEX = Regex("[^\\w%.\\-]")
+
+        private const val STYLE_PSEUDO = ":style("
+
+        /** uBO-only procedural pseudo-classes. They are not valid CSS and have no
+         *  DOM-equivalent here, so rules using them are dropped at parse time instead
+         *  of reaching the injected stylesheet, where one invalid selector would
+         *  invalidate the whole comma-joined batch it lands in (#823). */
+        private val PROCEDURAL_PSEUDO_CLASSES = listOf(
+            ":has-text(", ":not-text(", ":matches-css(", ":matches-css-before(", ":matches-css-after(",
+            ":matches-attr(", ":matches-media(", ":matches-path(", ":matches-prop(",
+            ":xpath(", ":remove(", ":remove-attr(", ":watch-attr(", ":watch-attrs(",
+            ":upward(", ":downward(", ":nth-ancestor(", ":min-text-length(",
+            ":others(", ":lcs(", ":lcss(", ":pattern("
+        )
+
+        private val LIST_TITLE_REGEX = Regex("(?i)^!\\s*Title\\s*:\\s*(.+)$")
+
+        /** Display title from an ABP/uBO list header (`! Title: ...`), if present. */
+        private fun extractListTitle(content: String): String? =
+            content.lineSequence().take(25)
+                .firstNotNullOfOrNull { LIST_TITLE_REGEX.matchEntire(it.trim())?.groupValues?.get(1)?.trim() }
+                ?.takeIf { it.isNotEmpty() }
+                ?.take(120)
 
         private val SAFELIST_HOSTS = setOf(
 
@@ -727,7 +752,7 @@ class AdBlocker {
     // counter keeps this correct without per-navigation rebuilds.
     @Volatile
     private var cosmeticVersion = 0
-    private data class CosmeticEntry(val version: Int, val css: String, val script: String)
+    private data class CosmeticEntry(val version: Int, val css: String, val script: String, val hideBatches: List<String>)
     private val cosmeticCache = object : LinkedHashMap<String, CosmeticEntry>(64, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, CosmeticEntry>?): Boolean = size > 128
     }
@@ -915,12 +940,23 @@ class AdBlocker {
             val hit = cosmeticCache[pageHost]
             if (hit != null && hit.version == v) return hit
         }
-        val entry = CosmeticEntry(v, buildCosmeticCss(pageHost), buildAntiAdblockScript(pageHost))
+        val (css, hideBatches) = buildCosmeticRules(pageHost)
+        val entry = CosmeticEntry(v, css, buildAntiAdblockScript(pageHost), hideBatches)
         synchronized(cosmeticCache) { cosmeticCache[pageHost] = entry }
         return entry
     }
 
-    private fun buildCosmeticCss(pageHost: String): String {
+    /**
+     * Comma-joined selector batches backing the hide rules of [getCosmeticFilterCss],
+     * one entry per generated CSS rule. The DOM observer queries per batch so a single
+     * invalid selector list cannot skip hiding for the remaining batches (#823).
+     */
+    fun getCosmeticHideBatches(pageHost: String): List<String> {
+        if (!enabled) return emptyList()
+        return cosmeticEntry(pageHost).hideBatches
+    }
+
+    private fun buildCosmeticRules(pageHost: String): Pair<String, List<String>> {
 
         val exceptionSelectors = cosmeticExceptionFilters
             .filter { matchesCosmeticDomain(it, pageHost) }
@@ -928,7 +964,7 @@ class AdBlocker {
             .toSet()
 
         val selectors = cosmeticBlockFilters
-            .filter { matchesCosmeticDomain(it, pageHost) && it.selector !in exceptionSelectors }
+            .filter { it.styleOverride == null && matchesCosmeticDomain(it, pageHost) && it.selector !in exceptionSelectors }
             .map { it.selector }
             .distinct()
             .toMutableList()
@@ -976,12 +1012,22 @@ class AdBlocker {
             }
         }
 
-        if (selectors.isEmpty()) return ""
+        // Style overrides ship as standalone rules: they restyle elements, and mixing
+        // them into a hide batch would hide what the list only wants recolored.
+        val styleRules = cosmeticBlockFilters
+            .filter { it.styleOverride != null && matchesCosmeticDomain(it, pageHost) && it.selector !in exceptionSelectors }
+            .map { "${it.selector} { ${it.styleOverride} }" }
 
         val batchSize = 50
-        return selectors.chunked(batchSize).joinToString("\n") { batch ->
-            batch.joinToString(",\n") + " { display: none !important; visibility: hidden !important; height: 0 !important; min-height: 0 !important; overflow: hidden !important; }"
-        }
+        val hideBatches = selectors.chunked(batchSize).map { it.joinToString(",\n") }
+        val css = buildString {
+            hideBatches.forEach { batch ->
+                append(batch)
+                append(" { display: none !important; visibility: hidden !important; height: 0 !important; min-height: 0 !important; overflow: hidden !important; }\n")
+            }
+            styleRules.forEach { append(it).append('\n') }
+        }.trimEnd()
+        return css to hideBatches
     }
 
     fun getAntiAdblockScript(pageHost: String): String {
@@ -1317,8 +1363,23 @@ class AdBlocker {
 
     private fun parseCosmeticFilter(rule: String, idx: Int, delimiter: String, isException: Boolean) {
         val domainPart = rule.substring(0, idx)
-        val selector = rule.substring(idx + delimiter.length).trim()
+        var selector = rule.substring(idx + delimiter.length).trim()
         if (selector.isEmpty()) return
+
+        // uBO style override (`##sel:style(decl)`): restyle matches instead of hiding
+        // them. The pseudo is not valid CSS, so it must never reach the stylesheet raw.
+        var styleOverride: String? = null
+        val styleIdx = selector.lastIndexOf(STYLE_PSEUDO)
+        if (styleIdx >= 0 && selector.endsWith(")")) {
+            val body = selector.substring(styleIdx + STYLE_PSEUDO.length, selector.length - 1)
+            selector = selector.substring(0, styleIdx).trim()
+            // Braces in the body would terminate the generated CSS rule early.
+            val normalizedBody = body.replace("{", "").replace("}", "").trim()
+            styleOverride = if (normalizedBody.endsWith(";")) normalizedBody else "$normalizedBody;"
+            if (selector.isEmpty() || styleOverride.isEmpty()) return
+        } else if (PROCEDURAL_PSEUDO_CLASSES.any { selector.contains(it) }) {
+            return
+        }
 
         val (domains, excludedDomains) = parseDomainList(domainPart)
 
@@ -1327,7 +1388,8 @@ class AdBlocker {
             isException = isException,
             domains = domains,
             excludedDomains = excludedDomains,
-            rawRule = rule
+            rawRule = rule,
+            styleOverride = styleOverride
         )
 
         if (isException) cosmeticExceptionFilters.add(filter)
@@ -1906,6 +1968,10 @@ class AdBlocker {
             sourceRuleCounts[url] = 0
             if (!displayName.isNullOrBlank()) {
                 customSourceNames[url] = displayName
+            } else {
+                // ABP metadata header beats the URL-derived fallback so custom
+                // subscriptions list under their real name (#823).
+                extractListTitle(content)?.let { customSourceNames[url] = it }
             }
             if (context != null) {
                 saveSourcesRegistry(context)

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -2384,6 +2384,17 @@ class WebViewManager(
                                         .replace("'", "\\'")
                                         .replace("\n", "\\n")
                                         .replace("\r", "")
+                                    // Hide-selector batches mirror the CSS hide rules one
+                                    // entry per rule; querying per batch keeps one invalid
+                                    // selector list from skipping the remaining batches.
+                                    val hideBatchesJs = adBlocker.getCosmeticHideBatches(pageHost)
+                                        .joinToString(",") { batch ->
+                                            "'" + batch
+                                                .replace("\\", "\\\\")
+                                                .replace("'", "\\'")
+                                                .replace("\n", "\\n")
+                                                .replace("\r", "") + "'"
+                                        }
                                     view.evaluateJavascript("""
                                         (function() {
                                             'use strict';
@@ -2397,11 +2408,21 @@ class WebViewManager(
                                                 (document.head || document.documentElement).appendChild(style);
                                             }
 
-                                            var selectors = '$escapedCss'.match(/([^{]+)\{/g);
-                                            if (selectors && selectors.length > 0) {
-                                                var selectorList = selectors.map(function(s) {
-                                                    return s.replace(/\s*\{${'$'}/, '').trim();
-                                                }).join(',');
+                                            var batches = [$hideBatchesJs];
+                                            if (batches.length > 0) {
+                                                var hideMatches = function() {
+                                                    for (var b = 0; b < batches.length; b++) {
+                                                        try {
+                                                            var els = document.querySelectorAll(batches[b]);
+                                                            for (var i = 0; i < els.length; i++) {
+                                                                if (els[i].style.display !== 'none') {
+                                                                    els[i].style.setProperty('display', 'none', 'important');
+                                                                    els[i].style.setProperty('visibility', 'hidden', 'important');
+                                                                }
+                                                            }
+                                                        } catch(e) { /* invalid selector list — skip this batch */ }
+                                                    }
+                                                };
 
                                                 var pending = false;
                                                 var observer = new MutationObserver(function() {
@@ -2409,15 +2430,7 @@ class WebViewManager(
                                                     pending = true;
                                                     (window.requestIdleCallback || setTimeout)(function() {
                                                         pending = false;
-                                                        try {
-                                                            var els = document.querySelectorAll(selectorList);
-                                                            for (var i = 0; i < els.length; i++) {
-                                                                if (els[i].style.display !== 'none') {
-                                                                    els[i].style.setProperty('display', 'none', 'important');
-                                                                    els[i].style.setProperty('visibility', 'hidden', 'important');
-                                                                }
-                                                            }
-                                                        } catch(e) { /* selector parse error — skip */ }
+                                                        hideMatches();
                                                     }, { timeout: 100 });
                                                 });
 

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockerCustomSourcesTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockerCustomSourcesTest.kt
@@ -99,6 +99,45 @@ class AdBlockerCustomSourcesTest {
     }
 
     @Test
+    fun `url import without display name falls back to the list title header`() = runBlocking {
+        val url = "https://raw.example.test/giant-filters.txt"
+        AdBlockFilterCache.cacheUrlContent(
+            context,
+            url,
+            "! Title: Giant Pharmacy\n! Description: Dark mode rules\n" +
+                "||ads.example.test^\nexample.com##.banner:style(background: #121212 !important)"
+        )
+
+        adBlocker.importHostsFromUrl(url, context)
+        adBlocker.saveHostsRules(context)
+
+        val custom = adBlocker.getCustomHostsSources()
+        assertThat(custom).hasSize(1)
+        assertThat(custom.first().name).isEqualTo("Giant Pharmacy")
+
+        val fresh = AdBlocker()
+        fresh.hydrateSourcesMetadata(context)
+        assertThat(fresh.getCustomHostsSources().first().name).isEqualTo("Giant Pharmacy")
+    }
+
+    @Test
+    fun `compiled state round-trips style overrides`() = runBlocking {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+        adBlocker.addRule("example.com##.banner:style(background: #121212 !important)")
+        adBlocker.addRule("example.com##.slot")
+        adBlocker.saveHostsRules(context)
+
+        val fresh = AdBlocker()
+        fresh.loadHostsRules(context)
+        fresh.setEnabled(true)
+
+        val css = fresh.getCosmeticFilterCss("example.com")
+        assertThat(css).contains(".banner { background: #121212 !important; }")
+        assertThat(fresh.getCosmeticHideBatches("example.com").any { it.contains(".slot") }).isTrue()
+    }
+
+    @Test
     fun `file source key is consumable through the per-app subscription path`() = runBlocking {
         val uri = Uri.parse("content://media/external/filters/block.txt")
         Shadows.shadowOf(context.contentResolver).registerInputStream(

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockerTest.kt
@@ -133,4 +133,63 @@ class AdBlockerTest {
         assertThat(adBlocker.shouldBlock("https://cdn.example.com/static/banner.js\$rev=2", resourceType = "script")).isTrue()
     }
 
+    @Test
+    fun `style override rules restyle matches and stay out of hide batches`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##.banner:style(background: #121212 !important)")
+        adBlocker.addRule("example.com##.slot")
+
+        val css = adBlocker.getCosmeticFilterCss("example.com")
+        assertThat(css).contains(".banner { background: #121212 !important; }")
+
+        val hideBatches = adBlocker.getCosmeticHideBatches("example.com")
+        assertThat(hideBatches.any { it.contains(".slot") }).isTrue()
+        assertThat(hideBatches.any { it.contains(".banner") }).isFalse()
+        assertThat(hideBatches.any { it.contains(":style(") }).isFalse()
+    }
+
+    @Test
+    fun `style override rules do not poison the hide batch of sibling selectors`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##.keep")
+        adBlocker.addRule("example.com##.recolor:style(color: #d5d5d5 !important)")
+
+        // The raw `:style(...)` selector used to share the comma-joined hide rule and
+        // invalidate the whole batch (#823); hide batches carry only plain selectors.
+        val hideBatch = adBlocker.getCosmeticHideBatches("example.com").first { it.contains(".keep") }
+        assertThat(hideBatch).doesNotContain(":style(")
+        assertThat(adBlocker.getCosmeticFilterCss("example.com"))
+            .contains(".recolor { color: #d5d5d5 !important; }")
+    }
+
+    @Test
+    fun `procedural pseudo-class rules are dropped instead of poisoning hide batches`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##.keep")
+        adBlocker.addRule("example.com##.drop:has-text(advert)")
+        adBlocker.addRule("example.com##.gone:remove()")
+
+        val css = adBlocker.getCosmeticFilterCss("example.com")
+        assertThat(css).doesNotContain(":has-text(")
+        assertThat(css).doesNotContain(":remove(")
+        assertThat(adBlocker.getCosmeticHideBatches("example.com").any { it.contains(".keep") }).isTrue()
+    }
+
+    @Test
+    fun `style override exception cancels the matching style rule`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##.banner:style(background: #121212 !important)")
+        adBlocker.addRule("example.com#@#.banner:style(background: #121212 !important)")
+
+        assertThat(adBlocker.getCosmeticFilterCss("example.com")).doesNotContain(".banner {")
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes #823 — custom filter lists written for uBlock Origin were silently inert, and custom subscriptions displayed as bare URLs instead of their titles.

### 1. `:style()` cosmetic rules had no effect (and killed every neighbouring rule)

Reported with [giant-filters.txt](https://raw.githubusercontent.com/lincomax/Filter-Lists/refs/heads/main/giant-filters.txt) on `giantweb.rxtouch.com`: dark-mode/cleanup rules and even manually added rules did nothing, while the same list worked in uBlock Origin / AdGuard.

Root cause chain:

1. `parseCosmeticFilter()` stored the selector verbatim, including the uBO-only `:style(...)` pseudo-class.
2. `buildCosmeticCss()` comma-joins up to 50 selectors into one CSS rule. Per CSS spec, one invalid selector in a selector list invalidates the entire rule — so every hide rule sharing a batch with a `:style()` rule was discarded by the browser. The reported list puts all 45 matching selectors in a single batch, i.e. zero cosmetic effect.
3. The injected `MutationObserver` script re-extracted selectors from the CSS text and ran a single `document.querySelectorAll(selectorList)` over all of them. `:style(...)` is not valid selector syntax → `SyntaxError` → the whole DOM-hide pass was skipped, which is why the user's valid manual rules also appeared dead.

The blast radius extended to the bundled **uBlock Filters** preset (92 `:style()` rules in uAssets `filters.txt`): any page matched by one of them lost all cosmetic filtering.

### 2. Subscription titles showed the URL host

`importHostsFromUrl()` never parsed the ABP `! Title:` metadata header and the manual URL-import path passes no display name, so `getCustomHostsSources()` fell back to `URI.host` — every custom list rendered as e.g. `raw.githubusercontent.com` in Hosts Blocking and in the editor subscription card.

## Changes

- `AdBlocker.kt`
  - `CosmeticFilter.styleOverride`: `##sel:style(decl)` is split into selector + normalized style body at parse time.
  - `buildCosmeticRules()` (was `buildCosmeticCss`): hide batches contain only plain selectors; style overrides are emitted as standalone `sel { decl; }` restyle rules (restyle, not hide).
  - New `getCosmeticHideBatches()` exposes the per-rule selector batches backing the hide CSS.
  - uBO-only procedural pseudo-classes (`:has-text(`, `:matches-css(`, `:xpath(`, `:remove(`, …) are dropped at parse time instead of poisoning batches.
  - `importHostsFromUrl()` falls back to the `! Title:` header (first 25 lines) when no display name is supplied; persisted through the existing sources registry, so Hosts Blocking and the editor card show real names.
- `WebViewManager.kt`: the DOCUMENT_END observer no longer re-parses CSS text; it receives the explicit hide batches and queries per batch with per-batch `try/catch`, so one invalid selector list cannot skip the remaining batches.
- `AdBlockFilterCache.kt`: serializes `styleOverride`; `CACHE_VERSION` 2 → 3 (stale caches invalidate automatically).

## Testing

- `AdBlockerTest`: +4 cases — `:style()` parses into restyle rules and stays out of hide batches; sibling hide selectors are no longer poisoned; procedural pseudo-classes are dropped; `#@#sel:style(...)` cancels the matching style rule.
- `AdBlockerCustomSourcesTest`: +2 cases — URL import without display name resolves `! Title:` (and survives restart via the registry); compiled state round-trips `styleOverride`.
- Locally: `:app:testStandardDebugUnitTest --tests "com.webtoapp.core.adblock.*"` 31/31 green, `AdBlockExportWiringTest` green, `:shell:assembleRelease` + `:app:syncShellTemplateApk` rebuilt the template and the new symbols are present in the template dex (adblock/webview runtime is shell-synced, so exported APKs pick the fix up with the next template build).

No config fields, i18n strings, or `WebViewConfig` booleans were added.

## Out of scope (follow-up candidates)

JS implementations of procedural selectors (`:has-text()` & friends), subscription auto-refresh honoring `! Expires:`, and AdGuard `#$#` CSS-injection syntax — analyzed separately; see issue thread.