### PR TITLE
fix(apkbuilder): only STORED native libs need 16KB zip alignment

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ZipAligner.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ZipAligner.kt
@@ -370,18 +370,26 @@ object ZipAligner {
                     return false
                 }
                 var nativeLibCount = 0
+                var storedCount = 0
                 for (entry in entries) {
                     if (!isNativeLibraryEntry(entry.name)) continue
                     nativeLibCount++
-                    val isStored = entry.method == ZipEntry.STORED
+                    // DEFLATED libs can never be mmap'd from the zip: the
+                    // manifest ships extractNativeLibs=true (the template is
+                    // packaged with jniLibs.useLegacyPackaging), so the OS
+                    // extracts them to nativeLibraryDir at install and the
+                    // data offset is irrelevant. Only STORED libs — the
+                    // injected runtime binaries like libnode.so — may be
+                    // mapped in place and must sit on a page boundary.
+                    if (entry.method != ZipEntry.STORED) continue
+                    storedCount++
                     val dataOffset = entryDataOffset(raf, entry.localHeaderOffset)
-                    val isAligned = dataOffset % alignment == 0L
-                    if (!isStored || !isAligned) {
-                        AppLogger.w(TAG, "Native lib is not ${alignment / 1024}KB zip-aligned: ${entry.name} stored=$isStored dataOffset=$dataOffset remainder=${dataOffset % alignment}")
+                    if (dataOffset % alignment != 0L) {
+                        AppLogger.w(TAG, "Native lib is not ${alignment / 1024}KB zip-aligned: ${entry.name} dataOffset=$dataOffset remainder=${dataOffset % alignment}")
                         return false
                     }
                 }
-                AppLogger.d(TAG, "Native lib zip alignment verified: $nativeLibCount entries")
+                AppLogger.d(TAG, "Native lib zip alignment verified: $storedCount stored / $nativeLibCount total entries")
                 return true
             }
         } catch (e: Exception) {

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ZipAlignerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ZipAlignerTest.kt
@@ -77,4 +77,31 @@ class ZipAlignerTest {
         assertThat(ZipAligner.align(apk, output)).isTrue()
         assertThat(ZipAligner.verifyNativeLibAlignment(output)).isTrue()
     }
+
+    /**
+     * Regression: the shell template is built with packaging.jniLibs.useLegacyPackaging=true,
+     * so every template lib/ entry is DEFLATED and the manifest ships extractNativeLibs=true.
+     * PackageManager extracts such libs to nativeLibraryDir at install — the zip data offset
+     * is never mmap'd — therefore a compressed lib has no alignment requirement. Failing on
+     * stored=false here made EVERY export abort after the central-directory verifier started
+     * actually reaching lib/ (issue: "Native lib is not 16KB zip-aligned ... stored=false").
+     * Only STORED libs (injected runtimes like libnode.so) can be mapped in place and must
+     * sit on the 16KB boundary.
+     */
+    @Test
+    fun `verify accepts deflated native libs that are extracted at install`() {
+        val apk = temp.newFile("deflated-lib.apk")
+        ZipOutputStream(apk.outputStream()).use { zipOut ->
+            // DEFLATED via java.util.zip: bit-3 data descriptor, LFH compressedSize=0 —
+            // exactly what the AGP-built template carries.
+            zipOut.putNextEntry(ZipEntry("lib/arm64-v8a/libandroidx.graphics.path.so"))
+            zipOut.write(ByteArray(4_096) { (it % 251).toByte() })
+            zipOut.closeEntry()
+            zipOut.putNextEntry(ZipEntry("lib/arm64-v8a/libc++_shared.so"))
+            zipOut.write(ByteArray(8_192) { (it % 241).toByte() })
+            zipOut.closeEntry()
+        }
+
+        assertThat(ZipAligner.verifyNativeLibAlignment(apk)).isTrue()
+    }
 }


### PR DESCRIPTION
## Summary

- `ZipAligner.verifyNativeLibAlignment` now skips DEFLATED `lib/**.so` entries and only requires STORED libs to sit on a 16KB boundary
- Root cause of the export outage: the shell template packages all libs compressed (`jniLibs.useLegacyPackaging = true`, `extractNativeLibs=true`), so the OS extracts them at install and their zip offset is never mmap'd — compressed libs have no zip-alignment requirement. The central-directory verifier from #827 began actually reaching `lib/` (the old LFH walk desynchronized on data-descriptor entries and returned early) and started failing every build on `stored=false`
- The check still protects the case it was added for in #469: injected STORED runtime binaries (libnode.so, libphp.so, libpython3.so, …) must be 16KB-aligned
- New regression test: `verify accepts deflated native libs that are extracted at install`

Fixes #847

#### Test plan

- [x] `./gradlew :app:testStandardDebugUnitTest --tests "com.webtoapp.core.apkbuilder.*"` — all green, incl. new regression test
- [x] Verified template `lib/**.so` ELF `p_align = 0x4000` (16KB) — the real dlopen requirement on Android 15+ 16KB-page devices

Generated with [Devin](https://devin.ai)
