### PR TITLE
feat(adblock): subscription auto-refresh honoring ! Expires: headers

### DIFF
--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
@@ -4,13 +4,19 @@ import android.content.Context
 import android.net.Uri
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.concurrent.atomic.AtomicBoolean
 
 class AdBlocker {
 
@@ -109,6 +115,27 @@ class AdBlocker {
         )
 
         private val LIST_TITLE_REGEX = Regex("(?i)^!\\s*Title\\s*:\\s*(.+)$")
+
+        private val EXPIRES_REGEX = Regex("(?i)^!\\s*Expires\\s*:\\s*(\\d+)\\s*(days?|hours?|d|h)\\b")
+
+        const val MIN_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000L
+        const val MAX_REFRESH_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000L
+        const val DEFAULT_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000L
+        private const val REFRESH_FAILURE_BACKOFF_MS = 60 * 60 * 1000L
+
+        /** Refresh interval from an ABP `! Expires: N days|hours` header, clamped so a
+         *  hostile or typo'd header cannot hot-loop or pin a subscription. */
+        fun expiresIntervalMs(content: String): Long =
+            content.lineSequence().take(25)
+                .firstNotNullOfOrNull { line ->
+                    EXPIRES_REGEX.matchEntire(line.trim())?.let { m ->
+                        val n = m.groupValues[1].toLongOrNull() ?: return@let null
+                        val hours = if (m.groupValues[2].lowercase().startsWith("d")) n * 24 else n
+                        hours * 60 * 60 * 1000L
+                    }
+                }
+                ?.coerceIn(MIN_REFRESH_INTERVAL_MS, MAX_REFRESH_INTERVAL_MS)
+                ?: DEFAULT_REFRESH_INTERVAL_MS
 
         /** Display title from an ABP/uBO list header (`! Title: ...`), if present. */
         private fun extractListTitle(content: String): String? =
@@ -720,6 +747,23 @@ class AdBlocker {
      *  sources resolve their names from [getPopularHostsSources] instead. */
     private val customSourceNames = mutableMapOf<String, String>()
 
+    /** Subscription freshness metadata (registry v3 columns): epoch ms of the last
+     *  successful download and the per-list refresh interval derived from `! Expires:`. */
+    private val sourceLastRefresh = mutableMapOf<String, Long>()
+    private val sourceIntervals = mutableMapOf<String, Long>()
+
+    /** In-memory failure backoff so a dead list URL is not re-fetched on every page load. */
+    private val sourceRefreshFailures = mutableMapOf<String, Long>()
+
+    private val engineMutex = Mutex()
+    private val refreshRunning = AtomicBoolean(false)
+    private val refreshScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Parameters of the last [prepareRuntimeFilters] call, so a background refresh can
+     *  rebuild the exact same rule universe after re-downloading due sources. */
+    private var lastPrepSelected: List<String> = emptyList()
+    private var lastPrepCustomRules: List<String> = emptyList()
+
     private val networkBlockFilters = mutableListOf<NetworkFilter>()
     private val networkExceptionFilters = mutableListOf<NetworkFilter>()
 
@@ -1189,29 +1233,126 @@ class AdBlocker {
         enabled: Boolean,
         customRules: List<String> = emptyList(),
         subscriptionUrls: List<String> = emptyList()
-    ) {
+    ) = engineMutex.withLock {
         if (!enabled) {
             setEnabled(false)
-            return
+            return@withLock
         }
         val selected = subscriptionUrls.map { it.trim() }.filter { it.isNotEmpty() }
+        lastPrepSelected = selected
+        lastPrepCustomRules = customRules
         if (selected.isEmpty()) {
             loadHostsRules(context)
             customRules.forEach { parseAndAddRule(it) }
             setEnabled(true)
-            return
+            kickSourceRefresh(context, refreshableKeys(selected))
+            return@withLock
         }
-        resetEngineRules()
-        for (sourceKey in selected) {
-            val content = loadSourceContent(context, sourceKey)
-            if (content != null) {
-                ingestFilterContent(sourceKey, content)
-            } else if (sourceKey.startsWith("http://") || sourceKey.startsWith("https://")) {
-                importHostsFromUrl(sourceKey, context)
+        reingestSelected(context, selected, customRules)
+        setEnabled(true)
+        kickSourceRefresh(context, refreshableKeys(selected))
+    }
+
+    /** http(s) sources eligible for background refresh: this app's subscriptions plus
+     *  whatever Hosts Blocking has enabled, since both feed the compiled rule set. */
+    private fun refreshableKeys(selected: List<String>): List<String> =
+        (selected + enabledHostsSources)
+            .filter { it.startsWith("http://") || it.startsWith("https://") }
+            .distinct()
+
+    private fun kickSourceRefresh(context: Context, keys: List<String>) {
+        if (keys.isEmpty() || !refreshRunning.compareAndSet(false, true)) return
+        refreshScope.launch {
+            try {
+                refreshDueSources(context, keys)
+            } catch (e: Exception) {
+                com.webtoapp.core.logging.AppLogger.e("AdBlocker", "Background subscription refresh failed", e)
+            } finally {
+                refreshRunning.set(false)
             }
         }
+    }
+
+    /**
+     * Re-downloads every source whose `! Expires:` interval has elapsed and rebuilds the
+     * engine from the fresh on-disk content. Fail-soft per source: a failed download
+     * backs off for an hour and keeps the previously ingested content. Safe to call from
+     * the background [kickSourceRefresh] coroutine — the rebuild phase takes the engine
+     * mutex so it never races a concurrent [prepareRuntimeFilters].
+     *
+     * @param forceNetwork bypass the 24h URL cache; tests pass false to serve updates
+     *   from the cache instead of the network.
+     * @return true when at least one source's content changed and the engine was rebuilt.
+     */
+    suspend fun refreshDueSources(
+        context: Context,
+        keys: List<String>,
+        forceNetwork: Boolean = true
+    ): Boolean = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        var changed = false
+        for (key in keys) {
+            val interval = sourceIntervals[key] ?: DEFAULT_REFRESH_INTERVAL_MS
+            val last = sourceLastRefresh[key] ?: 0L
+            if (now - last < interval) continue
+            val failedAt = sourceRefreshFailures[key]
+            if (failedAt != null && now - failedAt < REFRESH_FAILURE_BACKOFF_MS) continue
+
+            val before = loadSourceContent(context, key)
+            val result = importHostsFromUrl(key, context, forceNetwork = forceNetwork)
+            if (result.isSuccess) {
+                if (loadSourceContent(context, key) != before) changed = true
+            } else {
+                sourceRefreshFailures[key] = now
+                com.webtoapp.core.logging.AppLogger.w(
+                    "AdBlocker",
+                    "Subscription refresh failed for $key: ${result.exceptionOrNull()?.message}"
+                )
+            }
+        }
+        if (changed) {
+            engineMutex.withLock {
+                rebuildEngine(context)
+            }
+        }
+        changed
+    }
+
+    private suspend fun reingestSelected(context: Context, selected: List<String>, customRules: List<String>) {
+        resetEngineRules()
+        for (sourceKey in selected) {
+            ingestSourceKey(context, sourceKey)
+        }
         customRules.forEach { parseAndAddRule(it) }
-        setEnabled(true)
+        rebuildUnanchoredIndex()
+    }
+
+    /** Rebuild after a refresh: same rule universe as the last [prepareRuntimeFilters]. */
+    private suspend fun rebuildEngine(context: Context) {
+        resetEngineRules()
+        if (lastPrepSelected.isEmpty()) {
+            val legacy = File(context.filesDir, "adblock_hosts.txt")
+            if (legacy.exists()) hostsFileHosts.addAll(legacy.readLines().filter { it.isNotBlank() })
+            for (key in enabledHostsSources.toList()) {
+                ingestSourceKey(context, key)
+            }
+        } else {
+            for (key in lastPrepSelected) {
+                ingestSourceKey(context, key)
+            }
+        }
+        lastPrepCustomRules.forEach { parseAndAddRule(it) }
+        rebuildUnanchoredIndex()
+        saveCompiledStateToCache(context)
+    }
+
+    private suspend fun ingestSourceKey(context: Context, sourceKey: String) {
+        val content = loadSourceContent(context, sourceKey)
+        if (content != null) {
+            ingestFilterContent(sourceKey, content)
+        } else if (sourceKey.startsWith("http://") || sourceKey.startsWith("https://")) {
+            importHostsFromUrl(sourceKey, context)
+        }
     }
 
     suspend fun compileRulesText(
@@ -1892,12 +2033,13 @@ class AdBlocker {
         url: String,
         context: Context? = null,
         displayName: String? = null,
+        forceNetwork: Boolean = false,
         onProgress: ((DownloadProgress) -> Unit)? = null
     ): Result<Int> = withContext(Dispatchers.IO) {
         try {
 
             var content: String? = null
-            if (context != null) {
+            if (context != null && !forceNetwork) {
                 content = AdBlockFilterCache.getCachedUrlContent(context, url)
             }
 
@@ -1973,6 +2115,9 @@ class AdBlocker {
                 // subscriptions list under their real name (#823).
                 extractListTitle(content)?.let { customSourceNames[url] = it }
             }
+            sourceLastRefresh[url] = System.currentTimeMillis()
+            sourceIntervals[url] = expiresIntervalMs(content)
+            sourceRefreshFailures.remove(url)
             if (context != null) {
                 saveSourcesRegistry(context)
             }
@@ -2076,18 +2221,21 @@ class AdBlocker {
         }
     }
 
+    private fun registryLine(url: String, enabled: Boolean): String {
+        val count = sourceRuleCounts[url] ?: 0
+        val flag = if (enabled) 1 else 0
+        val name = customSourceNames[url] ?: ""
+        val lastRefresh = sourceLastRefresh[url] ?: 0
+        val interval = sourceIntervals[url] ?: 0
+        return "$url\t$count\t$flag\t$name\t$lastRefresh\t$interval"
+    }
+
     private fun saveSourcesRegistry(context: Context) {
         val sourcesFile = File(context.filesDir, "adblock_hosts_sources.txt")
         sourcesFile.writeText(
             buildString {
-                enabledHostsSources.forEach { url ->
-                    val count = sourceRuleCounts[url] ?: 0
-                    appendLine("$url\t$count\t1\t${customSourceNames[url] ?: ""}")
-                }
-                disabledHostsSources.forEach { url ->
-                    val count = sourceRuleCounts[url] ?: 0
-                    appendLine("$url\t$count\t0\t${customSourceNames[url] ?: ""}")
-                }
+                enabledHostsSources.forEach { url -> appendLine(registryLine(url, enabled = true)) }
+                disabledHostsSources.forEach { url -> appendLine(registryLine(url, enabled = false)) }
             }.trimEnd()
         )
     }
@@ -2146,6 +2294,9 @@ class AdBlocker {
                 sourceRuleCounts[url] = count
                 // Optional 4th column (registry v2): display name for custom sources.
                 parts.getOrNull(3)?.takeIf { it.isNotBlank() }?.let { customSourceNames[url] = it }
+                // Optional 5th/6th columns (registry v3): refresh timestamp and interval.
+                parts.getOrNull(4)?.toLongOrNull()?.let { sourceLastRefresh[url] = it }
+                parts.getOrNull(5)?.toLongOrNull()?.takeIf { it > 0 }?.let { sourceIntervals[url] = it }
             }
     }
 

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockSubscriptionRefreshTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockSubscriptionRefreshTest.kt
@@ -1,0 +1,124 @@
+package com.webtoapp.core.adblock
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Coverage for subscription auto-refresh: `! Expires:` headers drive a per-source
+ * refresh interval (clamped), due sources re-download and rebuild the engine,
+ * not-due sources are untouched, and failed downloads back off without losing
+ * the previously ingested content.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class AdBlockSubscriptionRefreshTest {
+
+    private lateinit var context: Context
+    private val url = "https://filters.example.test/refreshable.txt"
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        AdBlockFilterCache.clearCache(context)
+    }
+
+    @Test
+    fun `expires header parses into a clamped refresh interval`() {
+        assertThat(AdBlocker.expiresIntervalMs("! Title: X\n! Expires: 5 days\n||a.example^"))
+            .isEqualTo(5 * 24 * 60 * 60 * 1000L)
+        assertThat(AdBlocker.expiresIntervalMs("! Expires: 12 hours\n||a.example^"))
+            .isEqualTo(12 * 60 * 60 * 1000L)
+        // Clamped to the 6h floor and 14d ceiling.
+        assertThat(AdBlocker.expiresIntervalMs("! Expires: 1 hours\n||a.example^"))
+            .isEqualTo(AdBlocker.MIN_REFRESH_INTERVAL_MS)
+        assertThat(AdBlocker.expiresIntervalMs("! Expires: 30 days\n||a.example^"))
+            .isEqualTo(AdBlocker.MAX_REFRESH_INTERVAL_MS)
+        // Missing header falls back to 24h.
+        assertThat(AdBlocker.expiresIntervalMs("! Title: X\n||a.example^"))
+            .isEqualTo(AdBlocker.DEFAULT_REFRESH_INTERVAL_MS)
+    }
+
+    @Test
+    fun `due source re-downloads and rebuilds the engine`() = runBlocking {
+        val v1 = "! Expires: 1 days\n||ads.example.test^"
+        AdBlockFilterCache.cacheUrlContent(context, url, v1)
+        val importer = AdBlocker()
+        assertThat(importer.importHostsFromUrl(url, context).isSuccess).isTrue()
+        importer.saveHostsRules(context)
+
+        // Age the registry timestamp past the 1 day interval.
+        val registry = File(context.filesDir, "adblock_hosts_sources.txt")
+        registry.writeText("$url\t1\t1\t\t${System.currentTimeMillis() - 2 * 86400000L}\t86400000")
+
+        val fresh = AdBlocker()
+        fresh.loadHostsRules(context)
+        fresh.setEnabled(true)
+        assertThat(fresh.shouldBlock("https://ads.example.test/banner.js", resourceType = "script")).isTrue()
+
+        // Updated list content arrives through the URL cache (forceNetwork = false).
+        val v2 = "! Expires: 1 days\n||newads.example.test^"
+        AdBlockFilterCache.cacheUrlContent(context, url, v2)
+
+        val changed = fresh.refreshDueSources(context, listOf(url), forceNetwork = false)
+
+        assertThat(changed).isTrue()
+        assertThat(fresh.shouldBlock("https://newads.example.test/banner.js", resourceType = "script")).isTrue()
+        assertThat(fresh.shouldBlock("https://ads.example.test/banner.js", resourceType = "script")).isFalse()
+    }
+
+    @Test
+    fun `not-due source keeps its ingested content`() = runBlocking {
+        val v1 = "! Expires: 1 days\n||ads.example.test^"
+        AdBlockFilterCache.cacheUrlContent(context, url, v1)
+        val importer = AdBlocker()
+        importer.importHostsFromUrl(url, context)
+        importer.saveHostsRules(context)
+
+        val fresh = AdBlocker()
+        fresh.loadHostsRules(context)
+        fresh.setEnabled(true)
+
+        // Fresh import timestamp: interval not elapsed, so the newer cached copy must
+        // NOT be picked up.
+        AdBlockFilterCache.cacheUrlContent(context, url, "! Expires: 1 days\n||newads.example.test^")
+
+        val changed = fresh.refreshDueSources(context, listOf(url), forceNetwork = false)
+
+        assertThat(changed).isFalse()
+        assertThat(fresh.shouldBlock("https://ads.example.test/banner.js", resourceType = "script")).isTrue()
+        assertThat(fresh.shouldBlock("https://newads.example.test/banner.js", resourceType = "script")).isFalse()
+    }
+
+    @Test
+    fun `failed download backs off and keeps previous content`() = runBlocking {
+        val v1 = "! Expires: 1 days\n||ads.example.test^"
+        AdBlockFilterCache.cacheUrlContent(context, url, v1)
+        val importer = AdBlocker()
+        importer.importHostsFromUrl(url, context)
+        importer.saveHostsRules(context)
+
+        val registry = File(context.filesDir, "adblock_hosts_sources.txt")
+        registry.writeText("$url\t1\t1\t\t${System.currentTimeMillis() - 2 * 86400000L}\t86400000")
+
+        val fresh = AdBlocker()
+        fresh.loadHostsRules(context)
+        fresh.setEnabled(true)
+
+        // No cached update and no network in Robolectric: the download fails.
+        val changed = fresh.refreshDueSources(context, listOf(url), forceNetwork = true)
+
+        assertThat(changed).isFalse()
+        assertThat(fresh.shouldBlock("https://ads.example.test/banner.js", resourceType = "script")).isTrue()
+
+        // Second call within the backoff window skips the source without retrying.
+        assertThat(fresh.refreshDueSources(context, listOf(url), forceNetwork = true)).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #833 (issue #823 analysis): subscriptions were frozen at import-time content **forever**. `loadSourceContent()` prefers the import-time `source_content` copy (no TTL) over the 24h URL cache, and nothing re-downloaded a list unless the user hit Retry manually. Lists declare `! Expires:` (4–5 days for the bundled presets, 1 day for the list in #823), but the header was never read — blocked ads and trackers silently return as lists age.

## Changes (`AdBlocker.kt` only)

- **`! Expires:` parsing**: `expiresIntervalMs()` reads the ABP header at import into a per-source refresh interval, clamped to 6h–14d (default 24h) so a hostile or typo'd header cannot hot-loop or pin a subscription.
- **Registry v3**: two new tolerantly-parsed columns — last successful refresh epoch and interval — persisted through the existing `saveSourcesRegistry` / hydration path.
- **Background refresh**: `prepareRuntimeFilters()` (the single hook used by host preview *and* exported-APK runtime) kicks a single-flight IO-scope refresh of due http(s) sources: the app's subscriptions plus Hosts-Blocking-enabled ones, since both feed the compiled rule set. Downloads bypass the 24h URL cache (`forceNetwork`); failures back off for one hour and keep the previously ingested content.
- **Rebuild**: when any content changed, the engine is rebuilt under a new `engineMutex` from fresh on-disk content for the exact rule universe of the last `prepareRuntimeFilters` call (subscriptions or Hosts-enabled sources + manual rules), then the compiled state is re-saved so the `loadHostsRules` path sees fresh rules too. The mutex also serializes refresh rebuilds against concurrent prepares.
- **Latent fix**: the subscription ingest path never called `rebuildUnanchoredIndex()`, so unanchored network rules from lists (e.g. `/banner\.js$/`, `*tracker*`) were silently skipped after `prepareRuntimeFilters`; the shared re-ingest path now rebuilds it.

## Testing

- New `AdBlockSubscriptionRefreshTest` (Robolectric): interval parsing + clamping (5 days, 12 hours, 1 hour → 6h floor, 30 days → 14d ceiling, missing → 24h); a due source re-downloads (via cache with `forceNetwork = false`) and the rebuilt engine blocks the new list's domains while dropping the old ones; a not-due source ignores newer cached content; a failed download (no network in Robolectric) backs off and keeps previous rules.
- Full adblock suite: 35/35 green locally.

No config fields, i18n strings, or UI changes. Shell-synced (`core/adblock`), so exported APKs pick the refresh up with the next template build.