### PR TITLE
perf(network): faster GitHub-mirrored fetches and resilient APK downloads

### DIFF
--- a/app/src/main/java/com/webtoapp/core/network/CnMirrorProbe.kt
+++ b/app/src/main/java/com/webtoapp/core/network/CnMirrorProbe.kt
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit
 object CnMirrorProbe {
 
     private const val TAG = "CnMirrorProbe"
-    private const val CACHE_TTL_MS = 5L * 60 * 1000
+    private const val CACHE_TTL_MS = 30L * 60 * 1000
 
     /** Channels at or under this TTFB are considered usable. */
     const val ACCEPTABLE_LATENCY_MS = 1000L
@@ -91,6 +91,22 @@ object CnMirrorProbe {
     fun invalidate() {
         cachedOrder = emptyList()
         cachedAt = 0L
+    }
+
+    /**
+     * The best-known channel order without ever blocking: the measured order while
+     * the cache is warm, otherwise declaration order — and a stale cache fires a
+     * background refresh so the next caller sees measured results. For callers
+     * (small JSON fetches) that race several candidates and therefore must not
+     * spend up-front time on a probe round.
+     */
+    fun peekChannels(): List<MirrorChannel> {
+        val now = System.currentTimeMillis()
+        if (cachedOrder.isNotEmpty() && (now - cachedAt) < CACHE_TTL_MS) {
+            return mergeNewChannels(cachedOrder)
+        }
+        scope.launch { runCatching { probe() } }
+        return mergeNewChannels(cachedOrder)
     }
 
     /**

--- a/app/src/main/java/com/webtoapp/core/network/GitHubMirror.kt
+++ b/app/src/main/java/com/webtoapp/core/network/GitHubMirror.kt
@@ -23,25 +23,25 @@ object GitHubMirror {
     }
 
     /**
-     * Candidate prefix accelerators. This is deliberately a wide net: the list
-     * is re-measured at runtime by [CnMirrorProbe] and anything slow or dead is
+     * Candidate prefix accelerators, curated from a live measurement pass
+     * (2026-09): ordered best-first, so the declaration order is also the
+     * fallback when a probe round finds nothing usable. The list is still
+     * re-measured at runtime by [CnMirrorProbe] and anything slow or dead is
      * dropped before the first download attempt, so a stale entry costs one
      * probe request and nothing else.
+     *
+     * Dropped from the previous wide-net pool: ghps.cc (404 on release
+     * routes), gh.con.sh (HTTP 200 serving "Suspent due to abuse report"
+     * text — a fake-200 poison), gh.jiasu.in / ghproxy.1888866.xyz /
+     * mirror.ghproxy.com (unreachable), gh.idayer.com / github.91chi.fun
+     * (429 rate-limited), gh-proxy.ygxz.in (TTFB ~2s, ~5KB/s throughput),
+     * ghfast / ghproxy.net (kept off the shortlist: slower than the three
+     * below on both TTFB and throughput).
      */
     val CN_PROXIES: List<MirrorChannel> = listOf(
-        MirrorChannel("ghfast", "https://ghfast.top/"),
         MirrorChannel("gh-proxy", "https://gh-proxy.com/"),
-        MirrorChannel("ghproxy.net", "https://ghproxy.net/"),
-        MirrorChannel("gh.llkk.cc", "https://gh.llkk.cc/"),
-        MirrorChannel("ghps.cc", "https://ghps.cc/"),
-        MirrorChannel("gh-proxy.ygxz.in", "https://gh-proxy.ygxz.in/"),
-        MirrorChannel("gh.jiasu.in", "https://gh.jiasu.in/"),
         MirrorChannel("gh.zwy.one", "https://gh.zwy.one/"),
-        MirrorChannel("gh.idayer.com", "https://gh.idayer.com/"),
-        MirrorChannel("ghproxy.1888866.xyz", "https://ghproxy.1888866.xyz/"),
-        MirrorChannel("gh.con.sh", "https://gh.con.sh/"),
-        MirrorChannel("mirror.ghproxy.com", "https://mirror.ghproxy.com/"),
-        MirrorChannel("github.91chi.fun", "https://github.91chi.fun/")
+        MirrorChannel("gh.llkk.cc", "https://gh.llkk.cc/")
     )
 
     /** Everything a download may try, direct route last in declaration order. */

--- a/app/src/main/java/com/webtoapp/core/startup/RuntimeWarmupStartup.kt
+++ b/app/src/main/java/com/webtoapp/core/startup/RuntimeWarmupStartup.kt
@@ -16,6 +16,12 @@ class RuntimeWarmupStartup(
             // crashed the app (issue #356). Filters are loaded lazily on first actual use
             // (preview/runtime via AdBlocker.loadHostsRules / prepareRuntimeFilters).
         }
+        // Warm the GitHub mirror probe so the first update check / module-market
+        // load / runtime download reads a hot cache instead of paying the probe
+        // round up front. Costs a few KB total (one ranged request per channel).
+        appScope.launch {
+            runCatching { com.webtoapp.core.network.CnMirrorProbe.probe() }
+        }
     }
 
     fun shutdown() {

--- a/app/src/main/java/com/webtoapp/core/update/ApkUpdateInstaller.kt
+++ b/app/src/main/java/com/webtoapp/core/update/ApkUpdateInstaller.kt
@@ -12,7 +12,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.Request
 import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
 
 /**
  * States emitted by [download]. The UI renders a deterministic view per state.
@@ -37,6 +40,25 @@ object ApkUpdateInstaller {
 
     /** Directory under app-private external storage that the file manager scans. */
     const val UPDATE_APK_DIR = "update_apks"
+
+    /**
+     * Route quality floor: a mirror that sustains less than
+     * [MIN_ROUTE_SPEED_BPS] for [STALL_GRACE_MS] (after a [ROUTE_WARMUP_MS]
+     * ramp-up grace) is abandoned and the next candidate resumes the file via
+     * HTTP Range. The probe only measures TTFB — a mirror can handshake fast
+     * and then trickle — so the floor is what keeps a slow route from crawling
+     * a 36MB APK to completion. The final candidate is exempt: when nothing
+     * faster exists, a slow finish beats an outright failure.
+     */
+    private const val MIN_ROUTE_SPEED_BPS = 64L * 1024
+    private const val STALL_GRACE_MS = 10_000L
+    private const val ROUTE_WARMUP_MS = 8_000L
+
+    /** A fully hung socket (zero bytes) still dies on this read timeout. */
+    private const val ROUTE_READ_TIMEOUT_MS = 30_000L
+
+    private class RouteStallException(val speedBps: Long) :
+        IOException("route too slow (${speedBps / 1024} KB/s)")
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -83,10 +105,13 @@ object ApkUpdateInstaller {
             // attempt instead of breaking.
             val candidates = com.webtoapp.core.network.GitHubMirror.proxiedCn(url)
             var lastError: Exception? = null
-            for (candidate in candidates) {
+            candidates.forEachIndexed { index, candidate ->
+                // The final fallback route is exempt from the speed floor:
+                // when nothing faster exists, a slow finish beats a failure.
+                val enforceSpeedFloor = index < candidates.lastIndex
                 try {
                     onState(UpdateDownloadState.Downloading(0L, -1L, 0L))
-                    val file = streamToFile(appContext, candidate, version, onState)
+                    val file = streamToFile(appContext, candidate, version, enforceSpeedFloor, onState)
                     if (expectedSha256 != null) {
                         onState(UpdateDownloadState.Verifying)
                         val actual = sha256Of(file)
@@ -98,10 +123,12 @@ object ApkUpdateInstaller {
                             )
                             // A mismatch here means the route served something
                             // other than the release asset; treat it like any
-                            // other broken mirror and try the next route.
+                            // other broken mirror and try the next route. The
+                            // file is deleted so the next route restarts clean —
+                            // resuming bytes that failed integrity is unsafe.
                             file.delete()
                             lastError = IllegalStateException("sha256-mismatch")
-                            continue
+                            return@forEachIndexed
                         }
                         AppLogger.i(TAG, "APK integrity verified (sha256 match)")
                     }
@@ -129,33 +156,65 @@ object ApkUpdateInstaller {
         activeJob = null
     }
 
+    /**
+     * Streams one route into the target file. When a previous route left a partial
+     * file, the transfer resumes via `Range: bytes=<existing>-` — a 206 appends,
+     * a 200 (Range ignored) restarts from zero. [enforceSpeedFloor] is on for
+     * every route except the last fallback, which is allowed to crawl to the end.
+     */
     private suspend fun streamToFile(
         context: android.content.Context,
         url: String,
         version: String,
+        enforceSpeedFloor: Boolean,
         onState: (UpdateDownloadState) -> Unit
     ): File {
         val dir = targetDir(context)
         val fileName = "web-to-app-$version.apk"
-        // Wipe stale copies of the same name so a partial previous download never resumes silently.
-        File(dir, fileName).takeIf { it.exists() }?.delete()
         val target = File(dir, fileName)
 
-        val response = NetworkModule.downloadClient.newCall(Request.Builder().url(url).build()).execute()
+        // Per-route client: a tighter read timeout than the shared download
+        // client so a dead mid-stream socket fails in 30s, not 120s.
+        val client = NetworkModule.downloadClient.newBuilder()
+            .readTimeout(ROUTE_READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .build()
+
+        fun openStream(offset: Long) = client.newCall(
+            Request.Builder().url(url).apply {
+                if (offset > 0) header("Range", "bytes=$offset-")
+            }.build()
+        ).execute()
+
+        var resumeFrom = target.takeIf { it.exists() }?.length() ?: 0L
+        var response = openStream(resumeFrom)
+        if (response.code == 416 && resumeFrom > 0) {
+            // Range not satisfiable: the partial is already at/past the asset
+            // size — either complete or corrupt. Drop it and refetch cleanly.
+            response.close()
+            target.delete()
+            resumeFrom = 0L
+            response = openStream(0L)
+        }
         if (!response.isSuccessful) {
             response.close()
             throw IllegalStateException("HTTP ${response.code}")
         }
         val body = response.body ?: throw IllegalStateException("empty response body")
-        val total = body.contentLength()
+        // 206 honours the Range; anything else (200) restarts the file.
+        val appending = resumeFrom > 0 && response.code == 206
+        val offset = if (appending) resumeFrom else 0L
+        val contentLength = body.contentLength()
+        val total = if (contentLength > 0) offset + contentLength else -1L
 
         body.byteStream().use { input ->
-            target.outputStream().buffered().use { output ->
+            FileOutputStream(target, appending).buffered().use { output ->
                 val buffer = ByteArray(64 * 1024)
-                var downloaded = 0L
-                var windowStartBytes = 0L
+                var downloaded = offset
+                var windowStartBytes = offset
                 var windowStartTime = System.currentTimeMillis()
+                val transferStart = windowStartTime
                 var lastEmit = 0L
+                var lowSpeedSince = 0L
                 while (true) {
                     // ensureActive so cancel() propagates promptly.
                     kotlinx.coroutines.coroutineScope { ensureActive() }
@@ -175,6 +234,17 @@ object ApkUpdateInstaller {
                         // reset sampling window so speed reflects the recent second, not whole run.
                         windowStartBytes = downloaded
                         windowStartTime = now
+
+                        if (enforceSpeedFloor && now - transferStart > ROUTE_WARMUP_MS) {
+                            if (speed < MIN_ROUTE_SPEED_BPS) {
+                                if (lowSpeedSince == 0L) lowSpeedSince = now
+                                if (now - lowSpeedSince >= STALL_GRACE_MS) {
+                                    throw RouteStallException(speed)
+                                }
+                            } else {
+                                lowSpeedSince = 0L
+                            }
+                        }
                     }
                 }
                 output.flush()

--- a/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
+++ b/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
@@ -6,8 +6,13 @@ import com.webtoapp.core.logging.AppLogger
 import java.io.BufferedReader
 import java.net.HttpURLConnection
 import java.net.URL
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 
 object UpdateChecker {
@@ -21,7 +26,21 @@ object UpdateChecker {
     private const val ALL_RELEASES_API =
         "https://api.github.com/repos/$OWNER/$REPO/releases?per_page=100"
 
-    private const val TIMEOUT_MS = 12000
+    private const val CONNECT_TIMEOUT_MS = 6000
+    private const val READ_TIMEOUT_MS = 10000
+
+    /**
+     * Hard cap on one raced JSON fetch: the first valid response wins long before
+     * this, the cap only bounds the "every route hangs" case.
+     */
+    private const val RACE_TIMEOUT_MS = 12000L
+
+    /**
+     * Losing race requests are launched here rather than in the caller's scope,
+     * so the winner returns immediately instead of waiting for every candidate
+     * to finish or time out.
+     */
+    private val raceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
      * Invisible boundary that separates the English and Chinese halves of a GitHub release body
@@ -157,8 +176,10 @@ object UpdateChecker {
      */
     suspend fun fetchAllReleases(): List<ReleaseSummary> = withContext(Dispatchers.IO) {
         try {
+            // Null means every candidate failed — surface it as an error so the
+            // history UI shows a failure state instead of an empty list.
             val json = fetchAllReleasesJson()
-                ?: return@withContext emptyList()
+                ?: throw IllegalStateException("Empty response from release API")
             val arr = org.json.JSONArray(json)
             val out = ArrayList<ReleaseSummary>(arr.length())
             for (i in 0 until arr.length()) {
@@ -207,43 +228,53 @@ object UpdateChecker {
         return best
     }
 
-    private fun fetchLatestReleaseJson(): String? {
-        val candidates = com.webtoapp.core.network.GitHubMirror.proxiedCnGitHubHost(LATEST_RELEASE_API)
-        var lastError: Exception? = null
-        for (endpoint in candidates) {
-            try {
-                val body = httpGet(endpoint) ?: continue
-                // A proxy can answer 200 with a plain-text error ("Suspent",
-                // "404 not found") — not every mirror actually proxies
-                // api.github.com. Only a JSON object counts as a hit; anything
-                // else falls through to the next candidate.
-                if (body.trimStart().startsWith("{")) return body
-                AppLogger.w(TAG, "Release API returned non-JSON via $endpoint: ${body.take(80)}")
-            } catch (e: Exception) {
-                AppLogger.w(TAG, "Release API failed via $endpoint: ${e.message}")
-                lastError = e
-            }
-        }
-        lastError?.let { throw it }
-        return null
-    }
+    private suspend fun fetchLatestReleaseJson(): String? =
+        // A proxy can answer 200 with a plain-text error ("Suspent",
+        // "404 not found") — not every mirror actually proxies
+        // api.github.com. Only a JSON object counts as a hit.
+        fetchJsonRaced(LATEST_RELEASE_API) { it.trimStart().startsWith("{") }
 
-    private fun fetchAllReleasesJson(): String? {
-        val candidates = com.webtoapp.core.network.GitHubMirror.proxiedCnGitHubHost(ALL_RELEASES_API)
-        var lastError: Exception? = null
-        for (endpoint in candidates) {
-            try {
-                // fetchAllReleasesJson expects an array response, not an object.
-                val body = httpGet(endpoint) ?: continue
-                if (body.trimStart().startsWith("[")) return body
-                AppLogger.w(TAG, "All-releases API returned non-JSON via $endpoint: ${body.take(80)}")
-            } catch (e: Exception) {
-                AppLogger.w(TAG, "All-releases API failed via $endpoint: ${e.message}")
-                lastError = e
+    private suspend fun fetchAllReleasesJson(): String? =
+        // The all-releases endpoint answers with an array, not an object.
+        fetchJsonRaced(ALL_RELEASES_API) { it.trimStart().startsWith("[") }
+
+    /**
+     * Fires one GET per mirror candidate concurrently and returns the first body
+     * accepted by [accept]. Candidate order comes from
+     * [CnMirrorProbe.peekChannels] — never blocking — so a cold probe cannot
+     * delay the first request; losing requests keep running detached until
+     * their own socket timeout (tiny payloads, bounded by the timeouts below).
+     */
+    private suspend fun fetchJsonRaced(apiUrl: String, accept: (String) -> Boolean): String? {
+        val urls = (com.webtoapp.core.network.CnMirrorProbe.peekChannels()
+            .map { it.rewrite(apiUrl) } + apiUrl).distinct()
+        val results = Channel<Pair<String, String?>>(urls.size)
+        val jobs = urls.map { endpoint ->
+            raceScope.launch {
+                val body = runCatching { httpGet(endpoint) }
+                    .onFailure {
+                        AppLogger.w(TAG, "API request failed via $endpoint: ${it.message}")
+                    }
+                    .getOrNull()
+                results.send(endpoint to body)
             }
         }
-        lastError?.let { throw it }
-        return null
+        var winner: String? = null
+        var remaining = urls.size
+        withTimeoutOrNull(RACE_TIMEOUT_MS) {
+            while (remaining > 0 && winner == null) {
+                remaining--
+                val (endpoint, body) = results.receive()
+                if (body != null && accept(body)) {
+                    AppLogger.d(TAG, "API request won via $endpoint")
+                    winner = body
+                } else if (body != null) {
+                    AppLogger.w(TAG, "API returned non-JSON via $endpoint: ${body.take(80)}")
+                }
+            }
+        }
+        jobs.forEach { it.cancel() }
+        return winner
     }
 
     private fun httpGet(endpoint: String): String {
@@ -252,8 +283,8 @@ object UpdateChecker {
             connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
                 requestMethod = "GET"
                 instanceFollowRedirects = true
-                connectTimeout = TIMEOUT_MS
-                readTimeout = TIMEOUT_MS
+                connectTimeout = CONNECT_TIMEOUT_MS
+                readTimeout = READ_TIMEOUT_MS
                 setRequestProperty("Accept", "application/vnd.github+json")
                 setRequestProperty("User-Agent", "WebToApp-UpdateChecker")
             }


### PR DESCRIPTION
## Summary

Speeds up every GitHub-mirrored fetch in the app (update checks, module market, runtime/dependency downloads, APK self-update):

- **`CnMirrorProbe`**: probe-result cache TTL 5 min → 30 min; new non-blocking `peekChannels()` returns the measured order when warm and declaration order otherwise (firing a background refresh) so raced callers never pay the probe round up front
- **`RuntimeWarmupStartup`**: warms the mirror probe at app start — first update check / market load reads a hot cache
- **`GitHubMirror`**: `CN_PROXIES` pruned 13 → 3 (gh-proxy.com, gh.zwy.one, gh.llkk.cc) based on a live measurement pass; dropped entries were dead, fake-200 ("Suspent" bodies), 429-limited or sub-5KB/s tricklers — each cost a probe request plus a wasted candidate slot per fetch. Direct URL remains the guaranteed last fallback
- **`UpdateChecker`**: small JSON fetches now race all candidates concurrently — first valid body wins (bounded by a 12s race cap, tighter 6s/10s connect/read timeouts) instead of burning 12s per dead route serially; `fetchAllReleases` now throws on total failure so the history UI shows an error instead of an empty list
- **`ApkUpdateInstaller`**: routes sustaining <64 KB/s past an 8s warmup + 10s grace are abandoned (final route exempt); the next candidate resumes via HTTP `Range` with 416 handling instead of restarting a 36MB APK from zero; per-route read timeout 30s

Fixes #846

#### Test plan

- [x] `./gradlew :app:testStandardDebugUnitTest --tests "com.webtoapp.core.network.*" --tests "com.webtoapp.core.update.*"` — green
- [ ] Manual: update check on a CN network returns promptly; a trickling mirror download switches routes and resumes

Generated with [Devin](https://devin.ai)
