### PR TITLE
fix(activation): reuse the remembered card at launch instead of demanding it every time

### DIFF
--- a/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
@@ -60,7 +60,9 @@ class ActivationManager(private val context: Context) {
         if (result is ActivationResult.Success) {
             clearFailedAttempts(appId)
             saveActivationStatus(appId, true)
-        } else if (result is ActivationResult.Invalid) {
+        } else if (result is ActivationResult.Invalid && !result.offline) {
+            // Offline failures are "couldn't ask the server", not a wrong code —
+            // they must not burn the brute-force lockout budget.
             recordFailedAttempt(appId)
         }
         return result
@@ -188,7 +190,12 @@ class ActivationManager(private val context: Context) {
         }
 
         val currentStatus = getActivationStatus(appId)
-        if (currentStatus.isActivated && currentStatus.isValid) {
+        // "Already activated" only answers "this exact card is already redeemed". A
+        // different listed code is a card switch and must fall through to a fresh
+        // activation, otherwise a live grant would trap the user on the old card.
+        if (currentStatus.isActivated && currentStatus.isValid &&
+            isGrantCode(appId, matchedCode)
+        ) {
             AppLogger.i(TAG, "Already activated: app=$appId")
             return ActivationResult.AlreadyActivated
         }
@@ -222,7 +229,10 @@ class ActivationManager(private val context: Context) {
 
         val currentStatus = getActivationStatus(appId)
 
-        if (currentStatus.isActivated) {
+        // A lapsed grant must only block re-entering the SAME card that backs it;
+        // rejecting every new code here would brick re-activation forever once a
+        // grant expired or ran out of uses.
+        if (currentStatus.isActivated && isGrantCode(appId, code)) {
             if (currentStatus.isExpired) {
                 return ActivationResult.Expired
             }
@@ -274,6 +284,82 @@ class ActivationManager(private val context: Context) {
         return true
     }
 
+    /**
+     * Startup gate for local codes with "verify every launch" enabled.
+     *
+     * The grant is re-validated instead of blindly trusted: it must still be
+     * valid AND the code that created it must still be listed in the config, so
+     * removing a card revokes existing activations on the next launch. When the
+     * remembered card still checks out the launch passes silently — the user
+     * never retypes it. The stored code is the config-side string, so no
+     * plaintext credential is persisted that the config itself doesn't carry.
+     *
+     * Deliberately does NOT reset state first: wiping expire/usage/lockout on
+     * every launch made time- and usage-limited cards effectively infinite and
+     * reset the brute-force lockout on each restart.
+     */
+    suspend fun resolveRelaunchActivation(
+        appId: Long,
+        validCodes: List<ActivationCode>
+    ): Boolean {
+        val status = getActivationStatus(appId)
+        if (!status.isActivated || !status.isValid) {
+            return false
+        }
+        val usedCode = getUsedCode(appId)
+        if (usedCode == null || !isCodeListed(usedCode, validCodes)) {
+            AppLogger.w(TAG, "Relaunch denied: remembered code no longer configured, app=$appId")
+            return false
+        }
+        return resolveStartupActivation(appId)
+    }
+
+    /**
+     * Unified startup gate for remote activation.
+     *
+     * [reverifyEveryLaunch] = "verify every launch": always re-verify the
+     * remembered code against the server (offline behaviour still follows the
+     * configured offlinePolicy). Otherwise a locally-valid grant plus a valid
+     * cached server result is enough; only when the cache cannot carry the
+     * launch (e.g. DENY policy, expired cache) is the remembered code re-verified.
+     * The dialog is only needed when this returns false.
+     */
+    suspend fun resolveRemoteStartup(
+        appId: Long,
+        request: RemoteActivationVerifier.RemoteRequest,
+        reverifyEveryLaunch: Boolean
+    ): Boolean {
+        if (!reverifyEveryLaunch &&
+            isActivated(appId).first() &&
+            isRemoteStartupAllowed(appId, request)
+        ) {
+            return true
+        }
+        return when (reverifyRemoteWithCachedCode(appId, request)) {
+            is ActivationResult.Success, is ActivationResult.AlreadyActivated -> true
+            else -> false
+        }
+    }
+
+    private suspend fun getUsedCode(appId: Long): String? {
+        return context.activationDataStore.data.first()
+            .let { it[stringPreferencesKey("used_code_$appId")] }
+    }
+
+    /** True when [code] is the card that backs the current grant. */
+    private suspend fun isGrantCode(appId: Long, code: ActivationCode): Boolean {
+        val used = getUsedCode(appId) ?: return false
+        return constantTimeEquals(normalizeCode(used), normalizeCode(code.code))
+    }
+
+    /** True when the remembered code string still appears in the configured list. */
+    private fun isCodeListed(usedCode: String, validCodes: List<ActivationCode>): Boolean {
+        val normalizedUsed = normalizeCode(usedCode)
+        return validCodes.any { candidate ->
+            constantTimeEquals(normalizedUsed, normalizeCode(candidate.code))
+        }
+    }
+
     suspend fun getActivationStatus(appId: Long): ActivationStatus {
         return context.activationDataStore.data.first().let { preferences ->
             getActivationStatusSync(appId, preferences)
@@ -323,14 +409,26 @@ class ActivationManager(private val context: Context) {
         context.activationDataStore.edit { preferences ->
             preferences[booleanPreferencesKey("activated_$appId")] = true
             preferences[longPreferencesKey("activated_time_$appId")] = currentTime
-            expireTime?.let {
-                preferences[longPreferencesKey("expire_time_$appId")] = it
+            // Write-through, not write-only-when-set: a card switch must not let a
+            // previous grant's expiry or usage budget leak onto the new card.
+            if (expireTime != null) {
+                preferences[longPreferencesKey("expire_time_$appId")] = expireTime
+            } else {
+                preferences.remove(longPreferencesKey("expire_time_$appId"))
             }
-            code.usageLimit?.let {
-                preferences[intPreferencesKey("usage_limit_$appId")] = it
+            if (code.usageLimit != null) {
+                preferences[intPreferencesKey("usage_limit_$appId")] = code.usageLimit
                 preferences[intPreferencesKey("usage_count_$appId")] = 0
+            } else {
+                preferences.remove(intPreferencesKey("usage_limit_$appId"))
+                preferences.remove(intPreferencesKey("usage_count_$appId"))
             }
             preferences[stringPreferencesKey("code_type_$appId")] = code.type.name
+            // The config-side code string that created this grant. Recorded so a
+            // relaunch can re-check the card is still configured ("verify every
+            // launch") and so "enter the same card again" can be told apart from
+            // "switch to a different card".
+            preferences[stringPreferencesKey("used_code_$appId")] = code.code
             // Recorded so state is complete and callers can audit where a code
             // was redeemed. Deliberately NOT enforced: a changed device id
             // (new phone, reflash, factory reset) would lock out paying users,
@@ -351,6 +449,9 @@ class ActivationManager(private val context: Context) {
                 preferences[longPreferencesKey("activated_time_$appId")] =
                     System.currentTimeMillis()
             }
+            // A remote grant isn't backed by a local card — drop any remembered
+            // code so relaunch checks never attribute this grant to a stale card.
+            preferences.remove(stringPreferencesKey("used_code_$appId"))
         }
     }
 
@@ -371,8 +472,15 @@ class ActivationManager(private val context: Context) {
             preferences.remove(intPreferencesKey("usage_limit_$appId"))
             preferences.remove(stringPreferencesKey("device_id_$appId"))
             preferences.remove(stringPreferencesKey("code_type_$appId"))
+            preferences.remove(stringPreferencesKey("used_code_$appId"))
             preferences.remove(intPreferencesKey("failed_attempts_$appId"))
             preferences.remove(longPreferencesKey("lockout_until_$appId"))
+            // Remote verification cache — a full reset must not leave a cached
+            // server grant that could silently re-activate the app next launch.
+            preferences.remove(stringPreferencesKey("remote_code_$appId"))
+            preferences.remove(longPreferencesKey("remote_expires_$appId"))
+            preferences.remove(longPreferencesKey("remote_verified_at_$appId"))
+            preferences.remove(stringPreferencesKey("remote_url_$appId"))
         }
         AppLogger.i(TAG, "Activation reset: app=$appId")
     }
@@ -507,7 +615,7 @@ class ActivationManager(private val context: Context) {
 
 sealed class ActivationResult {
     data class Success(val url: String? = null) : ActivationResult()
-    data class Invalid(val message: String = "") : ActivationResult()
+    data class Invalid(val message: String = "", val offline: Boolean = false) : ActivationResult()
     data object Empty : ActivationResult()
     data object AlreadyActivated : ActivationResult()
     data object Expired : ActivationResult()

--- a/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
@@ -1,6 +1,7 @@
 package com.webtoapp.core.activation
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -103,12 +104,12 @@ class RemoteActivationVerifier(private val context: Context) {
         }
 
         if (!parsed.ok) {
-            clearCache(appId)
+            clearRejectedGrant(appId, request.code)
             return ActivationResult.Invalid(parsed.message.ifBlank { remoteRejectedMessage() })
         }
 
         if (parsed.expiresAt != null && parsed.expiresAt <= System.currentTimeMillis()) {
-            clearCache(appId)
+            clearRejectedGrant(appId, request.code)
             return ActivationResult.Expired
         }
 
@@ -142,12 +143,13 @@ class RemoteActivationVerifier(private val context: Context) {
     private suspend fun handleOffline(appId: Long, request: RemoteRequest): ActivationResult {
         return when (request.offlinePolicy) {
             RemoteActivationOfflinePolicy.ALLOW -> ActivationResult.Success(getCachedRemoteUrl(appId))
-            RemoteActivationOfflinePolicy.DENY -> ActivationResult.Invalid(remoteOfflineDeniedMessage())
+            RemoteActivationOfflinePolicy.DENY ->
+                ActivationResult.Invalid(remoteOfflineDeniedMessage(), offline = true)
             RemoteActivationOfflinePolicy.ALLOW_CACHED -> {
                 if (readValidCache(appId, request) != null) {
                     ActivationResult.Success(getCachedRemoteUrl(appId))
                 } else {
-                    ActivationResult.Invalid(remoteOfflineNoCacheMessage())
+                    ActivationResult.Invalid(remoteOfflineNoCacheMessage(), offline = true)
                 }
             }
         }
@@ -357,12 +359,25 @@ class RemoteActivationVerifier(private val context: Context) {
         return url?.takeIf { it.isNotBlank() }
     }
 
-    private suspend fun clearCache(appId: Long) {
+    /**
+     * The server rejected or expired [rejectedCode]. Drop the cached remote
+     * result — but only when the rejected code is the one the cache is for, so
+     * a mistyped different code can't destroy a still-valid cached grant. When
+     * the rejected code DID back the grant, the local activated flag goes too:
+     * leaving it behind showed a stale "已激活" while the launch gate demanded
+     * a code, and let a revoked grant masquerade as valid.
+     */
+    private suspend fun clearRejectedGrant(appId: Long, rejectedCode: String) {
         context.activationDataStore.edit { prefs ->
-            prefs.remove(stringPreferencesKey("remote_code_$appId"))
-            prefs.remove(longPreferencesKey("remote_expires_$appId"))
-            prefs.remove(longPreferencesKey("remote_verified_at_$appId"))
-            prefs.remove(stringPreferencesKey("remote_url_$appId"))
+            val cachedCode = prefs[stringPreferencesKey("remote_code_$appId")]
+            if (cachedCode != null && normalize(cachedCode) == normalize(rejectedCode)) {
+                prefs.remove(stringPreferencesKey("remote_code_$appId"))
+                prefs.remove(longPreferencesKey("remote_expires_$appId"))
+                prefs.remove(longPreferencesKey("remote_verified_at_$appId"))
+                prefs.remove(stringPreferencesKey("remote_url_$appId"))
+                prefs.remove(booleanPreferencesKey("activated_$appId"))
+                prefs.remove(longPreferencesKey("activated_time_$appId"))
+            }
         }
     }
 

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -865,6 +865,7 @@ object Strings {
     val activationTypeCombined: String get() = StringsA.activationTypeCombined
     val activationTypeCombinedDesc: String get() = StringsA.activationTypeCombinedDesc
     val activated: String get() = StringsA.activated
+    val activationNeedsReverify: String get() = StringsA.activationNeedsReverify
     val activationExpired: String get() = StringsA.activationExpired
     val activationTime: String get() = StringsA.activationTime
     val remainingTime: String get() = StringsA.remainingTime
@@ -14644,16 +14645,16 @@ object StringsA {
     }
 
     val requireEveryLaunchHintOn: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "每次打开应用都需要输入激活码"
-        AppLanguage.ENGLISH -> "Enter activation code every time app opens"
-        AppLanguage.ARABIC -> "أدخل رمز التفعيل في كل مرة يفتح فيها التطبيق"
-        AppLanguage.PORTUGUESE -> "Insira o código de ativação toda vez que o app abrir"
-        AppLanguage.SPANISH -> "Introduce el código de activación cada vez que se abre la app"
-        AppLanguage.FRENCH -> "Saisir le code d'activation à chaque ouverture de l'app"
-        AppLanguage.GERMAN -> "Bei jedem Öffnen der App Aktivierungscode eingeben"
-        AppLanguage.RUSSIAN -> "Вводите код активации при каждом открытии приложения"
-        AppLanguage.JAPANESE -> "アプリを開くたびにアクティベーションコードを入力"
-        AppLanguage.KOREAN -> "앱을 열 때마다 활성화 코드 입력"
+        AppLanguage.CHINESE -> "每次启动重新验证上次的激活卡，失效或被移除才需重新输入"
+        AppLanguage.ENGLISH -> "Re-verify the last card on every launch; re-entry only if it lapsed or was revoked"
+        AppLanguage.ARABIC -> "إعادة التحقق من آخر بطاقة عند كل تشغيل؛ لا يُطلب الإدخال إلا إذا انتهت أو أُلغيت"
+        AppLanguage.PORTUGUESE -> "Reverificar o último cartão a cada abertura; só pede o código se expirar ou for revogado"
+        AppLanguage.SPANISH -> "Reverificar la última tarjeta en cada inicio; solo pide el código si caducó o fue revocada"
+        AppLanguage.FRENCH -> "Revérifie la dernière carte à chaque lancement ; ne redemande le code que si elle a expiré ou été révoquée"
+        AppLanguage.GERMAN -> "Letzte Karte bei jedem Start erneut prüfen; Eingabe nur nötig, wenn sie abgelaufen oder widerrufen ist"
+        AppLanguage.RUSSIAN -> "Перепроверять последнюю карту при каждом запуске; код запрашивается, только если она истекла или отозвана"
+        AppLanguage.JAPANESE -> "起動ごとに前回のカードを再検証。失効・削除時のみ再入力が必要"
+        AppLanguage.KOREAN -> "매번 실행 시 이전 카드를 재검증. 만료·폐기된 경우에만 다시 입력"
     }
 
     val requireEveryLaunchHintOff: String get() = when (Strings.lang) {
@@ -15906,6 +15907,22 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Активирован"
         AppLanguage.JAPANESE -> "アクティベート済み"
         AppLanguage.KOREAN -> "활성화됨"
+    }
+
+    // Shown on the activation record inside the code prompt when a valid grant
+    // exists but this launch still requires verification. Never claims "已激活"
+    // while a code is being demanded.
+    val activationNeedsReverify: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "需重新验证"
+        AppLanguage.ENGLISH -> "Re-verification required"
+        AppLanguage.ARABIC -> "يلزم إعادة التحقق"
+        AppLanguage.PORTUGUESE -> "Requer nova verificação"
+        AppLanguage.SPANISH -> "Se requiere reverificación"
+        AppLanguage.FRENCH -> "Revérification requise"
+        AppLanguage.GERMAN -> "Erneute Prüfung erforderlich"
+        AppLanguage.RUSSIAN -> "Требуется повторная проверка"
+        AppLanguage.JAPANESE -> "再検証が必要です"
+        AppLanguage.KOREAN -> "재검증 필요"
     }
 
     val activationExpired: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/components/EnhancedActivationDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/EnhancedActivationDialog.kt
@@ -74,7 +74,8 @@ fun EnhancedActivationDialog(
                 }
 
                 AnimatedVisibility(
-                    visible = activationResult !is ActivationResult.Success,
+                    visible = activationResult !is ActivationResult.Success &&
+                        activationResult !is ActivationResult.AlreadyActivated,
                     enter = fadeIn() + expandVertically(),
                     exit = fadeOut() + shrinkVertically()
                 ) {
@@ -110,7 +111,8 @@ fun EnhancedActivationDialog(
         },
         confirmButton = {
             AnimatedVisibility(
-                visible = activationResult !is ActivationResult.Success,
+                visible = activationResult !is ActivationResult.Success &&
+                    activationResult !is ActivationResult.AlreadyActivated,
                 enter = fadeIn(),
                 exit = fadeOut()
             ) {
@@ -161,7 +163,9 @@ fun EnhancedActivationDialog(
             activationResult = result
             isLoading = false
 
-            if (result is ActivationResult.Success) {
+            if (result is ActivationResult.Success ||
+                result is ActivationResult.AlreadyActivated
+            ) {
                 kotlinx.coroutines.delay(1500)
                 onDismiss()
             }
@@ -389,9 +393,17 @@ private fun ActivationResultCard(result: ActivationResult) {
 private fun EnhancedActivationStatusCard(status: ActivationStatus) {
     val isValid = status.isValid
     val semantic = com.webtoapp.ui.design.WtaColors.semantic
-    val primaryColor = if (isValid) semantic.success else MaterialTheme.colorScheme.error
-    val bgColor = if (isValid) semantic.successContainer
-                  else MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f)
+    // A still-valid grant inside a code prompt is not "done" — the launch gate
+    // just refused it (re-verify required, card revoked, remote recheck failed).
+    // Show the record for context but label it honestly instead of "已激活".
+    val primaryColor = when {
+        isValid -> semantic.warning
+        else -> MaterialTheme.colorScheme.error
+    }
+    val bgColor = when {
+        isValid -> semantic.warningContainer
+        else -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f)
+    }
 
     Surface(
         shape = RoundedCornerShape(16.dp),
@@ -413,13 +425,13 @@ private fun EnhancedActivationStatusCard(status: ActivationStatus) {
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Icon(
-                        imageVector = if (isValid) Icons.Filled.VerifiedUser else Icons.Filled.GppBad,
+                        imageVector = if (isValid) Icons.Filled.Sync else Icons.Filled.GppBad,
                         contentDescription = null,
                         tint = primaryColor,
                         modifier = Modifier.size(20.dp)
                     )
                     Text(
-                        text = if (isValid) Strings.activated else Strings.activationExpired,
+                        text = if (isValid) Strings.activationNeedsReverify else Strings.activationExpired,
                         style = MaterialTheme.typography.titleSmall,
                         fontWeight = FontWeight.SemiBold,
                         color = primaryColor

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -57,8 +57,12 @@ fun ShellActivationDialog(
                     config.activationCodes
                 )
             }
-            if (result is ActivationResult.Success) {
-                onActivated(result.url)
+            // AlreadyActivated counts too: re-entering the card that already backs
+            // the grant must still let the user in, not trap them on the dialog.
+            when (result) {
+                is ActivationResult.Success -> onActivated(result.url)
+                is ActivationResult.AlreadyActivated -> onActivated(null)
+                else -> {}
             }
             result
         },

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -24,7 +24,6 @@ import com.webtoapp.core.webview.LongPressHandler
 import com.webtoapp.data.model.Announcement
 import com.webtoapp.util.TvUtils
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
@@ -174,38 +173,43 @@ fun ShellScreen(
 
         if (config.activationEnabled) {
 
-            if (config.activationRequireEveryTime) {
-                activation.resetActivation(-1L)
-                isActivated = false
-                isActivationChecked = true
-                showActivationDialog = true
+            // One gate for both modes: remote re-verifies the remembered code
+            // (always when "every launch" is on, otherwise only when the cached
+            // result can't carry this launch); local codes re-check the remembered
+            // card against the configured list under "every launch", or just the
+            // persisted grant otherwise. The dialog only shows when this fails.
+            val activated = if (config.activationRemoteEnabled) {
+                activation.resolveRemoteStartup(
+                    -1L,
+                    activation.buildRemoteRequest(
+                        verifyUrl = config.activationRemoteVerifyUrl,
+                        publicKeyBase64 = config.activationRemotePublicKey,
+                        offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
+                        deliverUrl = config.activationRemoteDeliverUrl,
+                        encryptUrl = config.activationRemoteEncryptUrl,
+                        aesKeyBase64 = config.activationRemoteAesKey,
+                        deviceBound = config.activationRemoteDeviceBound
+                    ),
+                    reverifyEveryLaunch = config.activationRequireEveryTime
+                )
+            } else if (config.activationRequireEveryTime) {
+                activation.resolveRelaunchActivation(
+                    -1L,
+                    config.activationCodes.map { raw ->
+                        com.webtoapp.core.activation.ActivationCode.fromJson(raw)
+                            ?: com.webtoapp.core.activation.ActivationCode.fromLegacyString(raw)
+                    }
+                )
             } else {
-
-                val activated = if (config.activationRemoteEnabled) {
-                    activation.isActivated(-1L).first() &&
-                        activation.isRemoteStartupAllowed(
-                            -1L,
-                            activation.buildRemoteRequest(
-                                verifyUrl = config.activationRemoteVerifyUrl,
-                                publicKeyBase64 = config.activationRemotePublicKey,
-                                offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
-                                deliverUrl = config.activationRemoteDeliverUrl,
-                                encryptUrl = config.activationRemoteEncryptUrl,
-                                aesKeyBase64 = config.activationRemoteAesKey,
-                                deviceBound = config.activationRemoteDeviceBound
-                            )
-                        )
-                } else {
-                    activation.resolveStartupActivation(-1L)
-                }
-                isActivated = activated
-                isActivationChecked = true
-                if (activated && config.activationRemoteEnabled && config.activationRemoteDeliverUrl) {
-                    dynamicUrl = activation.getCachedRemoteUrl(-1L)
-                }
-                if (!activated) {
-                    showActivationDialog = true
-                }
+                activation.resolveStartupActivation(-1L)
+            }
+            isActivated = activated
+            isActivationChecked = true
+            if (activated && config.activationRemoteEnabled && config.activationRemoteDeliverUrl) {
+                dynamicUrl = activation.getCachedRemoteUrl(-1L)
+            }
+            if (!activated) {
+                showActivationDialog = true
             }
         }
 

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -38,7 +38,6 @@ import com.webtoapp.ui.components.announcement.toUiTemplate
 import com.webtoapp.ui.theme.WebToAppTheme
 import com.webtoapp.util.normalizeExternalIntentUrl
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -127,35 +126,30 @@ fun SplashLauncherScreen(
 
     LaunchedEffect(Unit) {
         if (activationEnabled) {
-            if (activationRequireEveryTime && !remoteConfig.enabled) {
-                activation.resetActivation(activationAppId)
-                isActivated = false
-                showActivationDialog = true
-            } else if (remoteConfig.enabled) {
-                val remoteRequest = activation.buildRemoteRequest(
-                    verifyUrl = remoteConfig.verifyUrl,
-                    publicKeyBase64 = remoteConfig.publicKeyBase64,
-                    offlinePolicy = remoteConfig.offlinePolicy,
-                    deliverUrl = remoteConfig.deliverUrl,
-                    encryptUrl = remoteConfig.encryptUrl,
-                    aesKeyBase64 = remoteConfig.aesKeyBase64,
-                    deviceBound = remoteConfig.deviceBound
+            // Same gate as shell/preview: remote re-verifies the remembered code
+            // (always under "every launch", else only when the cached result can't
+            // carry this launch); local codes re-check the remembered card.
+            val ok = if (remoteConfig.enabled) {
+                activation.resolveRemoteStartup(
+                    activationAppId,
+                    activation.buildRemoteRequest(
+                        verifyUrl = remoteConfig.verifyUrl,
+                        publicKeyBase64 = remoteConfig.publicKeyBase64,
+                        offlinePolicy = remoteConfig.offlinePolicy,
+                        deliverUrl = remoteConfig.deliverUrl,
+                        encryptUrl = remoteConfig.encryptUrl,
+                        aesKeyBase64 = remoteConfig.aesKeyBase64,
+                        deviceBound = remoteConfig.deviceBound
+                    ),
+                    reverifyEveryLaunch = activationRequireEveryTime
                 )
-                if (activationRequireEveryTime) {
-                    val result = activation.reverifyRemoteWithCachedCode(activationAppId, remoteRequest)
-                    isActivated = result is com.webtoapp.core.activation.ActivationResult.Success || result is com.webtoapp.core.activation.ActivationResult.AlreadyActivated
-                    showActivationDialog = !isActivated
-                } else {
-                    val ok = activation.isActivated(activationAppId).first() &&
-                        activation.isRemoteStartupAllowed(activationAppId, remoteRequest)
-                    isActivated = ok
-                    showActivationDialog = !ok
-                }
+            } else if (activationRequireEveryTime) {
+                activation.resolveRelaunchActivation(activationAppId, activationCodes)
             } else {
-                val ok = activation.resolveStartupActivation(activationAppId)
-                isActivated = ok
-                showActivationDialog = !ok
+                activation.resolveStartupActivation(activationAppId)
             }
+            isActivated = ok
+            showActivationDialog = !ok
         }
     }
 

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -74,7 +74,6 @@ import android.content.pm.ActivityInfo
 import com.webtoapp.ui.theme.WebToAppTheme
 import com.webtoapp.util.DownloadHelper
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import com.webtoapp.ui.shared.WindowHelper
@@ -1471,38 +1470,37 @@ fun WebViewScreen(
 
                 if (app.activationEnabled) {
 
-                    if (app.activationRequireEveryTime) {
-                        activation.resetActivation(appId)
-                        isActivated = false
-                        isActivationChecked = true
-                        showActivationDialog = true
+                    // Same gate as the generated APK shell: remote re-verifies
+                    // the remembered code (always under "every launch", else only
+                    // when the cached result can't carry this launch); local codes
+                    // re-check the remembered card under "every launch".
+                    val remote = app.activationRemoteConfig?.takeIf { it.enabled }
+                    val activated = if (remote != null) {
+                        activation.resolveRemoteStartup(
+                            appId,
+                            activation.buildRemoteRequest(
+                                verifyUrl = remote.verifyUrl,
+                                publicKeyBase64 = remote.publicKeyBase64,
+                                offlinePolicy = remote.offlinePolicy,
+                                deliverUrl = remote.deliverUrl,
+                                encryptUrl = remote.encryptUrl,
+                                aesKeyBase64 = remote.aesKeyBase64,
+                                deviceBound = remote.deviceBound
+                            ),
+                            reverifyEveryLaunch = app.activationRequireEveryTime
+                        )
+                    } else if (app.activationRequireEveryTime) {
+                        activation.resolveRelaunchActivation(appId, app.activationCodeList)
                     } else {
-                        val remote = app.activationRemoteConfig?.takeIf { it.enabled }
-                        val activated = if (remote != null) {
-                            activation.isActivated(appId).first() &&
-                                activation.isRemoteStartupAllowed(
-                                    appId,
-                                    activation.buildRemoteRequest(
-                                        verifyUrl = remote.verifyUrl,
-                                        publicKeyBase64 = remote.publicKeyBase64,
-                                        offlinePolicy = remote.offlinePolicy,
-                                        deliverUrl = remote.deliverUrl,
-                                        encryptUrl = remote.encryptUrl,
-                                        aesKeyBase64 = remote.aesKeyBase64,
-                                        deviceBound = remote.deviceBound
-                                    )
-                                )
-                        } else {
-                            activation.resolveStartupActivation(appId)
-                        }
-                        isActivated = activated
-                        isActivationChecked = true
-                        if (activated && remote != null && remote.deliverUrl) {
-                            remoteDeliveredUrl = activation.getCachedRemoteUrl(appId)
-                        }
-                        if (!activated) {
-                            showActivationDialog = true
-                        }
+                        activation.resolveStartupActivation(appId)
+                    }
+                    isActivated = activated
+                    isActivationChecked = true
+                    if (activated && remote != null && remote.deliverUrl) {
+                        remoteDeliveredUrl = activation.getCachedRemoteUrl(appId)
+                    }
+                    if (!activated) {
+                        showActivationDialog = true
                     }
                 } else {
 

--- a/app/src/test/java/com/webtoapp/core/activation/ActivationRelaunchTest.kt
+++ b/app/src/test/java/com/webtoapp/core/activation/ActivationRelaunchTest.kt
@@ -1,0 +1,238 @@
+package com.webtoapp.core.activation
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.RemoteActivationOfflinePolicy
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.security.KeyPairGenerator
+import java.security.spec.ECGenParameterSpec
+
+/**
+ * Guards the remembered-card relaunch behaviour: an app activated once must be
+ * able to reuse the remembered card on the next launch instead of demanding it
+ * again, while revoked/expired/exhausted cards still land on the code prompt.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ActivationRelaunchTest {
+
+    private lateinit var manager: ActivationManager
+    private lateinit var context: android.content.Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        manager = ActivationManager(context)
+        runBlocking { manager.resetActivation(APP_ID) }
+    }
+
+    private fun permanent(code: String) =
+        ActivationCode(code = code, type = ActivationCodeType.PERMANENT)
+
+    @Test
+    fun `relaunch passes silently with the remembered card`() = runTest {
+        val codes = listOf(permanent("CARD-AAAA"), permanent("CARD-BBBB"))
+        val result = manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", codes)
+        assertThat(result).isInstanceOf(ActivationResult.Success::class.java)
+
+        // Second launch ("verify every launch" gate) reuses the stored card.
+        assertThat(manager.resolveRelaunchActivation(APP_ID, codes)).isTrue()
+    }
+
+    @Test
+    fun `relaunch fails when the remembered card was removed from the config`() = runTest {
+        val codes = listOf(permanent("CARD-AAAA"))
+        manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", codes)
+
+        // Developer revoked the card: the grant exists but the code is gone.
+        assertThat(manager.resolveRelaunchActivation(APP_ID, emptyList())).isFalse()
+        assertThat(manager.resolveRelaunchActivation(APP_ID, listOf(permanent("OTHER-999")))).isFalse()
+    }
+
+    @Test
+    fun `relaunch fails when the grant expired`() = runTest {
+        val codes = listOf(permanent("CARD-AAAA"))
+        manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", codes)
+
+        // Force the persisted grant into the past.
+        context.activationDataStore.edit { prefs ->
+            prefs[longPreferencesKey("expire_time_$APP_ID")] = System.currentTimeMillis() - 1_000
+        }
+
+        assertThat(manager.resolveRelaunchActivation(APP_ID, codes)).isFalse()
+    }
+
+    @Test
+    fun `relaunch consumes usage and stops when exhausted`() = runTest {
+        val code = ActivationCode(
+            code = "CARD-AAAA",
+            type = ActivationCodeType.USAGE_LIMITED,
+            usageLimit = 2
+        )
+        manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", listOf(code))
+
+        // Each app launch is a fresh process (fresh manager), so each consumes one use.
+        fun relaunch() = kotlinx.coroutines.runBlocking {
+            ActivationManager(context).resolveRelaunchActivation(APP_ID, listOf(code))
+        }
+        // usage_count starts at 0, limit 2 → two launches then the card is done.
+        assertThat(relaunch()).isTrue()
+        assertThat(relaunch()).isTrue()
+        assertThat(relaunch()).isFalse()
+    }
+
+    @Test
+    fun `relaunch fails when nothing was ever activated`() = runTest {
+        assertThat(manager.resolveRelaunchActivation(APP_ID, listOf(permanent("CARD-AAAA"))))
+            .isFalse()
+    }
+
+    @Test
+    fun `entering a different listed code switches the card`() = runTest {
+        val codes = listOf(permanent("CARD-AAAA"), permanent("CARD-BBBB"))
+        manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", codes)
+
+        val switch = manager.verifyActivationCodeWithObjects(APP_ID, "CARD-BBBB", codes)
+        assertThat(switch).isInstanceOf(ActivationResult.Success::class.java)
+
+        // The grant now belongs to CARD-BBBB: relaunch must still pass.
+        assertThat(manager.resolveRelaunchActivation(APP_ID, codes)).isTrue()
+    }
+
+    @Test
+    fun `re-entering the backing code reports AlreadyActivated`() = runTest {
+        val codes = listOf(permanent("CARD-AAAA"))
+        manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", codes)
+
+        val again = manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", codes)
+        assertThat(again).isEqualTo(ActivationResult.AlreadyActivated)
+    }
+
+    @Test
+    fun `a lapsed grant does not block activating a new card`() = runTest {
+        val codes = listOf(permanent("CARD-AAAA"), permanent("CARD-BBBB"))
+        manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", codes)
+
+        context.activationDataStore.edit { prefs ->
+            prefs[longPreferencesKey("expire_time_$APP_ID")] = System.currentTimeMillis() - 1_000
+        }
+
+        // Regression: previously ANY new code was rejected with Expired because the
+        // stale grant short-circuited validation — the user could never switch cards.
+        val result = manager.verifyActivationCodeWithObjects(APP_ID, "CARD-BBBB", codes)
+        assertThat(result).isInstanceOf(ActivationResult.Success::class.java)
+        assertThat(manager.resolveStartupActivation(APP_ID)).isTrue()
+    }
+
+    @Test
+    fun `re-entering the same expired card still reports Expired`() = runTest {
+        val code = ActivationCode(
+            code = "CARD-AAAA",
+            type = ActivationCodeType.TIME_LIMITED,
+            timeLimitMs = 60_000
+        )
+        manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", listOf(code))
+
+        context.activationDataStore.edit { prefs ->
+            prefs[longPreferencesKey("expire_time_$APP_ID")] = System.currentTimeMillis() - 1_000
+        }
+
+        val result = manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", listOf(code))
+        assertThat(result).isEqualTo(ActivationResult.Expired)
+    }
+
+    // ---- remote startup gate ----
+
+    private fun remoteRequest(
+        policy: RemoteActivationOfflinePolicy
+    ): RemoteActivationVerifier.RemoteRequest {
+        val kpg = KeyPairGenerator.getInstance("EC").apply {
+            initialize(ECGenParameterSpec("secp256r1"))
+        }
+        val publicKey = android.util.Base64.encodeToString(
+            kpg.generateKeyPair().public.encoded, android.util.Base64.DEFAULT
+        )
+        // Unroutable-but-https URL: connection refuses instantly, so verify()
+        // lands in the offline-policy branch without depending on real network.
+        return RemoteActivationVerifier.RemoteRequest(
+            verifyUrl = "https://127.0.0.1:1/verify",
+            publicKeyBase64 = publicKey,
+            offlinePolicy = policy,
+            code = "",
+            deviceId = "device",
+            packageName = "pkg"
+        )
+    }
+
+    // saveCache persists the normalized request code, so seeds use that form.
+    private suspend fun seedRemoteGrant(code: String = "REMOTE1") {
+        context.activationDataStore.edit { prefs ->
+            prefs[stringPreferencesKey("remote_code_$APP_ID")] = code
+            prefs[longPreferencesKey("remote_expires_$APP_ID")] = 0L
+        }
+        manager.saveActivationStatus(APP_ID, true)
+    }
+
+    @Test
+    fun `remote startup passes on the cached result without reverify`() = runTest {
+        seedRemoteGrant()
+        val request = remoteRequest(RemoteActivationOfflinePolicy.ALLOW_CACHED)
+
+        assertThat(manager.resolveRemoteStartup(APP_ID, request, reverifyEveryLaunch = false))
+            .isTrue()
+    }
+
+    @Test
+    fun `remote startup with DENY re-verifies the remembered code`() = runTest {
+        seedRemoteGrant()
+        val request = remoteRequest(RemoteActivationOfflinePolicy.DENY)
+
+        // Offline + DENY → the launch is refused, but it was refused by POLICY
+        // after an actual re-verification attempt — not by a missing prompt.
+        assertThat(manager.resolveRemoteStartup(APP_ID, request, reverifyEveryLaunch = false))
+            .isFalse()
+    }
+
+    @Test
+    fun `remote every-launch reuses the cached code offline under ALLOW_CACHED`() = runTest {
+        seedRemoteGrant()
+        val request = remoteRequest(RemoteActivationOfflinePolicy.ALLOW_CACHED)
+
+        // "Verify every launch" path: re-verifies the remembered code; offline the
+        // ALLOW_CACHED policy still honours the cached server result.
+        assertThat(manager.resolveRemoteStartup(APP_ID, request, reverifyEveryLaunch = true))
+            .isTrue()
+    }
+
+    @Test
+    fun `remote startup with no remembered code asks for one`() = runTest {
+        val request = remoteRequest(RemoteActivationOfflinePolicy.ALLOW_CACHED)
+        assertThat(manager.resolveRemoteStartup(APP_ID, request, reverifyEveryLaunch = true))
+            .isFalse()
+        assertThat(manager.resolveRemoteStartup(APP_ID, request, reverifyEveryLaunch = false))
+            .isFalse()
+    }
+
+    @Test
+    fun `remote grant clears remembered local card`() = runTest {
+        manager.verifyActivationCodeWithObjects(APP_ID, "CARD-AAAA", listOf(permanent("CARD-AAAA")))
+        manager.saveActivationStatus(APP_ID, true) // remote grant overwrites
+
+        // The grant is now remote-backed; the stale local card must not relaunch.
+        assertThat(manager.resolveRelaunchActivation(APP_ID, listOf(permanent("CARD-AAAA"))))
+            .isFalse()
+    }
+
+    companion object {
+        private const val APP_ID = 4242L
+    }
+}

--- a/docs/guide/app-actions/edit-common-config/activation.md
+++ b/docs/guide/app-actions/edit-common-config/activation.md
@@ -8,7 +8,7 @@ Gate the generated app behind activation codes, so it runs only after a valid co
 
 - **Enable** — turn activation gating on (`activationEnabled`).
 - **Activation codes** — the list of valid codes (`activationCodeList`).
-- **Require every time** — ask for the code on every launch, not just the first (`activationRequireEveryTime`).
+- **Require every time** — re-verify the activation on every launch instead of trusting it once (`activationRequireEveryTime`). The remembered card is re-validated silently: local codes must still be listed in the config (removing a card revokes it), remote codes are re-checked against your server. The user is only asked to re-enter a code when the remembered one fails (expired, exhausted, revoked, or rejected).
 - **Dialog config** — customize the activation dialog (title, subtitle, input label, button text).
 - **Remote activation** — verify against your own HTTPS endpoint signed with EC P-256, with an offline policy (`activationRemoteConfig`).
 - **Device binding (one-time codes)** — remote-verification only (`activationRemoteConfig.deviceBound`). The verification request carries a device identifier and the server enforces per-code seats: each code is limited to 1 device by default (first device to activate claims the seat), so a code behaves as a one-time / single-device code. Other devices are rejected with the server's message. The claimed seat survives uninstall + reinstall on the same device. Requires a verification server that enforces binding — the [reference worker](https://github.com/shiaho777/web-to-app/blob/main/examples/remote-activation-worker/README.md) does this out of the box via `maxDevices`.

--- a/docs/zh/guide/app-actions/edit-common-config/activation.md
+++ b/docs/zh/guide/app-actions/edit-common-config/activation.md
@@ -8,7 +8,7 @@
 
 - **启用** —— 打开激活门控(`activationEnabled`)。
 - **激活码** —— 有效码列表(`activationCodeList`)。
-- **每次验证** —— 每次启动都要求输入码,而非仅首次(`activationRequireEveryTime`)。
+- **每次验证** —— 每次启动都重新校验激活,而非仅信任一次(`activationRequireEveryTime`)。上次的卡会被静默复验:本地码必须仍在配置列表中(移除即吊销),远程码会向服务器重新校验。仅当上次的卡已失效(过期、用尽、被移除或被服务器拒绝)时才要求重新输入。
 - **对话框配置** —— 自定义激活对话框(标题、副标题、输入框标签、按钮文本)。
 - **远程激活** —— 对你自己经 EC P-256 签名的 HTTPS 端点校验,带离线策略(`activationRemoteConfig`)。
 - **设备绑定(一码一次)** —— 仅远程验证可用(`activationRemoteConfig.deviceBound`)。激活请求携带设备标识,由服务器执行每码占座:每个码默认限 1 台设备(首台激活的设备占座),即一次性/单设备码;其他设备激活会被拒绝并显示服务器消息。同一设备卸载重装不丢失占座。需要能执行绑定的验证服务器——[参考 Worker](https://github.com/shiaho777/web-to-app/blob/main/examples/remote-activation-worker/README.md) 通过 `maxDevices` 开箱即用。


### PR DESCRIPTION
## Summary

Fixes #842.

The activation flow contradicted itself: the prompt could show a green "Activated" card while still demanding a code, because the launch gate and the persisted grant were never reconciled — the remembered card was never retried.

**Launch gate (all three paths now share one gate: generated APK shell, host preview, clone splash launcher):**

- Local + "verify every launch": re-validates the remembered card against the configured list — grant valid AND card still listed → silent pass; removed/expired/exhausted → prompt. No more blind `resetActivation` + unconditional prompt.
- Remote: unified `resolveRemoteStartup` — cached-result fast path, falling back to re-verifying the remembered code (always under every-launch mode; previously only the clone launcher did this).
- The remembered card is now persisted (`used_code_`) at activation time.

**Grant-integrity fixes:**

- Stop resetting state on every launch — the old reset laundered `expire_time`/`usage_count` (limits never bit) and reset the lockout each restart.
- `AlreadyActivated` only answers "this exact card is redeemed"; a different listed code switches the grant.
- A lapsed grant only blocks re-entering the same card — new cards activate normally (previously an expired grant rejected every code as Expired).
- `saveActivationStatus` writes through — switching cards can't inherit the previous grant's expiry/usage budget.
- Server rejection clears the local `activated_` flag with the remote cache, but only when the rejected code is the cached one (a mistyped different code no longer destroys a valid grant).
- Offline failures no longer burn the brute-force lockout budget (`Invalid.offline`).

**UI:** the in-dialog status card shows "Re-verification required" (warning tone) instead of the contradictory "Activated" when the grant is valid but the launch still demands a code; `AlreadyActivated` is a completing result everywhere (shell dialog previously ignored it and trapped the user).

Editor hint and EN/ZH activation docs updated to the new semantics.

#### Test plan

- [x] `ActivationRelaunchTest` (12 new cases): silent relaunch, revoked card, expiry, usage exhaustion across launches, card switching, lapsed grant not blocking a new card, remote cached/DENY/ALLOW_CACHED paths
- [x] `:app:testStandardDebugUnitTest` — all pass
- [x] `:app:compileStandardDebugKotlin` + `:shell:compileDebugKotlin` — pass
- [x] `:app:checkConfigFieldDrift` — OK

Generated with [Devin](https://devin.ai)
