### PR TITLE
fix(extension): stop the startup load outliving ExtensionManager.release()

### DIFF
--- a/app/src/main/java/com/webtoapp/core/backup/DataBackupManager.kt
+++ b/app/src/main/java/com/webtoapp/core/backup/DataBackupManager.kt
@@ -591,13 +591,18 @@ class DataBackupManager(private val context: Context) {
 
     private fun restoreExtensionFiles(modulesJsonBytes: ByteArray?, builtInStatesJsonBytes: ByteArray?) {
         runCatching {
+            // Release before writing the restored bytes, not after: release() cancels the
+            // outgoing instance's startup load, and cancelling it only helps if it happens
+            // before the restored file lands. With the old order the load could still be
+            // mid-migration and rewrite modules.json on top of the bytes just restored.
+            com.webtoapp.core.extension.ExtensionManager.release()
+
             if (modulesJsonBytes != null || builtInStatesJsonBytes != null) {
                 val extensionDir = File(context.filesDir, "extension_modules").apply { mkdirs() }
                 modulesJsonBytes?.let { File(extensionDir, "modules.json").writeBytes(it) }
                 builtInStatesJsonBytes?.let { File(extensionDir, "builtin_states.json").writeBytes(it) }
             }
 
-            com.webtoapp.core.extension.ExtensionManager.release()
             com.webtoapp.core.extension.ExtensionManager.getInstance(context)
             AppLogger.i(TAG, "扩展模块配置已恢复并重新加载")
         }.onFailure { e ->

--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionManager.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionManager.kt
@@ -13,6 +13,7 @@ import com.google.gson.JsonParser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -52,6 +53,7 @@ class ExtensionManager private constructor(private val context: Context) {
 
         fun release() {
             synchronized(this) {
+                INSTANCE?.shutdown()
                 INSTANCE = null
             }
         }
@@ -110,6 +112,23 @@ class ExtensionManager private constructor(private val context: Context) {
 
     private val initScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    @Volatile
+    private var released = false
+
+    /**
+     * Tears this instance down before [release] drops the singleton reference.
+     *
+     * Without this the startup load outlives the instance: it keeps holding the
+     * object alive and keeps writing into `modulesDir` — the same directory the
+     * backup restore path rewrites. Restoring releases the manager and then
+     * writes the restored file, so a load that survives the release can still
+     * rewrite `modules.json` over the restored bytes.
+     */
+    private fun shutdown() {
+        released = true
+        initScope.cancel()
+    }
+
     init {
 
         loadBuiltInModules()
@@ -118,8 +137,15 @@ class ExtensionManager private constructor(private val context: Context) {
         initScope.launch {
             loadModulesAsync()
             rebuildAllModulesCache()
-            _isLoading.value = false
             AppLogger.d(TAG, "Async module loading completed")
+        }.invokeOnCompletion {
+            // Settle on every exit path, not just success. Cancelling the scope
+            // can complete this coroutine before its body ever runs, and a
+            // non-Exception Throwable from the body would skip a plain trailing
+            // assignment too. Leaving isLoading at true strands awaitLoaded()
+            // forever, and AgentViewModel / the agent tools call it without a
+            // timeout (only ApkBuilder wraps it in withTimeoutOrNull).
+            _isLoading.value = false
         }
     }
 
@@ -136,6 +162,13 @@ class ExtensionManager private constructor(private val context: Context) {
             AppLogger.d(TAG, "loadModulesAsync: path=${file.absolutePath}, exists=${file.exists()}, size=${if (file.exists()) file.length() else 0}")
             if (file.exists()) {
                 val json = file.readText()
+
+                // shutdown() cancels initScope, but everything from here on is
+                // non-suspending file IO, so cancellation cannot preempt it. Bail
+                // before writing anything back: a released instance must not
+                // rewrite modules.json out from under a backup restore.
+                if (released) return@withContext
+
                 if (json.isBlank()) {
                     AppLogger.d(TAG, "Modules file is empty")
                     _modules.value = emptyList()
@@ -181,7 +214,11 @@ class ExtensionManager private constructor(private val context: Context) {
                     m
                 }
 
-                if (needsMigration) {
+                // The migration loop below writes a sidecar file per module, so a
+                // release() landing partway through it is not caught by the check
+                // above. Re-check right before the rewrite: this is the write that
+                // would clobber modules.json.
+                if (needsMigration && !released) {
                     AppLogger.i(TAG, "Migrating ${modules.size} modules: stripping inline code to separate files")
                     file.writeText(gson.toJson(migratedModules))
                 }

--- a/app/src/test/java/com/webtoapp/core/extension/ExtensionManagerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/extension/ExtensionManagerTest.kt
@@ -2,6 +2,7 @@ package com.webtoapp.core.extension
 
 import android.content.Context
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -106,5 +107,46 @@ class ExtensionManagerTest {
             "builtin-dark-mode", true,
             "builtin-auto-scroll", false
         )
+    }
+
+    @Test
+    fun `release before the initial load lands leaves modules json untouched`() = runTest {
+        // Inline code makes loadModulesAsync take the strip-to-sidecar migration, so any
+        // load that reaches its commit step rewrites modules.json and is visible on disk.
+        // The seed is large enough that the read is still in flight when release() runs,
+        // which is what DataBackupManager.restoreExtensionFiles() guards against: it
+        // releases the manager before writing the restored file, so a load that survived
+        // the release would rewrite modules.json over the restored bytes.
+        val seeded = (1..150).map { index ->
+            ExtensionModule(
+                id = "seed-$index",
+                name = "Seed $index",
+                code = "window.__seed$index = true;".repeat(200)
+            )
+        }
+        val modulesFile = File(modulesDir, "modules.json")
+        modulesFile.writeText(seeded.joinToString(",", "[", "]") { it.toJson() })
+        val before = modulesFile.readText()
+
+        val manager = ExtensionManager.getInstance(context)
+        ExtensionManager.release()
+
+        // isLoading settles on every exit path, cancellation included, so this returns only
+        // once the released instance's load is definitively finished with the file.
+        manager.isLoading.first { !it }
+
+        assertThat(modulesFile.readText()).isEqualTo(before)
+    }
+
+    @Test
+    fun `awaitLoaded returns on a released instance instead of hanging`() = runTest {
+        // release() cancels initScope, and a coroutine cancelled before its body runs never
+        // reaches a trailing isLoading assignment. Stranding the flag at true would hang
+        // awaitLoaded() forever: AgentViewModel and the agent tools call it with no timeout
+        // (only ApkBuilder wraps it in withTimeoutOrNull).
+        val manager = ExtensionManager.getInstance(context)
+        ExtensionManager.release()
+
+        manager.awaitLoaded()
     }
 }


### PR DESCRIPTION
## What this fixes

`ExtensionManager.release()` only dropped the singleton reference. The instance's `initScope` was never cancelled, so the startup load kept running — holding the instance alive and still able to write into `modulesDir`. Closes #837.

Two things made this more than a missing `cancel()`:

**1. Cancelling alone does not stop the write.** `loadModulesAsync()` runs inside a single `withContext(Dispatchers.IO) { }` whose body contains no suspension points — `readText`, the per-module sidecar writes and `writeText` are all plain file IO. A coroutine that is already executing that block runs it to completion; `cancel()` only takes effect on exit. So the cancel had to be paired with an explicit check.

**2. Cancelling without settling `isLoading` would hang the export path.** `_isLoading` starts at `true` and was only ever cleared on the success path, so a coroutine cancelled *before its body runs* would strand it and `awaitLoaded()` (`isLoading.first { !it }`) would never return. `AgentViewModel` and the three agent module tools call `awaitLoaded()` with no timeout — only `ApkBuilder` wraps it in `withTimeoutOrNull`.

## The change

**`core/extension/ExtensionManager.kt`**

- `release()` now tears the instance down before dropping it, matching the existing convention in `OfflineManager.unregister()` / `DownloadNotificationManager.cleanup()`:
  ```kotlin
  fun release() {
      synchronized(this) {
          INSTANCE?.shutdown()
          INSTANCE = null
      }
  }
  ```
- `shutdown()` sets a `@Volatile released` flag and cancels `initScope`.
- `_isLoading.value = false` moved off the success path into `invokeOnCompletion`, so it settles on **every** exit path — success, failure, or a cancellation that completes the coroutine before its body runs.
- `loadModulesAsync()` checks `released` before writing anything back: once after reading `modules.json`, and again immediately before the migration rewrite. The loop between the two writes one sidecar file per module, so a `release()` landing partway through it would otherwise slip past the first check.

**`core/backup/DataBackupManager.kt`**

- `restoreExtensionFiles()` now releases the manager **before** writing the restored bytes instead of after. Cancelling the outgoing load only helps if it happens before the restored file lands; with the old order the load could still be mid-migration and rewrite `modules.json` on top of the bytes just restored. This is the only production caller that writes after releasing, so it is the ordering half of the same defect. `release()` only cancels and nulls, so moving it earlier changes nothing else.

## User-visible effect

No change to normal operation — `released` is only set by `release()`, and the guards sit on the startup path. What changes is that a released instance stops doing work: a backup restore can no longer be undone by a stale startup load, and the leaked scope is reclaimed instead of running to completion.

## Verification

- **The new regression test fails before the change and passes after.** `release before the initial load lands leaves modules json untouched` seeds a `modules.json` whose modules carry inline code, so any load that reaches the commit step takes the strip-to-sidecar migration and rewrites the file. Against unmodified `ExtensionManager.kt` it fails:
  ```
  tests="5" skipped="0" failures="1" errors="0"
  ExtensionManagerTest > release before the initial load lands leaves modules json untouched FAILED
      com.google.common.truth.ComparisonFailureWithFacts at ExtensionManagerTest.kt:113
  ```
  With the change it passes, 5 consecutive runs: `tests="5" failures="0" errors="0"`.
- `awaitLoaded returns on a released instance instead of hanging` pins the no-hang invariant. **It passes against the unmodified code too** — it guards against the naive fix (cancel without settling the flag), not against this bug.
- `ExtensionManager` is inside the shell sync set (`shell/build.gradle.kts` → `**/core/extension/**`), so this ships into generated APKs: `:shell:compileDebugKotlin` is clean.
- Full CI-equivalent local run of `:app:compileStandardDebugKotlin :shell:compileDebugKotlin :app:testStandardDebugUnitTest :app:checkConfigFieldDrift` — `tests=1174 failures=0 errors=0 skipped=4`, `check_config_field_drift: OK (payload=444 shell=476 allowlist=49 shared=437)`.

## Residual

The check-then-write is not atomic, so a `release()` landing between the flag check and the `writeText` still lets that single write through. Closing that would need the load's commit and the restore to share a lock. With the `DataBackupManager` reorder the window no longer overlaps the restore at all, so a bespoke lock is not worth it here.

Fixes #837
