### PR TITLE
feat(adblock): procedural cosmetic selectors (:has-text, :upward, :remove) in page JS

### DIFF
--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlockFilterCache.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlockFilterCache.kt
@@ -15,7 +15,7 @@ object AdBlockFilterCache {
     private const val SOURCE_CONTENT_DIR = "source_content"
     private const val COMPILED_STATE_FILE = "compiled_state.bin"
     private const val CONTENT_HASH_FILE = "content_hash.txt"
-    private const val CACHE_VERSION = 4
+    private const val CACHE_VERSION = 5
     private const val URL_CACHE_TTL_MS = 24 * 60 * 60 * 1000L
 
     suspend fun getCachedUrlContent(context: Context, url: String): String? = withContext(Dispatchers.IO) {
@@ -325,6 +325,10 @@ object AdBlockFilterCache {
         if (filter.styleOverride != null) out.writeUTF(filter.styleOverride)
         out.writeBoolean(filter.injectedCss != null)
         if (filter.injectedCss != null) out.writeUTF(filter.injectedCss)
+        out.writeBoolean(filter.proceduralOps != null)
+        if (filter.proceduralOps != null) writeStringSet(out, filter.proceduralOps.toSet())
+        out.writeBoolean(filter.proceduralRaw != null)
+        if (filter.proceduralRaw != null) out.writeUTF(filter.proceduralRaw)
     }
 
     private fun readCosmeticFilter(input: DataInputStream): AdBlocker.CosmeticFilter {
@@ -334,13 +338,18 @@ object AdBlockFilterCache {
         val excludedDomains = readStringSet(input)
         val styleOverride = if (input.readBoolean()) input.readUTF() else null
         val injectedCss = if (input.readBoolean()) input.readUTF() else null
+        // Ops order matters (the chain applies left to right); readStringSet keeps it.
+        val proceduralOps = if (input.readBoolean()) readStringSet(input).toList() else null
+        val proceduralRaw = if (input.readBoolean()) input.readUTF() else null
         return AdBlocker.CosmeticFilter(
             selector = selector,
             isException = isException,
             domains = domains,
             excludedDomains = excludedDomains,
             styleOverride = styleOverride,
-            injectedCss = injectedCss
+            injectedCss = injectedCss,
+            proceduralOps = proceduralOps,
+            proceduralRaw = proceduralRaw
         )
     }
 

--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
@@ -93,7 +93,12 @@ class AdBlocker {
         /** Body of a uBO `:style(...)` pseudo: restyle matches instead of hiding them. */
         val styleOverride: String? = null,
         /** AdGuard `#$#` payload: a complete CSS rule injected for the anchor domains. */
-        val injectedCss: String? = null
+        val injectedCss: String? = null,
+        /** Procedural pseudo-class chain (`t:text`, `u:arg`, `r`) evaluated in page JS;
+         *  [selector] then holds only the plain-CSS base part. */
+        val proceduralOps: List<String>? = null,
+        /** Full selector text including procedural pseudos, for exception matching. */
+        val proceduralRaw: String? = null
     )
 
     companion object {
@@ -798,7 +803,13 @@ class AdBlocker {
     // counter keeps this correct without per-navigation rebuilds.
     @Volatile
     private var cosmeticVersion = 0
-    private data class CosmeticEntry(val version: Int, val css: String, val script: String, val hideBatches: List<String>)
+    private data class CosmeticEntry(
+        val version: Int,
+        val css: String,
+        val script: String,
+        val hideBatches: List<String>,
+        val proceduralJs: String
+    )
     private val cosmeticCache = object : LinkedHashMap<String, CosmeticEntry>(64, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, CosmeticEntry>?): Boolean = size > 128
     }
@@ -987,10 +998,44 @@ class AdBlocker {
             if (hit != null && hit.version == v) return hit
         }
         val (css, hideBatches) = buildCosmeticRules(pageHost)
-        val entry = CosmeticEntry(v, css, buildAntiAdblockScript(pageHost), hideBatches)
+        val entry = CosmeticEntry(v, css, buildAntiAdblockScript(pageHost), hideBatches, buildProceduralJs(pageHost))
         synchronized(cosmeticCache) { cosmeticCache[pageHost] = entry }
         return entry
     }
+
+    /**
+     * Page-side JS literal for procedural cosmetic rules (`:has-text()`, `:upward()`,
+     * `:remove()`): `[{"b":baseSelector,"o":["t:text","u:2","r"],"a":removeFlag}]`,
+     * evaluated by the observer script injected in WebViewManager.
+     */
+    fun getCosmeticProceduralRulesJs(pageHost: String): String {
+        if (!enabled) return "[]"
+        return cosmeticEntry(pageHost).proceduralJs
+    }
+
+    private fun buildProceduralJs(pageHost: String): String {
+        val exceptionRaws = cosmeticExceptionFilters
+            .filter { matchesCosmeticDomain(it, pageHost) }
+            .mapNotNull { it.proceduralRaw }
+            .toSet()
+        val rules = cosmeticBlockFilters.filter {
+            it.proceduralOps != null && matchesCosmeticDomain(it, pageHost) && it.proceduralRaw !in exceptionRaws
+        }
+        if (rules.isEmpty()) return "[]"
+        return rules.joinToString(",", "[", "]") { f ->
+            val ops = f.proceduralOps.orEmpty()
+            val remove = if (ops.any { it == "r" }) 1 else 0
+            """{"b":${jsonString(f.selector)},"o":[${ops.joinToString(",") { jsonString(it) }}],"a":$remove}"""
+        }
+    }
+
+    private fun jsonString(value: String): String =
+        '"' + value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t") + '"'
 
     /**
      * Comma-joined selector batches backing the hide rules of [getCosmeticFilterCss],
@@ -1004,13 +1049,18 @@ class AdBlocker {
 
     private fun buildCosmeticRules(pageHost: String): Pair<String, List<String>> {
 
+        // Procedural exceptions cancel by full raw selector (see buildProceduralJs),
+        // not by base selector, so they must not leak into the plain-hide exception set.
         val exceptionSelectors = cosmeticExceptionFilters
-            .filter { matchesCosmeticDomain(it, pageHost) }
+            .filter { it.proceduralOps == null && matchesCosmeticDomain(it, pageHost) }
             .map { it.selector }
             .toSet()
 
         val selectors = cosmeticBlockFilters
-            .filter { it.styleOverride == null && matchesCosmeticDomain(it, pageHost) && it.selector !in exceptionSelectors }
+            .filter {
+                it.styleOverride == null && it.proceduralOps == null &&
+                    matchesCosmeticDomain(it, pageHost) && it.selector !in exceptionSelectors
+            }
             .map { it.selector }
             .distinct()
             .toMutableList()
@@ -1540,7 +1590,20 @@ class AdBlocker {
             val normalizedBody = body.replace("{", "").replace("}", "").trim()
             styleOverride = if (normalizedBody.endsWith(";")) normalizedBody else "$normalizedBody;"
             if (selector.isEmpty() || styleOverride.isEmpty()) return
-        } else if (PROCEDURAL_PSEUDO_CLASSES.any { selector.contains(it) }) {
+        }
+
+        var proceduralOps: List<String>? = null
+        var proceduralRaw: String? = null
+        val proc = parseProceduralSelector(selector)
+        if (proc != null) {
+            proceduralOps = proc.ops
+            proceduralRaw = selector
+            selector = proc.base
+        } else if (PROCEDURAL_PSEUDO_CLASSES.any { selector.contains(it) } ||
+            SUPPORTED_PROCEDURAL_PSEUDOS.any { selector.contains(it) }
+        ) {
+            // Unsupported or nested procedural syntax is not valid CSS; ingesting it
+            // raw would invalidate the whole comma-joined batch it lands in (#823).
             return
         }
 
@@ -1552,11 +1615,73 @@ class AdBlocker {
             domains = domains,
             excludedDomains = excludedDomains,
             rawRule = rule,
-            styleOverride = styleOverride
+            styleOverride = styleOverride,
+            proceduralOps = proceduralOps,
+            proceduralRaw = proceduralRaw
         )
 
         if (isException) cosmeticExceptionFilters.add(filter)
         else cosmeticBlockFilters.add(filter)
+    }
+
+    /** Procedural pseudo-classes implemented by the page-side observer script. */
+    private val SUPPORTED_PROCEDURAL_PSEUDOS = listOf(":has-text(", ":upward(", ":remove(")
+
+    private data class ProceduralParse(val base: String, val ops: List<String>)
+
+    /**
+     * Splits a selector into its plain-CSS base and a chain of top-level procedural
+     * pseudo-classes (`:has-text()`, `:upward()`, `:remove()`), encoded as `t:text`,
+     * `u:arg` and `r` ops. Returns null — i.e. "drop the rule" — when the syntax is
+     * unsupported: pseudos nested inside another pseudo (e.g. `:has(span:has-text(x))`),
+     * text between pseudos, unbalanced parens, or an empty base selector.
+     */
+    private fun parseProceduralSelector(selector: String): ProceduralParse? {
+        var depth = 0
+        var nested = false
+        val tops = mutableListOf<Pair<Int, String>>()
+        for (i in selector.indices) {
+            when {
+                selector[i] == '(' -> depth++
+                selector[i] == ')' -> depth--
+                else -> SUPPORTED_PROCEDURAL_PSEUDOS.firstOrNull { selector.startsWith(it, i) }?.let { name ->
+                    if (depth == 0) tops.add(i to name) else nested = true
+                }
+            }
+        }
+        if (nested || tops.isEmpty()) return null
+
+        val base = selector.substring(0, tops.first().first).trim()
+        if (base.isEmpty()) return null
+
+        val ops = mutableListOf<String>()
+        var cursor = tops.first().first
+        for ((idx, name) in tops) {
+            if (idx != cursor) return null
+            val open = idx + name.length - 1
+            var d = 0
+            var j = open
+            while (j < selector.length) {
+                if (selector[j] == '(') d++
+                else if (selector[j] == ')') {
+                    d--
+                    if (d == 0) break
+                }
+                j++
+            }
+            if (j >= selector.length) return null
+            val arg = selector.substring(open + 1, j).trim()
+            ops.add(
+                when (name) {
+                    ":has-text(" -> "t:$arg"
+                    ":upward(" -> "u:$arg"
+                    else -> "r"
+                }
+            )
+            cursor = j + 1
+        }
+        if (cursor != selector.length) return null
+        return ProceduralParse(base, ops)
     }
 
     /** AdGuard CSS-injection rule (`domain#$#rule`, cancelled by `domain#@$#rule`). */

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -2395,6 +2395,8 @@ class WebViewManager(
                                                 .replace("\n", "\\n")
                                                 .replace("\r", "") + "'"
                                         }
+                                    // Already a JS literal (JSON-escaped in AdBlocker).
+                                    val procJs = adBlocker.getCosmeticProceduralRulesJs(pageHost)
                                     view.evaluateJavascript("""
                                         (function() {
                                             'use strict';
@@ -2409,21 +2411,69 @@ class WebViewManager(
                                             }
 
                                             var batches = [$hideBatchesJs];
-                                            if (batches.length > 0) {
-                                                var hideMatches = function() {
-                                                    for (var b = 0; b < batches.length; b++) {
-                                                        try {
-                                                            var els = document.querySelectorAll(batches[b]);
-                                                            for (var i = 0; i < els.length; i++) {
-                                                                if (els[i].style.display !== 'none') {
-                                                                    els[i].style.setProperty('display', 'none', 'important');
-                                                                    els[i].style.setProperty('visibility', 'hidden', 'important');
+                                            var procRules = $procJs;
+
+                                            var hideMatches = function() {
+                                                for (var b = 0; b < batches.length; b++) {
+                                                    try {
+                                                        var els = document.querySelectorAll(batches[b]);
+                                                        for (var i = 0; i < els.length; i++) {
+                                                            if (els[i].style.display !== 'none') {
+                                                                els[i].style.setProperty('display', 'none', 'important');
+                                                                els[i].style.setProperty('visibility', 'hidden', 'important');
+                                                            }
+                                                        }
+                                                    } catch(e) { /* invalid selector list — skip this batch */ }
+                                                }
+                                            };
+
+                                            // Procedural rules: base selector via qSA, then the
+                                            // pseudo chain (t = text match, u = upward walk,
+                                            // r = remove) evaluated here in page JS.
+                                            var applyProc = function() {
+                                                for (var r = 0; r < procRules.length; r++) {
+                                                    var rule = procRules[r];
+                                                    try {
+                                                        var els = document.querySelectorAll(rule.b);
+                                                        for (var i = 0; i < els.length; i++) {
+                                                            var el = els[i];
+                                                            var ok = true;
+                                                            for (var o = 0; o < rule.o.length && ok; o++) {
+                                                                var op = rule.o[o];
+                                                                var kind = op.charAt(0);
+                                                                var arg = op.substring(2);
+                                                                if (kind === 't') {
+                                                                    var txt = el.textContent || '';
+                                                                    if (arg.length > 2 && arg.charAt(0) === '/' && arg.charAt(arg.length - 1) === '/') {
+                                                                        ok = new RegExp(arg.substring(1, arg.length - 1), 'i').test(txt);
+                                                                    } else {
+                                                                        ok = txt.toLowerCase().indexOf(arg.toLowerCase()) >= 0;
+                                                                    }
+                                                                } else if (kind === 'u') {
+                                                                    var steps = parseInt(arg, 10);
+                                                                    if (!isNaN(steps)) {
+                                                                        while (steps-- > 0 && el) el = el.parentElement;
+                                                                    } else if (el.closest) {
+                                                                        el = el.closest(arg);
+                                                                    } else {
+                                                                        el = null;
+                                                                    }
+                                                                    ok = !!el;
                                                                 }
                                                             }
-                                                        } catch(e) { /* invalid selector list — skip this batch */ }
-                                                    }
-                                                };
+                                                            if (!ok || !el) continue;
+                                                            if (rule.a === 1) {
+                                                                el.remove();
+                                                            } else if (el.style && el.style.display !== 'none') {
+                                                                el.style.setProperty('display', 'none', 'important');
+                                                                el.style.setProperty('visibility', 'hidden', 'important');
+                                                            }
+                                                        }
+                                                    } catch(e) { /* invalid base selector — skip rule */ }
+                                                }
+                                            };
 
+                                            if (batches.length > 0 || procRules.length > 0) {
                                                 var pending = false;
                                                 var observer = new MutationObserver(function() {
                                                     if (pending) return;
@@ -2431,6 +2481,7 @@ class WebViewManager(
                                                     (window.requestIdleCallback || setTimeout)(function() {
                                                         pending = false;
                                                         hideMatches();
+                                                        applyProc();
                                                     }, { timeout: 100 });
                                                 });
 
@@ -2442,6 +2493,7 @@ class WebViewManager(
                                                 }
 
                                                 setTimeout(function() { observer.disconnect(); }, 30000);
+                                                applyProc();
                                             }
                                         })();
                                     """.trimIndent(), null)

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockerCustomSourcesTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockerCustomSourcesTest.kt
@@ -153,6 +153,23 @@ class AdBlockerCustomSourcesTest {
     }
 
     @Test
+    fun `compiled state round-trips procedural rules`() = runBlocking {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+        adBlocker.addRule("example.com##.item:has-text(Sponsor):upward(1)")
+        adBlocker.saveHostsRules(context)
+
+        val fresh = AdBlocker()
+        fresh.loadHostsRules(context)
+        fresh.setEnabled(true)
+
+        val js = fresh.getCosmeticProceduralRulesJs("example.com")
+        assertThat(js).contains("\"b\":\".item\"")
+        assertThat(js).contains("t:Sponsor")
+        assertThat(js).contains("u:1")
+    }
+
+    @Test
     fun `file source key is consumable through the per-app subscription path`() = runBlocking {
         val uri = Uri.parse("content://media/external/filters/block.txt")
         Shadows.shadowOf(context.contentResolver).registerInputStream(

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockerTest.kt
@@ -239,4 +239,63 @@ class AdBlockerTest {
         assertThat(adBlocker.getAntiAdblockScript("example.com")).isNotEmpty()
     }
 
+    @Test
+    fun `procedural has-text rules are evaluated in page js not css`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##.item:has-text(Sponsor)")
+
+        val js = adBlocker.getCosmeticProceduralRulesJs("example.com")
+        assertThat(js).contains("\"b\":\".item\"")
+        assertThat(js).contains("t:Sponsor")
+        // Procedural selectors must not leak into CSS or hide batches.
+        assertThat(adBlocker.getCosmeticFilterCss("example.com")).doesNotContain(":has-text(")
+        assertThat(adBlocker.getCosmeticHideBatches("example.com").any { it.contains(".item") }).isFalse()
+        assertThat(adBlocker.getCosmeticProceduralRulesJs("other.com")).isEqualTo("[]")
+    }
+
+    @Test
+    fun `upward and remove ops encode into the procedural chain`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##.cell:has-text(Ad):upward(2)")
+        adBlocker.addRule("example.com##.overlay:remove()")
+
+        val js = adBlocker.getCosmeticProceduralRulesJs("example.com")
+        assertThat(js).contains("u:2")
+        assertThat(js).contains("\"b\":\".overlay\"")
+        // :remove() flips the action flag; the text+upward rule keeps hide semantics.
+        val removeRule = js.substringAfter("\"b\":\".overlay\"")
+        assertThat(removeRule.substring(0, removeRule.indexOf('}'))).contains("\"a\":1")
+        val hideRule = js.substringAfter("\"b\":\".cell\"").substringBefore(",{\"b\":")
+        assertThat(hideRule).contains("\"a\":0")
+    }
+
+    @Test
+    fun `procedural pseudos nested inside other pseudos are dropped`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##div:has(span:has-text(Sponsored))")
+
+        assertThat(adBlocker.getCosmeticProceduralRulesJs("example.com")).isEqualTo("[]")
+        assertThat(adBlocker.getCosmeticFilterCss("example.com")).doesNotContain(":has-text(")
+    }
+
+    @Test
+    fun `procedural exception cancels by full raw selector only`() {
+        adBlocker.initialize(useDefaultRules = false)
+        adBlocker.setEnabled(true)
+
+        adBlocker.addRule("example.com##.item")
+        adBlocker.addRule("example.com##.item:has-text(Sponsor)")
+        adBlocker.addRule("example.com#@#.item:has-text(Sponsor)")
+
+        assertThat(adBlocker.getCosmeticProceduralRulesJs("example.com")).isEqualTo("[]")
+        // The plain hide rule for the same base selector survives the procedural exception.
+        assertThat(adBlocker.getCosmeticHideBatches("example.com").any { it.contains(".item") }).isTrue()
+    }
+
 }


### PR DESCRIPTION
## Summary

Third and last follow-up to the #823 analysis (#833, #834, #835). Procedural element-hiding rules — the uBO/AdGuard syntax that filters elements by content or position — were inert: ~800 such rules across the bundled presets (`:has-text(` 395, `:upward(` 343, `:remove(` 160, plus `:matches-css`/`:xpath` left for later) matched nothing in preview or exported APKs. Before #833 they were actively harmful (invalid CSS poisoning hide batches); #833 made them drop cleanly. This PR makes the high-frequency subset actually work.

## Changes

- **`AdBlocker.kt`**
  - `parseProceduralSelector()`: splits a cosmetic selector into its plain-CSS base plus a top-level chain of `:has-text()` / `:upward()` / `:remove()`, encoded as `t:` / `u:` / `r` ops. Unsupported shapes keep the poison-proof drop: pseudos nested inside another pseudo (`div:has(span:has-text(x))` — 287 EasyList rules of this shape), text between pseudos, unbalanced parens, empty base.
  - `CosmeticFilter.proceduralOps` / `proceduralRaw`; procedural filters are excluded from CSS hide batches.
  - `getCosmeticProceduralRulesJs(pageHost)`: JSON literal `[{"b":base,"o":[ops],"a":removeFlag}]`, domain-matched, exceptions applied.
  - Exceptions cancel procedural rules **by full raw selector** (`#@#.x:has-text(y)`), and no longer leak into the plain-hide exception set — previously-shaped code would have let a procedural exception cancel an unrelated `##.x` hide rule.
- **`WebViewManager.kt`**: the DOCUMENT_END observer evaluates the procedural chain per rule with per-rule `try/catch` — case-insensitive substring (or `/regex/`) text match, ancestor walk (numeric steps or `closest(selector)`), element removal — applied once at injection and on the throttled mutation pass alongside the hide batches.
- **`AdBlockFilterCache.kt`**: serializes ops + raw selector; `CACHE_VERSION` 4 → 5.

## Testing

- `AdBlockerTest`: +4 — ops encoding and action flags (`:remove()` → `a:1`), page-JS-only output (absent from CSS and hide batches, domain-scoped), nested-pseudo drop, raw-selector exception semantics.
- `AdBlockerCustomSourcesTest`: +1 — compiled-state round-trip preserving op order.
- The injected observer script was extracted and syntax-checked with `node --check`.
- Full adblock suite 45/45 green locally.

## Deliberately out of scope

`:matches-css()`, `:xpath()`, `:matches-attr()` (≈85 rules across presets) stay dropped; full ABP/AdGuard engine parity is not the goal here.

No config fields, i18n strings, or UI changes. Shell-synced, so exported APKs pick this up with the next template build.