### PR TITLE
chore: bump version to 2.6.1 (versionCode 63)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ rest.
 
 > **English** · [简体中文](#贡献-webtoapp中文)
 
-This guide targets **WebToApp 2.6.0** (`versionCode 62`).
+This guide targets **WebToApp 2.6.1** (`versionCode 63`).
 
 ---
 
@@ -258,7 +258,7 @@ logged and otherwise disregarded.
 非常感谢你愿意花时间。WebToApp 的迭代速度取决于"小而聚焦"的贡献——下面三条路
 里挑一条走，其他的先忽略。
 
-本指南对应 **WebToApp 2.6.0**（`versionCode 62`）。
+本指南对应 **WebToApp 2.6.1**（`versionCode 63`）。
 
 ### 你想做什么？
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
         minSdk = 23
 
         targetSdk = 36
-        versionCode = 62
-        versionName = "2.6.0"
+        versionCode = 63
+        versionName = "2.6.1"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/modules/README.md
+++ b/modules/README.md
@@ -201,7 +201,7 @@ entry mirrors the module manifest plus a `path` (folder name) and a
 
 `minAppVersion` lets you ship a module that needs APIs only present from a
 specific WebToApp `versionCode` onwards — older clients hide the entry.
-The current `versionCode` is **62** (`v2.6.0`); set this only if you
+The current `versionCode` is **63** (`v2.6.1`); set this only if you
 genuinely depend on a newer build.
 
 `iconUrl` is optional. Either a relative path (`"icon.png"`, `"icon.svg"`,

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 62
-        versionName = "2.6.0"
+        versionCode = 63
+        versionName = "2.6.1"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
## Summary

Version bump for the v2.6.1 release — `versionCode 62 → 63`, `versionName 2.6.0 → 2.6.1` in all four places: `app/build.gradle.kts`, `shell/build.gradle.kts`, `.github/CONTRIBUTING.md` (EN + ZH), `modules/README.md`.

Closes #844.

#### Test plan

- [x] CI check/build

Generated with [Devin](https://devin.ai)