### PR TITLE
test(extension): stop ExtensionManagerTest spinning on virtual time

### DIFF
--- a/app/src/test/java/com/webtoapp/core/extension/ExtensionManagerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/extension/ExtensionManagerTest.kt
@@ -2,9 +2,7 @@ package com.webtoapp.core.extension
 
 import android.content.Context
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -40,18 +38,12 @@ class ExtensionManagerTest {
         modulesDir.deleteRecursively()
     }
 
-    private suspend fun awaitLoaded(manager: ExtensionManager) {
-        withTimeout(5_000) {
-            while (manager.isLoading.value) {
-                delay(20)
-            }
-        }
-    }
-
     @Test
     fun `addModule persists across manager reload`() = runTest {
         val manager = ExtensionManager.getInstance(context)
-        awaitLoaded(manager)
+        // Load-bearing: addModule() builds its list from _modules.value, so an async load
+        // landing after the add would clobber the module and rewrite modules.json from disk.
+        manager.awaitLoaded()
 
         val module = ExtensionModule(
             id = "user-module-1",
@@ -64,7 +56,7 @@ class ExtensionManagerTest {
 
         ExtensionManager.release()
         val reloadedManager = ExtensionManager.getInstance(context)
-        awaitLoaded(reloadedManager)
+        reloadedManager.awaitLoaded()
 
         val stored = reloadedManager.getAllModules()
             .filterNot { it.builtIn }
@@ -78,8 +70,10 @@ class ExtensionManagerTest {
 
     @Test
     fun `parseModulesJson skips malformed items`() = runTest {
+        // Pure Gson parsing on gson only, so no awaitLoaded() here on purpose: waiting inside
+        // runTest burns virtual time, not real time, which would couple this test to real
+        // Dispatchers.IO scheduling latency for no benefit.
         val manager = ExtensionManager.getInstance(context)
-        awaitLoaded(manager)
 
         val validJson = ExtensionModule(
             id = "valid-module",
@@ -96,8 +90,8 @@ class ExtensionManagerTest {
 
     @Test
     fun `parseBuiltInStatesJson skips malformed entries`() = runTest {
+        // Same as above: parseBuiltInStatesJson reads no async state, so there is nothing to wait for.
         val manager = ExtensionManager.getInstance(context)
-        awaitLoaded(manager)
 
         val decoded = manager.parseBuiltInStatesJson("""
             {


### PR DESCRIPTION
## What this fixes

`ExtensionManagerTest` waited for the async module load with a spin loop inside `runTest`:

```kotlin
withTimeout(5_000) {
    while (manager.isLoading.value) delay(20)
}
```

Under `runTest` that 5s budget is **virtual**. `TestCoroutineScheduler` fast-forwards every `delay(20)` without consuming real time, so the whole loop burns through in a few milliseconds of wall clock and the "timeout" never protects anything. The outcome of the test is then decided by real `Dispatchers.IO` thread-scheduling latency — which is why the failures cluster on loaded machines.

Raising the budget does not fix it: the real-time window grows far more slowly than the virtual budget, so it can never reliably outlast a real IO thread dispatch. Injecting a test dispatcher would have meant changing `ExtensionManager.kt`'s constructor — production code that is inside the shell sync set (`shell/build.gradle.kts:192`) and ships into every generated APK — purely for testability, which is not worth it here.

## The change

- The private `awaitLoaded(manager)` helper is deleted, along with the `kotlinx.coroutines.delay` and `kotlinx.coroutines.withTimeout` imports.
- `parseModulesJson skips malformed items` and `parseBuiltInStatesJson skips malformed entries` drop their await entirely. Both are pure Gson parsers that read none of `_modules` / `_allModulesCache` / `_isLoading`, so the wait protected no assertion and was the only source of the race.
- `addModule persists across manager reload` now calls the production API `manager.awaitLoaded()` (`isLoading.first { !it }` — a real suspension point) instead of a private reimplementation of it. That API already has six production call sites, including the export path at `ApkBuilder.kt:4978`, so the test now exercises the contract the product actually uses.

Net diff: `+8 -14`.

## User-visible effect

None at runtime — this is test-only. It removes a source of spurious red CI on `main` and on every PR that happens to run the suite on a loaded machine.

## Verification

```
./gradlew :app:testStandardDebugUnitTest \
  --tests 'com.webtoapp.core.extension.ExtensionManagerTest' \
  -PskipShellTemplateSync=true --no-configuration-cache --rerun
```

reports `tests="3" skipped="0" failures="0" errors="0"`, repeated 5 times under a 40-spinner CPU load on a 14-core machine.

**Honest caveat about that control experiment:** the same 40-spinner load on the *pre-fix* revision also passed 5/5, so the load test does not discriminate — it demonstrates no regression, not the fix. The discriminating evidence is mechanical: two of the three tests no longer wait at all, so their race is removed rather than made less likely, and the third now suspends on the production API instead of spinning on virtual time. The mechanism was additionally reproduced in isolation (coroutines-test + `Dispatchers.IO`, no Android/Robolectric), where an injected 5–20ms IO delay reliably produced `TimeoutCancellationException` with the old spin helper and passed with `awaitLoaded()`.

Also checked: no other test under `app/src/test` uses the same `while (...) { delay(...) }` spin pattern, and none uses `Thread.sleep`, so this is the only instance of it in the repo.

## Related

Filed #837 separately for an adjacent defect found while tracing this: `ExtensionManager.release()` never cancels `initScope`, so a released instance's IO coroutine keeps writing to `modulesDir`. It is **not** the cause of #831 — a new instance has its own `_isLoading` — and fixing it naively (cancelling the scope without settling the flag) would hang `awaitLoaded()` and therefore the export path. Deliberately out of scope here.

Fixes #831
