### PR TITLE
fix(nodejs): embed libnode.so for every selected ABI, not just the host's

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -97,6 +97,25 @@ class ApkBuilder(private val context: Context) {
         internal fun injectedDeviceLibEntries(appType: String, deviceAbi: String): Set<String> =
             injectedNativeLibNames(appType).mapTo(mutableSetOf()) { "lib/$deviceAbi/$it" }
 
+        /**
+         * Additional lib/ entries the injection step writes for selected ABIs OTHER than the
+         * device ABI. The template ships the bridge/launcher libs for every ABI already (they
+         * are 16KB-aligned), so only libnode.so — never in the template, downloaded on demand —
+         * is injected per extra ABI. Skipping these during the copy pass keeps CONTENT_OVERLAY
+         * builds from duplicating entries already present in the cached base APK.
+         */
+        internal fun injectedMultiAbiLibEntries(
+            appType: String,
+            deviceAbi: String,
+            abiFilters: List<String>
+        ): Set<String> = if (appType == "NODEJS_APP") {
+            com.webtoapp.core.nodejs.NodeDependencyManager.NODE_EXPORT_ABIS
+                .filter { it != deviceAbi && (abiFilters.isEmpty() || it in abiFilters) }
+                .mapTo(mutableSetOf()) {
+                    "lib/$it/${com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME}"
+                }
+        } else emptySet()
+
         internal fun geckoRuntimeEntryNames(
             nativeLibNamesByAbi: Map<String, List<String>>,
             abiFilters: List<String>
@@ -726,7 +745,8 @@ class ApkBuilder(private val context: Context) {
                 val ensured = ExportRuntimeEnsure.ensure(
                     context,
                     appTypeEnum,
-                    cronetNeededForExport(config)
+                    cronetNeededForExport(config),
+                    neededAbis = architecture.abiFilters
                 )
                 logger.logKeyValue("exportRuntimeEnsure", ensured)
                 if (!ensured) {
@@ -833,7 +853,8 @@ class ApkBuilder(private val context: Context) {
                 nativeLibsFingerprint = runtimeAssetsFingerprint(
                     webApp.appType,
                     config.engineType,
-                    cronetNeededForExport(config)
+                    cronetNeededForExport(config),
+                    architecture.abiFilters
                 ),
                 hostVersionCode = hostVersionCode,
                 forceFullRebuild = forceFullRebuild,
@@ -1322,12 +1343,14 @@ class ApkBuilder(private val context: Context) {
         var discoveredOldIconPaths = emptySet<String>()
         var discoveredIconSpecs = emptyList<ArscRebuilder.DiscoveredIconPath>()
 
-        // Native libs the per-app-type injection step writes for the device ABI (16KB-aligned).
-        // The template also ships them; skip the template's device-ABI copy in the loop below so
-        // the injection is the single source and we don't emit a duplicate zip entry
+        // Native libs the per-app-type injection step writes (16KB-aligned): the device-ABI
+        // set plus, for NODEJS_APP, libnode.so for every other selected ABI. The template also
+        // ships the device-ABI ones; skip the template's copies in the loop below so the
+        // injection is the single source and we don't emit a duplicate zip entry
         // ("duplicate entry: lib/<abi>/<lib>.so").
         val deviceAbi = android.os.Build.SUPPORTED_ABIS?.firstOrNull() ?: "arm64-v8a"
-        val injectedDeviceLibs = injectedDeviceLibEntries(config.appType, deviceAbi)
+        val injectedLibs = injectedDeviceLibEntries(config.appType, deviceAbi) +
+            injectedMultiAbiLibEntries(config.appType, deviceAbi, abiFilters)
 
         val geckoEngineFiles = if (mode == ModifyApkMode.FULL && config.engineType == "GECKOVIEW") {
             val manager = com.webtoapp.core.engine.download.EngineFileManager(context)
@@ -1391,7 +1414,7 @@ class ApkBuilder(private val context: Context) {
                             // device ABI on every build regardless of mode; copying the cached
                             // copies here too would emit each lib twice (near-2x bloat and
                             // undefined duplicate-entry behavior).
-                            entry.name in injectedDeviceLibs -> {
+                            entry.name in injectedLibs -> {
                                 AppLogger.d("ApkBuilder", "Skipping cached native lib (re-injected this build): ${entry.name}")
                             }
                             else -> {
@@ -1480,8 +1503,8 @@ class ApkBuilder(private val context: Context) {
 
                             when {
 
-                                injectedDeviceLibs.contains(entry.name) -> {
-                                    AppLogger.d("ApkBuilder", "Skipping template native lib (injected for device ABI): ${entry.name}")
+                                injectedLibs.contains(entry.name) -> {
+                                    AppLogger.d("ApkBuilder", "Skipping template/cached native lib (injected this build): ${entry.name}")
                                 }
 
                                 abiFilters.isNotEmpty() && !abiFilters.contains(abi) -> {
@@ -1682,7 +1705,7 @@ class ApkBuilder(private val context: Context) {
                         fnAddHtmlFiles = ::addHtmlFilesToAssets,
                         fnAddGalleryItems = ::addGalleryItemsToAssets,
                         fnAddWordPressFiles = ::addWordPressFilesToAssets,
-                        fnAddNodeJsFiles = ::addNodeJsFilesToAssets,
+                        fnAddNodeJsFiles = { zo, dir -> addNodeJsFilesToAssets(zo, dir, abiFilters) },
                         fnAddFrontendFiles = ::addFrontendFilesToAssets,
                         fnAddPhpAppFiles = ::addPhpAppFilesToAssets,
                         fnAddPythonAppFiles = ::addPythonAppFilesToAssets,
@@ -2321,11 +2344,12 @@ class ApkBuilder(private val context: Context) {
 
     private fun addNodeJsFilesToAssets(
         zipOut: ZipOutputStream,
-        projectDir: File
+        projectDir: File,
+        abiFilters: List<String>
     ) {
 
         RuntimeAssetEmbedder.embedProjectFiles(zipOut, projectDir, RuntimeAssetEmbedder.nodeJsConfig(), logger)
-        injectNodeJsNativeLibs(zipOut)
+        injectNodeJsNativeLibs(zipOut, abiFilters)
     }
 
     private fun resolveNodeJsBinary(): File? {
@@ -2394,7 +2418,8 @@ class ApkBuilder(private val context: Context) {
     private fun runtimeAssetsFingerprint(
         appType: com.webtoapp.data.model.AppType,
         engineType: String?,
-        cronetNeeded: Boolean = false
+        cronetNeeded: Boolean = false,
+        abiFilters: List<String> = emptyList()
     ): String? {
         val parts = mutableListOf<String>()
         if (appType == com.webtoapp.data.model.AppType.NODEJS_APP) {
@@ -2403,6 +2428,19 @@ class ApkBuilder(private val context: Context) {
             parts += "bridge=${libFingerprint(File(nativeDir, "libnode_bridge.so"))}"
             parts += "cxx=${libFingerprint(File(nativeDir, "libc++_shared.so"))}"
             parts += "node=${libFingerprint(node)}"
+            // Per-ABI libnode fingerprints: a Node runtime re-download that fills in
+            // previously missing ABIs must invalidate REUSE_UNSIGNED so the cached
+            // unsigned APK is rebuilt with lib/<abi>/libnode.so for every selected ABI.
+            val deviceAbi = com.webtoapp.core.nodejs.NodeDependencyManager.getDeviceAbi()
+            com.webtoapp.core.nodejs.NodeDependencyManager.NODE_EXPORT_ABIS
+                .filter { it != deviceAbi && (abiFilters.isEmpty() || it in abiFilters) }
+                .forEach { extraAbi ->
+                    val lib = File(
+                        com.webtoapp.core.nodejs.NodeDependencyManager.getNodeDir(context, extraAbi),
+                        com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME
+                    )
+                    parts += "node-$extraAbi=${libFingerprint(lib)}"
+                }
         }
         if (appType == com.webtoapp.data.model.AppType.PHP_APP ||
             appType == com.webtoapp.data.model.AppType.WORDPRESS
@@ -2456,7 +2494,7 @@ class ApkBuilder(private val context: Context) {
         return "sha256=$sha,size=${file.length()},aligned16k=$aligned"
     }
 
-    private fun injectNodeJsNativeLibs(zipOut: ZipOutputStream) {
+    private fun injectNodeJsNativeLibs(zipOut: ZipOutputStream, abiFilters: List<String>) {
         val abi = com.webtoapp.core.nodejs.NodeDependencyManager.getDeviceAbi()
         val nativeDir = File(context.applicationInfo.nativeLibraryDir)
         val bridge = File(nativeDir, "libnode_bridge.so")
@@ -2509,6 +2547,50 @@ class ApkBuilder(private val context: Context) {
             logger.log(
                 "Node.js binary embedded as native lib: lib/$abi/${com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME} (${alignedNode.length() / 1024} KB)"
             )
+
+            // Multi-ABI export: the template already ships libnode_bridge.so /
+            // libnode_launcher.so / libc++_shared.so (16KB-aligned) for every ABI; only
+            // libnode.so is downloaded content, so it is embedded here per selected ABI.
+            // Without this the APK only ran on devices sharing the build host's ABI —
+            // x86_64 emulators without ARM translation reported "libnode.so not installed".
+            val selectedAbis = if (abiFilters.isEmpty()) {
+                com.webtoapp.core.nodejs.NodeDependencyManager.NODE_EXPORT_ABIS
+            } else {
+                abiFilters.toSet()
+            }
+            for (extraAbi in selectedAbis - abi) {
+                val extraLib = com.webtoapp.core.nodejs.NodeDependencyManager
+                    .nodeLibForAbi(context, extraAbi)
+                when {
+                    extraLib != null -> {
+                        // displayName must stay the bare lib name: ensureAligned16kNativeLib
+                        // decides fail-vs-warn on it, and a misaligned libnode.so is exactly
+                        // the Android-15/16KB-page breakage this path exists to prevent.
+                        val alignedExtra = ensureAligned16kNativeLib(
+                            extraLib,
+                            com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME
+                        )
+                        writeEntryStoredStreaming(
+                            zipOut,
+                            "lib/$extraAbi/${com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME}",
+                            alignedExtra
+                        )
+                        logger.log(
+                            "Node.js binary embedded as native lib: lib/$extraAbi/" +
+                                "${com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME} (${alignedExtra.length() / 1024} KB)"
+                        )
+                    }
+                    extraAbi in com.webtoapp.core.nodejs.NodeDependencyManager.NODE_EXPORT_ABIS -> {
+                        val msg = "libnode.so for $extraAbi missing from the Node.js runtime cache. " +
+                            "Re-download Node.js in Settings → Runtime Engines (the zip carries all ABIs), then re-export."
+                        logger.error(msg)
+                        throw IllegalStateException(msg)
+                    }
+                    else -> logger.warn(
+                        "No upstream libnode.so for $extraAbi — that ABI will not run this app's Node.js runtime"
+                    )
+                }
+            }
         } catch (e: IllegalStateException) {
             throw e
         } catch (e: Exception) {

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ExportRuntimeEnsure.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ExportRuntimeEnsure.kt
@@ -8,13 +8,20 @@ import com.webtoapp.data.model.AppType
 
 object ExportRuntimeEnsure {
 
-    fun needsEnsure(context: Context, appType: AppType, needsCronet: Boolean = false): Boolean {
+    fun needsEnsure(
+        context: Context,
+        appType: AppType,
+        needsCronet: Boolean = false,
+        neededAbis: Collection<String>? = null
+    ): Boolean {
         if (needsCronet && !com.webtoapp.core.webview.CronetDependencyManager.isCronetReady(context)) {
             return true
         }
         return when (appType) {
             AppType.PYTHON_APP -> !PythonDependencyManager.isPythonReady(context)
-            AppType.NODEJS_APP -> !NodeDependencyManager.isNodeReady(context)
+            AppType.NODEJS_APP -> !NodeDependencyManager.isNodeReady(context) ||
+                (neededAbis != null &&
+                    NodeDependencyManager.missingExportAbis(context, neededAbis).isNotEmpty())
             AppType.PHP_APP -> !WordPressDependencyManager.isPhpReady(context)
             AppType.WORDPRESS -> {
                 !WordPressDependencyManager.isPhpReady(context) ||
@@ -24,7 +31,12 @@ object ExportRuntimeEnsure {
         }
     }
 
-    suspend fun ensure(context: Context, appType: AppType, needsCronet: Boolean = false): Boolean {
+    suspend fun ensure(
+        context: Context,
+        appType: AppType,
+        needsCronet: Boolean = false,
+        neededAbis: Collection<String>? = null
+    ): Boolean {
         if (needsCronet && !com.webtoapp.core.webview.CronetDependencyManager.isCronetReady(context)) {
             if (!com.webtoapp.core.webview.CronetDependencyManager.downloadCronetRuntime(context)) {
                 return false
@@ -36,8 +48,14 @@ object ExportRuntimeEnsure {
                 else PythonDependencyManager.downloadPythonRuntime(context)
             }
             AppType.NODEJS_APP -> {
-                if (NodeDependencyManager.isNodeReady(context)) true
-                else NodeDependencyManager.downloadNodeRuntime(context)
+                val ready = if (NodeDependencyManager.isNodeReady(context)) true
+                    else NodeDependencyManager.downloadNodeRuntime(context)
+                // Multi-ABI export: the runtime zip ships arm64/arm32/x86_64, but installs
+                // predating per-ABI extraction only cached the device ABI — re-download
+                // once so the export can embed libnode.so for every selected ABI.
+                if (!ready) false
+                else if (neededAbis == null) true
+                else NodeDependencyManager.ensureExportAbis(context, neededAbis).isEmpty()
             }
             AppType.PHP_APP -> {
                 if (WordPressDependencyManager.isPhpReady(context)) true

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeDependencyManager.kt
@@ -86,8 +86,72 @@ object NodeDependencyManager {
 
     fun getNodeDir(context: Context): File {
         val abi = getDeviceAbi()
+        return getNodeDir(context, abi)
+    }
+
+    fun getNodeDir(context: Context, abi: String): File {
         return File(getDepsDir(context), "node/$abi").also { it.mkdirs() }
     }
+
+    /**
+     * Every ABI directory name that can appear inside the upstream nodejs-mobile zip.
+     * Extraction routes entries by path segment, so "x86" never swallows "x86_64" paths.
+     */
+    private val NODE_KNOWN_ABIS = setOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+
+    /**
+     * ABIs the upstream v18.20.4 nodejs-mobile zip actually ships (32-bit x86 was dropped
+     * upstream). Export requires a cached libnode.so for each selected ABI in this set;
+     * any other selected ABI (e.g. x86) is skipped with a warning instead of failing.
+     */
+    val NODE_EXPORT_ABIS: Set<String> = setOf("armeabi-v7a", "arm64-v8a", "x86_64")
+
+    /** The libnode.so cached for [abi], or null when the runtime zip never provided it. */
+    fun nodeLibForAbi(context: Context, abi: String): File? {
+        val lib = File(getNodeDir(context, abi), NODE_BINARY_NAME)
+        return lib.takeIf { it.exists() && it.isFile && it.length() > 0L }
+    }
+
+    /**
+     * Selected export ABIs that are expected to have a libnode.so but currently lack one.
+     * The device ABI is also satisfied by the host's own nativeLibraryDir (bundled builds).
+     * ABIs outside [NODE_EXPORT_ABIS] can never be satisfied upstream and are not reported.
+     */
+    fun missingExportAbis(context: Context, neededAbis: Collection<String>): Set<String> {
+        val deviceAbi = getDeviceAbi()
+        return neededAbis.filter { it in NODE_EXPORT_ABIS }
+            .filterNot { abi ->
+                nodeLibForAbi(context, abi) != null ||
+                    (abi == deviceAbi && File(context.applicationInfo.nativeLibraryDir, NODE_BINARY_NAME)
+                        .let { it.exists() && it.length() > 0L })
+            }.toSet()
+    }
+
+    /**
+     * Ensure every export-requested ABI has a cached libnode.so, re-downloading the runtime
+     * zip once when some are missing (the zip carries all ABIs; older installs only ever
+     * extracted the device ABI). Returns the ABIs still missing after the attempt.
+     */
+    suspend fun ensureExportAbis(context: Context, neededAbis: Collection<String>): Set<String> =
+        withContext(Dispatchers.IO) {
+            var missing = missingExportAbis(context, neededAbis)
+            if (missing.isEmpty()) return@withContext missing
+            runtimeDownloadMutex.withLock {
+                missing = missingExportAbis(context, neededAbis)
+                if (missing.isNotEmpty()) {
+                    AppLogger.i(
+                        TAG,
+                        "Node.js export needs libnode.so for $missing — re-downloading runtime zip (all ABIs)"
+                    )
+                    downloadNode(context, getMirrorConfig())
+                    missing = missingExportAbis(context, neededAbis)
+                    if (missing.isNotEmpty()) {
+                        AppLogger.e(TAG, "Still no libnode.so for $missing after re-download")
+                    }
+                }
+            }
+            missing
+        }
 
     fun getNodeProjectsDir(context: Context): File {
         return File(context.filesDir, "nodejs_projects").also { it.mkdirs() }
@@ -239,7 +303,7 @@ object NodeDependencyManager {
         _downloadState.value = DownloadState.Extracting("Node.js")
         DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Extracting("Node.js"))
         try {
-            extractNodeZip(archiveFile, destDir, abi)
+            val extractedAbis = extractNodeZip(archiveFile, context, abi)
 
             val nodeLib = File(destDir, NODE_BINARY_NAME)
             if (nodeLib.exists()) {
@@ -251,7 +315,9 @@ object NodeDependencyManager {
                 return false
             }
 
-            ensureLibnodePageAligned(nodeLib)
+            extractedAbis.forEach { extractedAbi ->
+                ensureLibnodePageAligned(File(getNodeDir(context, extractedAbi), NODE_BINARY_NAME))
+            }
 
             archiveFile.delete()
             return true
@@ -262,42 +328,55 @@ object NodeDependencyManager {
         }
     }
 
-    private fun extractNodeZip(zipFile: File, destDir: File, abi: String) {
+    /**
+     * Extract the upstream zip into per-ABI dirs (`node/<abi>/libnode.so`) so multi-arch
+     * exports can embed libnode.so for ABIs other than the host device's. Returns the set
+     * of ABIs whose libnode.so was extracted; [deviceAbi] must be among them.
+     */
+    private fun extractNodeZip(zipFile: File, context: Context, deviceAbi: String): Set<String> {
         val zipInput = java.util.zip.ZipInputStream(zipFile.inputStream().buffered())
-        var foundLib = false
         val guard = com.webtoapp.util.SafeZip.EntryGuard()
+        val extractedAbis = mutableSetOf<String>()
 
         zipInput.use { zis ->
             var entry = zis.nextEntry
             while (entry != null) {
                 guard.onEntry()
+                val abi = nodeAbiOfEntry(entry.name)
 
-                if (!entry.isDirectory && entry.name.contains(abi) && entry.name.endsWith("libnode.so")) {
-                    val outFile = File(destDir, NODE_BINARY_NAME)
+                if (!entry.isDirectory && abi != null && entry.name.endsWith(".so")) {
+                    val soName = entry.name.substringAfterLast("/")
+                    val outFile = File(getNodeDir(context, abi), soName)
                     outFile.parentFile?.mkdirs()
                     FileOutputStream(outFile).use { fos ->
                         guard.copyTo(zis, fos)
                     }
-                    outFile.setExecutable(true, false)
-                    foundLib = true
-                    AppLogger.i(TAG, "Extracting ${entry.name} -> ${outFile.absolutePath}")
-                } else if (!entry.isDirectory && entry.name.endsWith(".so") && entry.name.contains(abi)) {
-
-                    val soName = entry.name.substringAfterLast("/")
-                    val outFile = File(destDir, soName)
-                    outFile.parentFile?.mkdirs()
-                    FileOutputStream(outFile).use { fos ->
-                        guard.copyTo(zis, fos)
+                    if (soName == NODE_BINARY_NAME) {
+                        outFile.setExecutable(true, false)
+                        extractedAbis += abi
+                        AppLogger.i(TAG, "Extracting ${entry.name} -> ${outFile.absolutePath}")
                     }
                 }
                 entry = zis.nextEntry
             }
         }
 
-        if (!foundLib) {
-            throw IllegalStateException(Strings.nodeLibNotFoundInZip.format(abi))
+        if (deviceAbi !in extractedAbis) {
+            throw IllegalStateException(Strings.nodeLibNotFoundInZip.format(deviceAbi))
         }
+        val absent = NODE_EXPORT_ABIS - extractedAbis
+        if (absent.isNotEmpty()) {
+            AppLogger.w(TAG, "Node.js zip ships no libnode.so for $absent — exports cannot target those ABIs")
+        }
+        return extractedAbis
     }
+
+    /**
+     * The ABI a zip entry belongs to, matched on whole path segments so "x86" can never
+     * capture "x86_64" paths (a plain contains("x86") check would misroute them).
+     */
+    internal fun nodeAbiOfEntry(entryName: String): String? =
+        entryName.split('/').firstOrNull { it in NODE_KNOWN_ABIS }
 
     private fun syncEngineState() {
         when (val es = DependencyDownloadEngine.state.value) {

--- a/app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt
@@ -260,7 +260,8 @@ private fun BuildApkContent(
                 context,
                 webAppWithConfig.appType,
                 webAppWithConfig.webViewConfig.forceHttp3 ||
-                    webAppWithConfig.webViewConfig.dnsConfig.echEffective
+                    webAppWithConfig.webViewConfig.dnsConfig.echEffective,
+                neededAbis = webAppWithConfig.apkExportConfig?.architecture?.abiFilters
             )
             if (!ensureOk) {
                 progressText = when (webAppWithConfig.appType) {
@@ -318,7 +319,13 @@ private fun BuildApkContent(
         if (!uiReady) return@LaunchedEffect
         val config = currentBuildConfig()
         val needsCronet = config.webViewConfig.forceHttp3 || config.webViewConfig.dnsConfig.echEffective
-        if (ExportRuntimeEnsure.needsEnsure(context, config.appType, needsCronet)) {
+        if (ExportRuntimeEnsure.needsEnsure(
+                context,
+                config.appType,
+                needsCronet,
+                neededAbis = webApp.apkExportConfig?.architecture?.abiFilters
+            )
+        ) {
             isEnsuringRuntime = true
             ensureRuntimeText = when (config.appType) {
                 AppType.PYTHON_APP -> Strings.preparingPythonEnv
@@ -327,7 +334,12 @@ private fun BuildApkContent(
                 AppType.WORDPRESS -> Strings.preparing
                 else -> Strings.preparing
             }
-            val ensureOk = ExportRuntimeEnsure.ensure(context, config.appType, needsCronet)
+            val ensureOk = ExportRuntimeEnsure.ensure(
+                context,
+                config.appType,
+                needsCronet,
+                neededAbis = webApp.apkExportConfig?.architecture?.abiFilters
+            )
             if (!ensureOk) {
                 ensureRuntimeText = when (config.appType) {
                     AppType.PYTHON_APP -> Strings.pythonRuntimeDownloadFailed

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuilderInjectedLibsTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuilderInjectedLibsTest.kt
@@ -65,4 +65,37 @@ class ApkBuilderInjectedLibsTest {
         assertThat(ApkBuilder.injectedDeviceLibEntries("WEB", "arm64-v8a")).isEmpty()
         assertThat(ApkBuilder.injectedDeviceLibEntries("HTML", "arm64-v8a")).isEmpty()
     }
+
+    @Test
+    fun `node app skips injected libnode for every selected non-device abi`() {
+        // Multi-ABI export injects libnode.so per selected ABI (upstream ships
+        // arm64-v8a / armeabi-v7a / x86_64 — never 32-bit x86). Only libnode.so is
+        // injected for extra ABIs: the template already carries the aligned
+        // bridge/launcher/cxx libs, so those template entries must NOT be skipped.
+        assertThat(
+            ApkBuilder.injectedMultiAbiLibEntries(
+                "NODEJS_APP", "arm64-v8a", listOf("arm64-v8a", "x86_64")
+            )
+        ).containsExactly("lib/x86_64/libnode.so")
+
+        assertThat(
+            ApkBuilder.injectedMultiAbiLibEntries(
+                "NODEJS_APP", "arm64-v8a", emptyList() // empty = all selected
+            )
+        ).containsExactly("lib/armeabi-v7a/libnode.so", "lib/x86_64/libnode.so")
+    }
+
+    @Test
+    fun `multi-abi injection never targets unsupported or non-node types`() {
+        // x86 (32-bit) has no upstream libnode.so — nothing to inject/skip for it.
+        assertThat(
+            ApkBuilder.injectedMultiAbiLibEntries("NODEJS_APP", "arm64-v8a", listOf("x86"))
+        ).isEmpty()
+        assertThat(
+            ApkBuilder.injectedMultiAbiLibEntries("PHP_APP", "arm64-v8a", emptyList())
+        ).isEmpty()
+        assertThat(
+            ApkBuilder.injectedMultiAbiLibEntries("WEB", "arm64-v8a", emptyList())
+        ).isEmpty()
+    }
 }

--- a/app/src/test/java/com/webtoapp/core/nodejs/NodeDependencyManagerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/nodejs/NodeDependencyManagerTest.kt
@@ -123,4 +123,40 @@ class NodeDependencyManagerTest {
             nativeLibDir.deleteRecursively()
         }
     }
+
+    @Test
+    fun `nodeAbiOfEntry matches whole path segments and never confuses x86 with x86_64`() {
+        assertThat(
+            NodeDependencyManager.nodeAbiOfEntry("nodejs-mobile-v18.20.4-android/bin/arm64-v8a/libnode.so")
+        ).isEqualTo("arm64-v8a")
+        assertThat(NodeDependencyManager.nodeAbiOfEntry("bin/x86_64/libnode.so")).isEqualTo("x86_64")
+        assertThat(NodeDependencyManager.nodeAbiOfEntry("bin/x86/libnode.so")).isEqualTo("x86")
+        assertThat(NodeDependencyManager.nodeAbiOfEntry("bin/armeabi-v7a/libnode.so")).isEqualTo("armeabi-v7a")
+        assertThat(NodeDependencyManager.nodeAbiOfEntry("x86_64/libnode.so")).isEqualTo("x86_64")
+        assertThat(NodeDependencyManager.nodeAbiOfEntry("include/node/node_api.h")).isNull()
+        assertThat(NodeDependencyManager.nodeAbiOfEntry("libnode.so")).isNull()
+    }
+
+    @Test
+    fun `missingExportAbis reports only satisfiable abis lacking a cached libnode`() {
+        // Empty cache: every upstream ABI is missing; x86 is never reported because
+        // upstream ships no 32-bit x86 libnode and the gap can never be fixed.
+        assertThat(
+            NodeDependencyManager.missingExportAbis(context, listOf("arm64-v8a", "x86_64", "x86"))
+        ).containsExactly("arm64-v8a", "x86_64")
+
+        // A cached libnode.so satisfies that ABI.
+        File(
+            NodeDependencyManager.getNodeDir(context, "x86_64"),
+            NodeDependencyManager.NODE_BINARY_NAME
+        ).apply {
+            parentFile?.mkdirs()
+            writeBytes(byteArrayOf(1))
+        }
+
+        assertThat(NodeDependencyManager.missingExportAbis(context, listOf("x86_64"))).isEmpty()
+        assertThat(
+            NodeDependencyManager.missingExportAbis(context, listOf("arm64-v8a", "x86_64"))
+        ).containsExactly("arm64-v8a")
+    }
 }

--- a/docs/guide/app-types/nodejs.md
+++ b/docs/guide/app-types/nodejs.md
@@ -23,6 +23,14 @@ The exported APK embeds:
 
 Missing any of these causes `loadNode` / `loadJniBridge` failure at runtime.
 
+The bridge/launcher/C++ libs ship inside the shell template for all four ABIs. `libnode.so`
+is downloaded content and is embedded once per selected APK architecture — the upstream
+nodejs-mobile zip provides `arm64-v8a`, `armeabi-v7a` and `x86_64` (no 32-bit `x86`). If a
+selected ABI is missing from the local runtime cache, export re-downloads the Node.js
+runtime once and extracts every ABI; a still-missing ABI fails the build rather than
+shipping an APK that would report "libnode.so not installed" on that architecture (e.g.
+x86_64 emulators without ARM translation).
+
 ## Core config
 
 Backed by `NodeJsConfig`.

--- a/docs/zh/guide/app-types/nodejs.md
+++ b/docs/zh/guide/app-types/nodejs.md
@@ -23,6 +23,8 @@ Express/Fastify/Koa 应用、API 和服务端演示。
 
 缺少任何一个都会在运行时导致 `loadNode` / `loadJniBridge` 失败。
 
+桥接/启动器/C++ 库由 shell 模板为全部四种 ABI 内置;`libnode.so` 属于按需下载内容,会按所选 APK 架构逐 ABI 嵌入 —— 上游 nodejs-mobile 包提供 `arm64-v8a`、`armeabi-v7a` 和 `x86_64`(不含 32 位 `x86`)。若所选 ABI 在本地运行时缓存中缺失,导出时会自动重新下载一次 Node.js 运行时并解压全部 ABI;若仍缺失,构建直接失败,避免产出在该架构上启动即报"libnode.so 未安装"的 APK(例如没有 ARM 转译的 x86_64 模拟器)。
+
 ## 核心配置
 
 由 `NodeJsConfig` 支撑。


### PR DESCRIPTION
## Summary

Fixes #840.

A `NODEJS_APP` exported on an arm64 phone embedded `libnode.so` for the host ABI only, so the generated APK failed at launch on x86_64 devices without ARM translation (MuMu Android 15, etc.) with the misleading *"libnode.so not installed — download the Node.js runtime"* error.

- `extractNodeZip` extracts every ABI in the upstream zip into per-ABI cache dirs (`node/<abi>/libnode.so`), routing by whole path segment so `x86` can never swallow `x86_64` paths.
- `NodeDependencyManager.ensureExportAbis` re-downloads the runtime once when a selected export ABI lacks a cached `libnode.so` (installs predating this change only ever extracted the device ABI).
- `ExportRuntimeEnsure` accepts `neededAbis`, wired from `ApkExportConfig.architecture.abiFilters` in both the build pipeline and the Build APK screen, so the fetch happens up front with the normal download UX.
- `injectNodeJsNativeLibs` embeds `lib/<abi>/libnode.so` (16KB-aligned) for every selected ABI; a still-missing upstream ABI fails the build instead of shipping a broken APK, and 32-bit `x86` is warn-skipped since upstream ships no binary for it.
- `injectedMultiAbiLibEntries` extends the skip set so CONTENT_OVERLAY rebuilds never emit duplicate `lib/<abi>/libnode.so` entries.
- `runtimeAssetsFingerprint` fingerprints each selected ABI's `libnode.so`, so a runtime re-download invalidates REUSE_UNSIGNED correctly.

The bridge/launcher/C++ libs needed no work: the shell template already ships them 16KB-aligned for all four ABIs. PHP/WordPress stays arm64-only (pmmp ships no x86_64 binary) and Go already exposes an explicit `targetArch`; Node.js is the only runtime where a fix was both possible and needed.

#### Test plan

- [x] `:app:compileStandardDebugKotlin`, `:shell:compileDebugKotlin`, `:app:testStandardDebugUnitTest`, `:app:checkConfigFieldDrift` — all green locally.
- [x] New unit tests: per-ABI injection skip-set (`ApkBuilderInjectedLibsTest`), zip ABI routing incl. `x86`/`x86_64` disambiguation + `missingExportAbis` (`NodeDependencyManagerTest`).
- [ ] Manual: re-export a Node.js app on an arm64 phone, install on an x86_64 emulator without ARM translation → Node server starts.
- Docs updated (EN + ZH `guide/app-types/nodejs.md`).

Generated with [Devin](https://devin.ai)
