### PR TITLE
feat(adblock): AdGuard #$# CSS injection, #?# extended hiding, scriptlet routing fix

### DIFF
--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlockFilterCache.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlockFilterCache.kt
@@ -15,7 +15,7 @@ object AdBlockFilterCache {
     private const val SOURCE_CONTENT_DIR = "source_content"
     private const val COMPILED_STATE_FILE = "compiled_state.bin"
     private const val CONTENT_HASH_FILE = "content_hash.txt"
-    private const val CACHE_VERSION = 3
+    private const val CACHE_VERSION = 4
     private const val URL_CACHE_TTL_MS = 24 * 60 * 60 * 1000L
 
     suspend fun getCachedUrlContent(context: Context, url: String): String? = withContext(Dispatchers.IO) {
@@ -323,6 +323,8 @@ object AdBlockFilterCache {
         writeStringSet(out, filter.excludedDomains)
         out.writeBoolean(filter.styleOverride != null)
         if (filter.styleOverride != null) out.writeUTF(filter.styleOverride)
+        out.writeBoolean(filter.injectedCss != null)
+        if (filter.injectedCss != null) out.writeUTF(filter.injectedCss)
     }
 
     private fun readCosmeticFilter(input: DataInputStream): AdBlocker.CosmeticFilter {
@@ -331,12 +333,14 @@ object AdBlockFilterCache {
         val domains = readStringSet(input)
         val excludedDomains = readStringSet(input)
         val styleOverride = if (input.readBoolean()) input.readUTF() else null
+        val injectedCss = if (input.readBoolean()) input.readUTF() else null
         return AdBlocker.CosmeticFilter(
             selector = selector,
             isException = isException,
             domains = domains,
             excludedDomains = excludedDomains,
-            styleOverride = styleOverride
+            styleOverride = styleOverride,
+            injectedCss = injectedCss
         )
     }
 

--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
@@ -91,7 +91,9 @@ class AdBlocker {
 
         val rawRule: String = "",
         /** Body of a uBO `:style(...)` pseudo: restyle matches instead of hiding them. */
-        val styleOverride: String? = null
+        val styleOverride: String? = null,
+        /** AdGuard `#$#` payload: a complete CSS rule injected for the anchor domains. */
+        val injectedCss: String? = null
     )
 
     companion object {
@@ -1062,6 +1064,15 @@ class AdBlocker {
             .filter { it.styleOverride != null && matchesCosmeticDomain(it, pageHost) && it.selector !in exceptionSelectors }
             .map { "${it.selector} { ${it.styleOverride} }" }
 
+        // AdGuard `#$#` payloads are complete CSS rules of their own.
+        val exceptionCss = cosmeticExceptionFilters
+            .filter { matchesCosmeticDomain(it, pageHost) }
+            .mapNotNull { it.injectedCss }
+            .toSet()
+        val injectedRules = cosmeticBlockFilters
+            .filter { it.injectedCss != null && matchesCosmeticDomain(it, pageHost) && it.injectedCss !in exceptionCss }
+            .map { it.injectedCss!! }
+
         val batchSize = 50
         val hideBatches = selectors.chunked(batchSize).map { it.joinToString(",\n") }
         val css = buildString {
@@ -1070,6 +1081,7 @@ class AdBlocker {
                 append(" { display: none !important; visibility: hidden !important; height: 0 !important; min-height: 0 !important; overflow: hidden !important; }\n")
             }
             styleRules.forEach { append(it).append('\n') }
+            injectedRules.forEach { append(it).append('\n') }
         }.trimEnd()
         return css to hideBatches
     }
@@ -1473,33 +1485,43 @@ class AdBlocker {
         return decoded.ifBlank { null }
     }
 
+    /** Cosmetic / injection delimiters, longest first so `#@?#` wins over `#@`-prefixed
+     *  shorter matches when scanning. */
+    private val RULE_DELIMITERS = listOf("#@$#", "#$#", "#@?#", "#?#", "#@#", "##")
+
     private fun parseAndAddRule(rawRule: String) {
         val rule = rawRule.trim()
         if (rule.isEmpty() || rule.startsWith("!") || rule.startsWith("[")) return
 
-        val cosmeticExIdx = rule.indexOf("#@#")
-        val cosmeticIdx = if (cosmeticExIdx < 0) rule.indexOf("##") else -1
-
-        if (cosmeticExIdx >= 0) {
-            parseCosmeticFilter(rule, cosmeticExIdx, "#@#", isException = true)
-            return
-        }
-        if (cosmeticIdx >= 0 && !rule.startsWith("||")) {
-            parseCosmeticFilter(rule, cosmeticIdx, "##", isException = false)
-            return
-        }
-
-        if (rule.contains("#%#//scriptlet(")) {
+        // Scriptlets first: `##+js(...)` and `#%#//scriptlet(...)` also contain cosmetic
+        // delimiters, and parsing them as selectors yielded invalid CSS that poisoned
+        // hide batches while the scriptlet parsers below were unreachable dead code.
+        if (rule.contains("##+js(") || rule.contains("#%#//scriptlet(")) {
             parseScriptletRule(rule)
             return
         }
+        // Scriptlet exceptions are unsupported; drop them instead of letting the
+        // `+js(...)` payload reach the stylesheet as an invalid selector.
+        if (rule.contains("#@#+js(") || rule.contains("#@#//scriptlet(")) return
 
-        if (rule.contains("##+js(")) {
-            parseScriptletRule(rule)
+        if (rule.startsWith("||")) {
+            parseNetworkFilter(rule)
             return
         }
 
-        parseNetworkFilter(rule)
+        val (idx, delim) = RULE_DELIMITERS
+            .map { d -> rule.indexOf(d) to d }
+            .filter { it.first >= 0 }
+            .minByOrNull { it.first }
+            ?: run {
+                parseNetworkFilter(rule)
+                return
+            }
+
+        when (delim) {
+            "#$#", "#@$#" -> parseCssInjection(rule, idx, delim, isException = delim == "#@$#")
+            else -> parseCosmeticFilter(rule, idx, delim, isException = delim.startsWith("#@"))
+        }
     }
 
     private fun parseCosmeticFilter(rule: String, idx: Int, delimiter: String, isException: Boolean) {
@@ -1531,6 +1553,27 @@ class AdBlocker {
             excludedDomains = excludedDomains,
             rawRule = rule,
             styleOverride = styleOverride
+        )
+
+        if (isException) cosmeticExceptionFilters.add(filter)
+        else cosmeticBlockFilters.add(filter)
+    }
+
+    /** AdGuard CSS-injection rule (`domain#$#rule`, cancelled by `domain#@$#rule`). */
+    private fun parseCssInjection(rule: String, idx: Int, delimiter: String, isException: Boolean) {
+        val domainPart = rule.substring(0, idx)
+        val css = rule.substring(idx + delimiter.length).trim()
+        if (css.isEmpty() || !css.contains("{") || !css.contains("}")) return
+
+        val (domains, excludedDomains) = parseDomainList(domainPart)
+
+        val filter = CosmeticFilter(
+            selector = "",
+            isException = isException,
+            domains = domains,
+            excludedDomains = excludedDomains,
+            rawRule = rule,
+            injectedCss = css
         )
 
         if (isException) cosmeticExceptionFilters.add(filter)

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockerCustomSourcesTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockerCustomSourcesTest.kt
@@ -138,6 +138,21 @@ class AdBlockerCustomSourcesTest {
     }
 
     @Test
+    fun `compiled state round-trips injected css rules`() = runBlocking {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+        adBlocker.addRule("example.com#$#body { background: #121212 !important; }")
+        adBlocker.saveHostsRules(context)
+
+        val fresh = AdBlocker()
+        fresh.loadHostsRules(context)
+        fresh.setEnabled(true)
+
+        assertThat(fresh.getCosmeticFilterCss("example.com"))
+            .contains("body { background: #121212 !important; }")
+    }
+
+    @Test
     fun `file source key is consumable through the per-app subscription path`() = runBlocking {
         val uri = Uri.parse("content://media/external/filters/block.txt")
         Shadows.shadowOf(context.contentResolver).registerInputStream(

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockerTest.kt
@@ -192,4 +192,51 @@ class AdBlockerTest {
         assertThat(adBlocker.getCosmeticFilterCss("example.com")).doesNotContain(".banner {")
     }
 
+    @Test
+    fun `adguard css injection rules are emitted verbatim for anchor domains`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com#$#body { background: #121212 !important; }")
+
+        val css = adBlocker.getCosmeticFilterCss("example.com")
+        assertThat(css).contains("body { background: #121212 !important; }")
+        // Injected rules restyle via their own CSS; they are not hide selectors.
+        assertThat(adBlocker.getCosmeticHideBatches("example.com").any { it.contains("body") }).isFalse()
+        assertThat(adBlocker.getCosmeticFilterCss("other.com")).doesNotContain("#121212")
+    }
+
+    @Test
+    fun `css injection exception cancels the matching injected rule`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com#$#body { background: #121212 !important; }")
+        adBlocker.addRule("example.com#@$#body { background: #121212 !important; }")
+
+        assertThat(adBlocker.getCosmeticFilterCss("example.com")).doesNotContain("#121212")
+    }
+
+    @Test
+    fun `extended hiding delimiter parses like element hiding`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com#?#.promo")
+
+        assertThat(adBlocker.getCosmeticHideBatches("example.com").any { it.contains(".promo") }).isTrue()
+    }
+
+    @Test
+    fun `scriptlet rules are parsed as scriptlets not cosmetic selectors`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##+js(set-constant, adsEnabled, false)")
+
+        // The `+js(...)` payload must never reach the stylesheet as a selector.
+        assertThat(adBlocker.getCosmeticFilterCss("example.com")).doesNotContain("+js(")
+        assertThat(adBlocker.getAntiAdblockScript("example.com")).isNotEmpty()
+    }
+
 }


### PR DESCRIPTION
## Summary

Second follow-up to the #823 analysis (#833, #834): extended filter-list syntax was silently misparsed into dead network rules, and one routing bug kept the entire scriptlet engine unreachable.

## Bugs

1. **`domain#$#css`** (AdGuard CSS injection — 10 rules in the bundled AdGuard Base preset, common in AdGuard-native lists) and **`domain#?#selector`** (extended element hiding — 287 rules in EasyList) contain neither `##` nor `#@#`, so `parseAndAddRule()` fell through to the network-filter parser: the rules compiled to URL patterns that never match. Silent no-ops.
2. **`##+js(...)` scriptlets were dead code.** The `##` cosmetic branch matched first (the delimiter is a substring of `##+js(`), so the `+js(...)` payload became a cosmetic selector — invalid CSS — and `parseScriptletRule()`/`generateScriptlet()` were unreachable. Hundreds of uAssets scriptlets (set-constant, abort-on-property-read, …) never executed in preview or exported APKs.

## Changes (`AdBlocker.kt`, `AdBlockFilterCache.kt`)

- Rule routing is now a single ordered delimiter scan — `#@$#`, `#$#`, `#@?#`, `#?#`, `#@#`, `##`, earliest match wins — with scriptlet forms (`##+js(`, `#%#//scriptlet(`) checked first and `||`-anchored rules short-circuited to the network parser.
- `#$#` payloads parse into `CosmeticFilter.injectedCss` and are emitted **verbatim** into the per-host stylesheet (they are complete CSS rules); `#@$#` cancels the matching injection. Not part of hide batches.
- `#?#` / `#@?#` route through the existing cosmetic path, so procedural pseudo-classes inside them remain poison-proof (and ready for the procedural-selector engine planned next).
- Unsupported scriptlet exceptions (`#@#+js(`) are dropped instead of poisoning hide batches.
- Compiled filter cache serializes `injectedCss`; `CACHE_VERSION` 3 → 4.

## Testing

- `AdBlockerTest`: +4 — injection emitted verbatim and domain-scoped (absent on other hosts), injection exception cancels, `#?#` parses into hide batches, `##+js(set-constant, …)` yields anti-adblock scriptlet JS and never CSS selectors.
- `AdBlockerCustomSourcesTest`: +1 — compiled-state round-trip of injected rules.
- Full adblock suite 40/40 green locally.

No config fields, i18n strings, or UI changes. Shell-synced, so exported APKs pick this up with the next template build.